### PR TITLE
Fix string.Concat for multiple arguments

### DIFF
--- a/Bridge/Resources/String.js
+++ b/Bridge/Resources/String.js
@@ -307,15 +307,15 @@
             return arr;
         },
 
-        concatArray: function (strs) {
-            if (strs == null) {
+        concatArray: function () {
+            if (arguments.length == 0) {
                 throw new Bridge.ArgumentNullException();
             }
 
             var sb = new Bridge.Text.StringBuilder();
 
-            for (var i = 0; i < strs.length; i++) {
-                sb.append(strs[i]);
+            for (var i = 0; i < arguments.length; i++) {
+                sb.append(arguments[i]);
             }
 
             return sb.toString();

--- a/Bridge/Resources/bridge.js
+++ b/Bridge/Resources/bridge.js
@@ -1317,15 +1317,15 @@
             return arr;
         },
 
-        concatArray: function (strs) {
-            if (strs == null) {
+        concatArray: function () {
+            if (arguments.length == 0) {
                 throw new Bridge.ArgumentNullException();
             }
 
             var sb = new Bridge.Text.StringBuilder();
 
-            for (var i = 0; i < strs.length; i++) {
-                sb.append(strs[i]);
+            for (var i = 0; i < arguments.length; i++) {
+                sb.append(arguments[i]);
             }
 
             return sb.toString();

--- a/Bridge/Resources/bridge.min.js
+++ b/Bridge/Resources/bridge.min.js
@@ -169,8 +169,8 @@ if(arguments.length==4){return strA.localeCompare(strB,arguments[3].name);}}}
 return strA.localeCompare(strB);},toCharArray:function(str,startIndex,length){if(startIndex<0||startIndex>str.length||startIndex>str.length-length){throw new Bridge.ArgumentOutOfRangeException("startIndex","startIndex cannot be less than zero and must refer to a location within the string");}
 if(length<0){throw new Bridge.ArgumentOutOfRangeException("length","must be non-negative");}
 var arr=[];for(var i=startIndex;i<startIndex+length;i++){arr.push(str.charCodeAt(i));}
-return arr;},concatArray:function(strs){if(strs==null){throw new Bridge.ArgumentNullException();}
-var sb=new Bridge.Text.StringBuilder();for(var i=0;i<strs.length;i++){sb.append(strs[i]);}
+return arr;},concatArray:function(){if(arguments.length==0){throw new Bridge.ArgumentNullException();}
+var sb=new Bridge.Text.StringBuilder();for(var i=0;i<arguments.length;i++){sb.append(arguments[i]);}
 return sb.toString();}};Bridge.String=string;})();
 
 (function(){var initializing=false;var base={cache:{},initCtor:function(){var value=arguments[0];if(this.$multipleCtors&&arguments.length>0&&typeof value=='string'){value=value==="constructor"?"$constructor":value;if((value==="$constructor"||Bridge.String.startsWith(value,"constructor\\$"))&&Bridge.isFunction(this[value])){this[value].apply(this,Array.prototype.slice.call(arguments,1));return;}}


### PR DESCRIPTION
If the string.Concat with params[] string is taken
the javascript implementation will take only the
first argument. The function basically returns the
first argument, since everything else is ommited.

I described it a bit more detailed in the comments of the commit https://github.com/bridgedotnet/Bridge/commit/43ba944e8e44607057fb351125b5817bc85d58a8