### PR TITLE
Issue #410 Math.X constants can be optimized away by compiler

### DIFF
--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -6,14 +6,22 @@ namespace System
     [Name("Math")]
     public static class Math
     {
-        public const double E = 0;
-        public const double LN10 = 0;
-        public const double LN2 = 0;
-        public const double LOG2E = 0;
-        public const double LOG10E = 0;
-        public const double PI = 0;
-        public const double SQRT1_2 = 0;
-        public const double SQRT2 = 0;
+        [Name( false )]
+        public static readonly double E;
+        [Name( false )]
+        public static readonly double LN10;
+        [Name( false )]
+        public static readonly double LN2;
+        [Name( false )]
+        public static readonly double LOG2E;
+        [Name( false )]
+        public static readonly double LOG10E;
+        [Name( false )]
+        public static readonly double PI;
+        [Name( false )]
+        public static readonly double SQRT1_2;
+        [Name( false )]
+        public static readonly double SQRT2;
 
         public static int Abs(int x)
         {


### PR DESCRIPTION
Change constants from const to static readonly and add [Name(false)] attribute