### PR TITLE
Removes 'Bridge.Html5.' namespace ref from TypedArray classes

### DIFF
--- a/Html5/TypedArray/Float32Array.cs
+++ b/Html5/TypedArray/Float32Array.cs
@@ -11,6 +11,7 @@ namespace Bridge.Html5
     /// notation).
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Float32Array
     {
         /// <summary>

--- a/Html5/TypedArray/Float64Array.cs
+++ b/Html5/TypedArray/Float64Array.cs
@@ -11,6 +11,7 @@ namespace Bridge.Html5
     /// notation).
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Float64Array
     {
         /// <summary>

--- a/Html5/TypedArray/Int16Array.cs
+++ b/Html5/TypedArray/Int16Array.cs
@@ -10,6 +10,7 @@ namespace Bridge.Html5
     /// standard array index syntax (that is, using bracket notation).
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Int16Array
     {
         /// <summary>

--- a/Html5/TypedArray/Int32Array.cs
+++ b/Html5/TypedArray/Int32Array.cs
@@ -10,6 +10,7 @@ namespace Bridge.Html5
     /// standard array index syntax (that is, using bracket notation).
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Int32Array
     {
         /// <summary>

--- a/Html5/TypedArray/Int8Array.cs
+++ b/Html5/TypedArray/Int8Array.cs
@@ -10,6 +10,7 @@ namespace Bridge.Html5
     /// array index syntax (that is, using bracket notation).
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Int8Array
     {
         /// <summary>

--- a/Html5/TypedArray/Prototype.cs
+++ b/Html5/TypedArray/Prototype.cs
@@ -12,6 +12,7 @@ namespace Bridge.Html5.TypedArray
     /// typed array types.
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Prototype<TypedArray, TypedElement>
     {
         #region Properties

--- a/Html5/TypedArray/Uint16Array.cs
+++ b/Html5/TypedArray/Uint16Array.cs
@@ -10,6 +10,7 @@ namespace Bridge.Html5
     /// standard array index syntax (that is, using bracket notation).
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Uint16Array
     {
         /// <summary>

--- a/Html5/TypedArray/Uint32Array.cs
+++ b/Html5/TypedArray/Uint32Array.cs
@@ -10,6 +10,7 @@ namespace Bridge.Html5
     /// standard array index syntax (that is, using bracket notation).
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Uint32Array
     {
         /// <summary>

--- a/Html5/TypedArray/Uint8Array.cs
+++ b/Html5/TypedArray/Uint8Array.cs
@@ -9,6 +9,7 @@ namespace Bridge.Html5
     /// array index syntax (that is, using bracket notation).
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Uint8Array
     {
         /// <summary>

--- a/Html5/TypedArray/Uint8ClampedArray.cs
+++ b/Html5/TypedArray/Uint8ClampedArray.cs
@@ -11,6 +11,7 @@ namespace Bridge.Html5
     /// methods, or using standard array index syntax (that is, using bracket notation).
     /// </summary>
     [Ignore]
+    [Namespace(false)]
     public class Uint8ClampedArray
     {
         /// <summary>


### PR DESCRIPTION
This implements the fix for issue #548