### PR TITLE
[UPDATE] [bridgedotnet/Frameworks#22] Removed WebGL packages.config from repositories.config since Bridge.WebGL now refers the Bridge project itself rather than Bridge NuGet package

### DIFF
--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
-  <repository path="..\..\Frameworks\WebGL\packages.config" />
   <repository path="..\..\Test\Bridge.Test.Plugin.QUnit\packages.config" />
   <repository path="..\..\Test\Bridge.Test.Plugin\packages.config" />
   <repository path="..\Bridge\packages.config" />


### PR DESCRIPTION
bridgedotnet/Frameworks#22