### PR TITLE
Global ignore cast

### DIFF
--- a/Compiler/Contract/Helpers.cs
+++ b/Compiler/Contract/Helpers.cs
@@ -207,6 +207,11 @@ namespace Bridge.Contract
 
         public static bool IsIgnoreCast(AstType astType, IEmitter emitter)
         {
+            if (emitter.AssemblyInfo.IgnoreCast)
+            {
+                return true;
+            }
+
             var typeDef = emitter.BridgeTypes.ToType(astType).GetDefinition();
 
             if (typeDef == null)
@@ -215,11 +220,6 @@ namespace Bridge.Contract
             }
 
             if (typeDef.Kind == TypeKind.Delegate)
-            {
-                return true;
-            }
-
-            if (emitter.AssemblyInfo.IgnoreCast)
             {
                 return true;
             }

--- a/Compiler/Contract/Helpers.cs
+++ b/Compiler/Contract/Helpers.cs
@@ -219,6 +219,11 @@ namespace Bridge.Contract
                 return true;
             }
 
+            if (emitter.AssemblyInfo.IgnoreCast)
+            {
+                return true;
+            }
+
             return emitter.Validator.HasAttribute(typeDef.Attributes, "Bridge.IgnoreCastAttribute");
         }
 

--- a/Compiler/Contract/IAssemblyInfo.cs
+++ b/Compiler/Contract/IAssemblyInfo.cs
@@ -230,5 +230,11 @@ namespace Bridge.Contract
             get;
             set;
         }
+
+        bool IgnoreCast
+        {
+            get;
+            set;
+        }
     }
 }

--- a/Compiler/Translator/Utils/AssemblyInfo.cs
+++ b/Compiler/Translator/Utils/AssemblyInfo.cs
@@ -247,5 +247,11 @@ namespace Bridge.Translator
             get;
             set;
         }
+
+        public bool IgnoreCast
+        {
+            get;
+            set;
+        }
     }
 }


### PR DESCRIPTION
This is a small feature I added to Bridge to globally control the "IgnoreCast" setting. My project is not only targeting JavaScript and therefore I want to keep my core classes mostly clean from third party code (special attributes etc). 

I don't want to spoil my types with additional "IgnoreCast" attributes to control the setting I thought it would be nice to have it globally in the bridge.json. 