### PR TITLE
Format validation in Decimal constructor was corrected.

### DIFF
--- a/Bridge/Resources/Decimal.js
+++ b/Bridge/Resources/Decimal.js
@@ -18,7 +18,7 @@
                 v = v.replace(nfInfo.numberDecimalSeparator, ".");
             }
 
-            if (!/^\s*[+-]?(\d+|\d*\.\d+)(e|E[+-]?\d+)?\s*$/.test(v)) {
+            if (!/^\s*[+-]?(\d+|\d*\.\d+)((e|E)[+-]?\d+)?\s*$/.test(v)) {
                 throw new Bridge.FormatException();
             }
 


### PR DESCRIPTION
Hi, this PR contains a fix for the regular expression that is used for validation of Decimal value provided in a string (see more information in Issue #968)