### PR TITLE
[#776] WebSocket API.

### DIFF
--- a/Html5/Bridge.Html5.csproj
+++ b/Html5/Bridge.Html5.csproj
@@ -56,6 +56,8 @@
     <Compile Include="CompatMode.cs" />
     <Compile Include="Console.cs" />
     <Compile Include="Elements\TemplateElement.cs" />
+    <Compile Include="Events\MessageEvent.cs" />
+    <Compile Include="Events\CloseEvent.cs" />
     <Compile Include="Events\TouchEvent.cs" />
     <Compile Include="Interfaces\Touch.cs" />
     <Compile Include="Interfaces\TouchList.cs" />
@@ -315,6 +317,7 @@
     <Compile Include="URLSearchParams.cs" />
     <Compile Include="ValidityState.cs" />
     <Compile Include="Global.cs" />
+    <Compile Include="WebSocket.cs" />
     <Compile Include="Window.cs" />
     <Compile Include="WindowInstance.cs" />
   </ItemGroup>

--- a/Html5/Events/CloseEvent.cs
+++ b/Html5/Events/CloseEvent.cs
@@ -1,0 +1,29 @@
+﻿namespace Bridge.Html5
+{
+	/// <summary>
+	/// A CloseEvent is sent to clients using WebSockets when the connection is closed.
+	/// </summary>
+	[External]
+	[Name("CloseEvent")]
+	public class CloseEvent : Event
+	{
+		private CloseEvent()
+		{
+		}
+
+		/// <summary>
+		/// Close code sent by the server.
+		/// </summary>
+		public readonly ushort Code;
+
+		/// <summary>
+		/// Reason the server closed the connection. This is specific to the particular server and sub-protocol.
+		/// </summary>
+		public readonly float Reason;
+
+		/// <summary>
+		/// Indicates whether or not the connection was cleanly closed.
+		/// </summary>
+		public readonly string WasClean;
+	}
+}

--- a/Html5/Events/MessageEvent.cs
+++ b/Html5/Events/MessageEvent.cs
@@ -1,0 +1,18 @@
+﻿namespace Bridge.Html5
+{
+	/// <summary>
+	/// A MessageEvent interface represents a message received by a target, being a WebSocket or a WebRTC RTCDataChannel.
+	/// </summary>
+	[External]
+	[Name("MessageEvent")]
+	public class MessageEvent : Event
+	{
+		private MessageEvent()
+		{
+		}
+
+		public readonly Any<string, Blob, ArrayBuffer> Data;
+
+		public readonly string Origin;
+	}
+}

--- a/Html5/WebSocket.cs
+++ b/Html5/WebSocket.cs
@@ -1,0 +1,167 @@
+﻿using System;
+
+namespace Bridge.Html5
+{
+	/// <summary>
+	/// The WebSocket interface provides the API for creating and managing a WebSocket connection
+	/// to a server, as well as for sending and receiving data on the connection.
+	/// </summary>
+	[External]
+	[Name("WebSocket")]
+	public class WebSocket
+	{
+		/// <param name="url">
+		/// The URL to which to connect; this should be the URL to which the WebSocket server will respond.
+		/// </param>
+		public WebSocket(string url)
+		{
+		}
+
+		/// <param name="url">
+		/// The URL to which to connect; this should be the URL to which the WebSocket server will respond.
+		/// </param>
+		/// <param name="protocol">
+		/// This string is used to indicate sub-protocol, so that a single server
+		/// can implement multiple WebSocket sub-protocols (for example, you might want one server
+		/// to be able to handle different types of interactions depending on the specified protocol).
+		/// </param>
+		public WebSocket(string url, string protocol)
+		{
+		}
+
+		/// <param name="url">
+		/// The URL to which to connect; this should be the URL to which the WebSocket server will respond.
+		/// </param>
+		/// <param name="protocols">
+		/// These strings are used to indicate sub-protocols, so that a single server
+		/// can implement multiple WebSocket sub-protocols (for example, you might want one server
+		/// to be able to handle different types of interactions depending on the specified protocol).
+		/// </param>
+		public WebSocket(string url, string[] protocols)
+		{
+		}
+
+		/// <summary>
+		/// Closes the WebSocket connection or connection attempt, if any.
+		/// If the connection is already closed, this method does nothing.
+		/// </summary>
+		public extern void Close();
+
+		/// <summary>
+		/// Closes the WebSocket connection or connection attempt, if any.
+		/// If the connection is already closed, this method does nothing.
+		/// </summary>
+		/// <param name="code">
+		/// A numeric value indicating the status code explaining why the connection is being closed.
+		/// </param>
+		public extern void Close(ushort code);
+
+		/// <summary>
+		/// Closes the WebSocket connection or connection attempt, if any.
+		/// If the connection is already closed, this method does nothing.
+		/// </summary>
+		/// <param name="code">
+		/// A numeric value indicating the status code explaining why the connection is being closed.
+		/// </param>
+		/// <param name="reason">
+		/// A human-readable string explaining why the connection is closing. This string
+		/// must be no longer than 123 bytes of UTF-8 text (not characters).
+		/// </param>
+		public extern void Close(ushort code, string reason);
+
+		/// <summary>
+		/// Transmits data to the server over the WebSocket connection.
+		/// </summary>
+		/// <param name="data">A text string to send to the server.</param>
+		public extern void Send(string data);
+
+		/// <summary>
+		/// Transmits data to the server over the WebSocket connection.
+		/// </summary>
+		/// <param name="data">A Blob to send to the server.</param>
+		public extern void Send(Blob data);
+
+		/// <summary>
+		/// Transmits data to the server over the WebSocket connection.
+		/// </summary>
+		/// <param name="data">An ArrayBuffer to send to the server.</param>
+		public extern void Send(ArrayBuffer data);
+
+		/// <summary>
+		/// An event handler property for handling socket connection event.
+		/// </summary>
+		[Name("onopen")]
+		public Action<Event> OnOpen;
+
+		/// <summary>
+		/// An event handler property for handling socket closing event.
+		/// </summary>
+		[Name("onclose")]
+		public Action<CloseEvent> OnClose;
+
+		/// <summary>
+		/// An event handler property for handling incoming message event.
+		/// </summary>
+		[Name("onmessage")]
+		public Action<MessageEvent> OnMessage;
+
+		/// <summary>
+		/// An event handler property for handling socket error event.
+		/// </summary>
+		[Name("onerror")]
+		public Action<Event> OnError;
+
+		/// <summary>
+		/// The current state of the connection.
+		/// </summary>
+		public readonly State ReadyState;
+
+		/// <summary>
+		/// The type of binary data being transmitted by the connection.
+		/// </summary>
+		public DataType BinaryType;
+
+		/// <summary>
+		/// The number of bytes of data that have been queued using calls to Send() but not yet
+		/// transmitted to the network. This value does not reset to zero when the connection is closed;
+		/// if you keep calling Send(), this will continue to climb.
+		/// </summary>
+		public readonly ulong BufferedAmount;
+
+		/// <summary>
+		/// The extensions selected by the server.
+		/// </summary>
+		public string Extensions;
+
+		/// <summary>
+		/// A string indicating the name of the sub-protocol the server selected;
+		/// this will be one of the strings specified in the protocols parameter of constructor.
+		/// </summary>
+		public string Protocol;
+
+		/// <summary>
+		/// The URL as resolved by the constructor. This is always an absolute URL.
+		/// </summary>
+		public readonly string Url;
+
+		[External]
+		[Name("Number")]
+		[Enum(Emit.Value)]
+		public enum State
+		{
+			Connecting = 0,
+			Open = 1,
+			Closing = 2,
+			Closed = 3
+		}
+
+		[External]
+		[Name("String")]
+		[Enum(Emit.StringNameLowerCase)]
+		public enum DataType
+		{
+			Blob,
+			ArrayBuffer
+		}
+	}
+}


### PR DESCRIPTION
Fixes #776 .

Changes proposed in this pull request:

- Implement WebSocket interface as-is in the HTML5.
- Implement related events, such as MessageEvent and CloseEvent.

Note: Though #776 is related to #780, it won't be easy to implement .NET ClientWebSocket, as it goes somewhat apart from HTML5 WebSocket (I'm researching this question now).