### PR TITLE
[#1088] Some members of Window.Location are translated incorrectly.

### DIFF
--- a/Html5/Location.cs
+++ b/Html5/Location.cs
@@ -29,6 +29,7 @@ namespace Bridge.Html5
         /// <summary>
         /// String containing the domain of the URL.
         /// </summary>
+        [Name("hostname")]
         public string HostName;
 
         /// <summary>
@@ -39,6 +40,7 @@ namespace Bridge.Html5
         /// <summary>
         /// String containing an initial '/' followed by the path of the URL.
         /// </summary>
+        [Name("pathname")]
         public string PathName;
 
         /// <summary>


### PR DESCRIPTION
Fixes #1088.

Changes proposed in this pull request:

- Fix JS names for Window.Location.HostName and Window.Location.PathName.