### PR TITLE
[FIX] [#1190] Changed erratic fields' ulong type to uint

### DIFF
--- a/Html5/CSS/CSSStyleSheet.cs
+++ b/Html5/CSS/CSSStyleSheet.cs
@@ -24,7 +24,7 @@ namespace Bridge.Html5
         /// <summary>
         /// Deletes a rule from the style sheet.
         /// </summary>
-        /// <param name="index"> is a long number representing the position of the rule.</param>
+        /// <param name="index"> is a number representing the position of the rule.</param>
         public virtual extern void DeleteRule(int index);
 
         /// <summary>

--- a/Html5/Document.cs
+++ b/Html5/Document.cs
@@ -1177,7 +1177,7 @@ namespace Bridge.Html5
         /// The Document.createTreeWalker() creator method returns a newly created TreeWalker object.
         /// </summary>
         /// <param name="root">Is the root Node of this TreeWalker traversal. Typically this will be an element owned by the document.</param>
-        /// <param name="whatToShow">Is an optionale unsigned long representing a bitmask created by combining the constant properties of NodeFilter. It is a convenient way of filtering for certain types of node. It defaults to 0xFFFFFFFF representing the SHOW_ALL constant.</param>
+        /// <param name="whatToShow">Is an optionale unsigned int representing a bitmask created by combining the constant properties of NodeFilter. It is a convenient way of filtering for certain types of node. It defaults to 0xFFFFFFFF representing the SHOW_ALL constant.</param>
         /// <returns></returns>
         public static extern TreeWalker CreateTreeWalker(Node root, NodeFilter whatToShow);
 
@@ -1185,7 +1185,7 @@ namespace Bridge.Html5
         /// The Document.createTreeWalker() creator method returns a newly created TreeWalker object.
         /// </summary>
         /// <param name="root">Is the root Node of this TreeWalker traversal. Typically this will be an element owned by the document.</param>
-        /// <param name="whatToShow">Is an optionale unsigned long representing a bitmask created by combining the constant properties of NodeFilter. It is a convenient way of filtering for certain types of node. It defaults to 0xFFFFFFFF representing the SHOW_ALL constant.</param>
+        /// <param name="whatToShow">Is an optionale unsigned int representing a bitmask created by combining the constant properties of NodeFilter. It is a convenient way of filtering for certain types of node. It defaults to 0xFFFFFFFF representing the SHOW_ALL constant.</param>
         /// <param name="filter">Is an optional NodeFilter, that is an object with a method acceptNode, which is called by the TreeWalker to determine whether or not to accept a node that has passed the whatToShow check.</param>
         /// <returns></returns>
         public static extern TreeWalker CreateTreeWalker(Node root, NodeFilter whatToShow, INodeFilter filter);

--- a/Html5/File/Blob.cs
+++ b/Html5/File/Blob.cs
@@ -79,7 +79,7 @@ namespace Bridge.Html5
         /// <summary>
         /// The size, in bytes, of the data contained in the Blob object.
         /// </summary>
-        public readonly ulong Size;
+        public readonly uint Size;
 
         /// <summary>
         /// A string indicating the MIME type of the data contained in the Blob. If the type is unknown, this string is empty.

--- a/Html5/File/Blob.cs
+++ b/Html5/File/Blob.cs
@@ -97,7 +97,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="start">An index into the Blob indicating the first byte to copy into the new Blob. If you specify a negative value, it's treated as an offset from the end of the string toward the beginning. For example, -10 would be the 10th from last byte in the Blob. The default value is 0. If you specify a value for start that is larger than the size of the source Blob, the returned Blob has size 0 and contains no data.</param>
         /// <returns>A new Blob object containing the specified data from the source Blob.</returns>
-        public virtual extern Blob Slice(long start);
+        public virtual extern Blob Slice(int start);
 
         /// <summary>
         /// Returns a new Blob object containing the data in the specified range of bytes of the source Blob.
@@ -105,7 +105,7 @@ namespace Bridge.Html5
         /// <param name="start">An index into the Blob indicating the first byte to copy into the new Blob. If you specify a negative value, it's treated as an offset from the end of the string toward the beginning. For example, -10 would be the 10th from last byte in the Blob. The default value is 0. If you specify a value for start that is larger than the size of the source Blob, the returned Blob has size 0 and contains no data.</param>
         /// <param name="end">An index into the Blob indicating the last byte to copy into the new Blob. If you specify a negative value, it's treated as an offset from the end of the string toward the beginning. For example, -10 would be the 10th from last byte in the Blob. The default value is size.</param>
         /// <returns>A new Blob object containing the specified data from the source Blob.</returns>
-        public virtual extern Blob Slice(long start, long end);
+        public virtual extern Blob Slice(int start, int end);
 
         /// <summary>
         /// Returns a new Blob object containing the data in the specified range of bytes of the source Blob.
@@ -114,6 +114,6 @@ namespace Bridge.Html5
         /// <param name="end">An index into the Blob indicating the last byte to copy into the new Blob. If you specify a negative value, it's treated as an offset from the end of the string toward the beginning. For example, -10 would be the 10th from last byte in the Blob. The default value is size.</param>
         /// <param name="contentType">The content type to assign to the new Blob; this will be the value of its type property. The default value is an empty string.</param>
         /// <returns>A new Blob object containing the specified data from the source Blob.</returns>
-        public virtual extern Blob Slice(long start, long end, string contentType);
+        public virtual extern Blob Slice(int start, int end, string contentType);
     }
 }

--- a/Html5/Interfaces/CanvasRenderingContext2D.cs
+++ b/Html5/Interfaces/CanvasRenderingContext2D.cs
@@ -667,7 +667,7 @@ namespace Bridge.Html5
         /// The Y coordinate in the destination canvas at which to place the top-left corner of the source image.
         /// </param>
         public virtual void DrawImage(Any<ImageElement, VideoElement, CanvasElement, CanvasRenderingContext2D> image,
-                                      Any<int, long, float, double> dx, Any<int, long, float, double> dy)
+                                      Any<int, int, float, double> dx, Any<int, int, float, double> dy)
         {
             return;
         }
@@ -694,8 +694,8 @@ namespace Bridge.Html5
         /// If null, the image is not scaled in height when drawn.
         /// </param>
         public virtual void DrawImage(Any<ImageElement, VideoElement, CanvasElement, CanvasRenderingContext2D> image,
-                                      Any<int, long, float, double> dx, Any<int, long, float, double> dy,
-                                      Any<int?, long?, float?, double?> dWidth, Any<int?, long?, float?, double?> dHeight)
+                                      Any<int, int, float, double> dx, Any<int, int, float, double> dy,
+                                      Any<int?, int?, float?, double?> dWidth, Any<int?, int?, float?, double?> dHeight)
         {
             return;
         }
@@ -736,12 +736,12 @@ namespace Bridge.Html5
         /// If not specified or null, the image is not scaled in height when drawn.
         /// </param>
         public virtual void DrawImage(Any<ImageElement, VideoElement, CanvasElement, CanvasRenderingContext2D> image,
-                                      Any<int, long, float, double> sx, Any<int, long, float, double> sy,
-                                      Any<int?, long?, float?, double?> sWidth,
-                                      Any<int?, long?, float?, double?> sHeight,
-                                      Any<int, long, float, double> dx, Any<int, long, float, double> dy,
-                                      Any<int?, long?, float?, double?> dWidth,
-                                      Any<int?, long?, float?, double?> dHeight)
+                                      Any<int, int, float, double> sx, Any<int, int, float, double> sy,
+                                      Any<int?, int?, float?, double?> sWidth,
+                                      Any<int?, int?, float?, double?> sHeight,
+                                      Any<int, int, float, double> dx, Any<int, int, float, double> dy,
+                                      Any<int?, int?, float?, double?> dWidth,
+                                      Any<int?, int?, float?, double?> dHeight)
         {
             return;
         }

--- a/Html5/Interfaces/ImageData.cs
+++ b/Html5/Interfaces/ImageData.cs
@@ -26,13 +26,13 @@ namespace Bridge.Html5
         /// is not available there.
         /// </summary>
         /// <param name="array">A Uint8ClampedArray containing the underlying pixel representation of theimage.</param>
-        /// <param name="width">An unsigned long representing the width of the represented image.</param>
+        /// <param name="width">An unsigned number representing the width of the represented image.</param>
         /// <param name="height">
-        /// An unsigned long representing the height of the represented image. This value is optional
+        /// An unsigned number representing the height of the represented image. This value is optional
         /// if an array is given: it will be inferred from its size and the given width.
         /// </param>
         /// <remarks>This is experimental API that should not be used in production code.</remarks>
-        public ImageData(Uint8ClampedArray array, ulong width, ulong? height = null)
+        public ImageData(Uint8ClampedArray array, uint width, uint? height = null)
         {
         }
 
@@ -41,10 +41,10 @@ namespace Bridge.Html5
         /// a black rectangle is created. Note that this is the most common way to create such an object in
         /// workers as createImageData() is not available there.
         /// </summary>
-        /// <param name="width">An unsigned long representing the width of the represented image.</param>
-        /// <param name="height">An unsigned long representing the height of the represented image.</param>
+        /// <param name="width">An unsigned number representing the width of the represented image.</param>
+        /// <param name="height">An unsigned number representing the height of the represented image.</param>
         /// <remarks>This is experimental API that should not be used in production code.</remarks>
-        public ImageData(ulong width, ulong height)
+        public ImageData(uint width, uint height)
         {
         }
 
@@ -56,13 +56,13 @@ namespace Bridge.Html5
         public readonly Uint8ClampedArray Data;
 
         /// <summary>
-        /// An unsigned long representing the actual height, in pixels, of the ImageData.
+        /// An unsigned number representing the actual height, in pixels, of the ImageData.
         /// </summary>
-        public readonly ulong Height;
+        public readonly uint Height;
 
         /// <summary>
-        /// An unsigned long representing the actual width, in pixels, of the ImageData.
+        /// An unsigned number representing the actual width, in pixels, of the ImageData.
         /// </summary>
-        public readonly ulong Width;
+        public readonly uint Width;
     }
 }

--- a/Html5/Performance.cs
+++ b/Html5/Performance.cs
@@ -41,107 +41,107 @@ namespace Bridge.Html5
         }
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, right after the prompt for unload terminates on the previous document in the same browsing context. If there is no previous document, this value will be the same as PerformanceTiming.fetchStart.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, right after the prompt for unload terminates on the previous document in the same browsing context. If there is no previous document, this value will be the same as PerformanceTiming.fetchStart.
         /// </summary>
         public readonly int NavigationStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, the unload event has been thrown. If there is no previous document, or if the previous document, or one of the needed redirects, is not of the same origin, the value returned is 0.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, the unload event has been thrown. If there is no previous document, or if the previous document, or one of the needed redirects, is not of the same origin, the value returned is 0.
         /// </summary>
         public readonly int UnloadEventStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, the unload event handler finishes. If there is no previous document, or if the previous document, or one of the needed redirects, is not of the same origin, the value returned is 0.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, the unload event handler finishes. If there is no previous document, or if the previous document, or one of the needed redirects, is not of the same origin, the value returned is 0.
         /// </summary>
         public readonly int UnloadEventEnd;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, the first HTTP redirect starts. If there is no redirect, or if one of the redirect is not of the same origin, the value returned is 0.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, the first HTTP redirect starts. If there is no redirect, or if one of the redirect is not of the same origin, the value returned is 0.
         /// </summary>
         public readonly int RedirectStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, the last HTTP redirect is completed, that is when the last byte of the HTTP response has been received. If there is no redirect, or if one of the redirect is not of the same origin, the value returned is 0.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, the last HTTP redirect is completed, that is when the last byte of the HTTP response has been received. If there is no redirect, or if one of the redirect is not of the same origin, the value returned is 0.
         /// </summary>
         public readonly int RedirectEnd;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, the browser is ready to fetch the document using an HTTP request. This moment is before the check to any application cache.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, the browser is ready to fetch the document using an HTTP request. This moment is before the check to any application cache.
         /// </summary>
         public readonly int FetchStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, where the domain lookup starts. If a persistent connection is used, or the information is stored in a cache or a local resource, the value will be the same as PerformanceTiming.fetchStart.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, where the domain lookup starts. If a persistent connection is used, or the information is stored in a cache or a local resource, the value will be the same as PerformanceTiming.fetchStart.
         /// </summary>
         public readonly int DomainLookupStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, where the domain lookup is finished. If a persistent connection is used, or the information is stored in a cache or a local resource, the value will be the same as PerformanceTiming.fetchStart.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, where the domain lookup is finished. If a persistent connection is used, or the information is stored in a cache or a local resource, the value will be the same as PerformanceTiming.fetchStart.
         /// </summary>
         public readonly int DomainLookupEnd;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, where the request to open a connection is sent to the network. If the transport layer reports an error and the connection establishment is started again, the last connection establisment start time is given. If a persistent connection is used, the value will be the same as PerformanceTiming.fetchStart.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, where the request to open a connection is sent to the network. If the transport layer reports an error and the connection establishment is started again, the last connection establisment start time is given. If a persistent connection is used, the value will be the same as PerformanceTiming.fetchStart.
         /// </summary>
         public readonly int ConnectStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, where the connection is opened network. If the transport layer reports an error and the connection establishment is started again, the last connection establisment end time is given. If a persistent connection is used, the value will be the same as PerformanceTiming.fetchStart. A connection is considered as opened when all secure connection handshake, or SOCKS authentication, is terminated.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, where the connection is opened network. If the transport layer reports an error and the connection establishment is started again, the last connection establisment end time is given. If a persistent connection is used, the value will be the same as PerformanceTiming.fetchStart. A connection is considered as opened when all secure connection handshake, or SOCKS authentication, is terminated.
         /// </summary>
         public readonly int ConnectEnd;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, where the secure connection handshake starts. If no such connection is requested, it returns 0.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, where the secure connection handshake starts. If no such connection is requested, it returns 0.
         /// </summary>
         public readonly int SecureConnectionStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, when the browser sent the request to obtain the actual document, from the server or from a cache. If the transport layer fails after the start of the request and the connection is reopened, this property will be set to the time corresponding to the new request.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, when the browser sent the request to obtain the actual document, from the server or from a cache. If the transport layer fails after the start of the request and the connection is reopened, this property will be set to the time corresponding to the new request.
         /// </summary>
         public readonly int RequestStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, when the browser received the first byte of the response, from the server from a cache, of from a local resource.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, when the browser received the first byte of the response, from the server from a cache, of from a local resource.
         /// </summary>
         public readonly int ResponseStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, when the browser received the last byte of the response, or when the connection is closed if this happened first, from the server from a cache, of from a local resource.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, when the browser received the last byte of the response, or when the connection is closed if this happened first, from the server from a cache, of from a local resource.
         /// </summary>
         public readonly int ResponseEnd;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, when the parser started its work, that is when its Document.readyState changes to 'loading' and the corresponding readystatechange event is thrown.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, when the parser started its work, that is when its Document.readyState changes to 'loading' and the corresponding readystatechange event is thrown.
         /// </summary>
         public readonly int DomLoading;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, when the parser finished its work on the main document, that is when its Document.readyState changes to 'interactive' and the corresponding readystatechange event is thrown.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, when the parser finished its work on the main document, that is when its Document.readyState changes to 'interactive' and the corresponding readystatechange event is thrown.
         /// </summary>
         public readonly int DomInteractive;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, right before the parser sent the DOMContentLoaded event, that is right after all the scripts that need to be executed right after parsing has been executed.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, right before the parser sent the DOMContentLoaded event, that is right after all the scripts that need to be executed right after parsing has been executed.
         /// </summary>
         public readonly int DomContentLoadedEventStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, right after all the scripts that need to be executed as soon as possible, in order or not, has been executed.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, right after all the scripts that need to be executed as soon as possible, in order or not, has been executed.
         /// </summary>
         public readonly int DomContentLoadedEventEnd;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, when the parser finished its work on the main document, that is when its Document.readyState changes to 'complete' and the corresponding readystatechange event is thrown.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, when the parser finished its work on the main document, that is when its Document.readyState changes to 'complete' and the corresponding readystatechange event is thrown.
         /// </summary>
         public readonly int DomComplete;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, when the load event was sent for the current document. If this event has not yet been sent, it returns 0.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, when the load event was sent for the current document. If this event has not yet been sent, it returns 0.
         /// </summary>
         public readonly int LoadEventStart;
 
         /// <summary>
-        /// Is an unsigned long long representing the moment, in miliseconds since the UNIX epoch, when the load event handler terminated, that is when the load event is completed. If this event has not yet been sent, or is not yet completed, it returns 0.
+        /// Is an int representing the moment, in miliseconds since the UNIX epoch, when the load event handler terminated, that is when the load event is completed. If this event has not yet been sent, or is not yet completed, it returns 0.
         /// </summary>
         public readonly int LoadEventEnd;
     }
@@ -159,12 +159,12 @@ namespace Bridge.Html5
         }
 
         /// <summary>
-        /// Is an unsigned short containing a constant describing how the navigation to this page was done.
+        /// Is an  short containing a constant describing how the navigation to this page was done.
         /// </summary>
         public readonly PerformanceNavigationType Type;
 
         /// <summary>
-        /// Is an unsigned short representing the number of REDIRECTs done before reaching the page.
+        /// Is an  short representing the number of REDIRECTs done before reaching the page.
         /// </summary>
         public readonly int RedirectCount;
     }

--- a/Html5/TypedArray/ArrayBuffer.cs
+++ b/Html5/TypedArray/ArrayBuffer.cs
@@ -18,21 +18,21 @@ namespace Bridge.Html5
         /// The constructor accepts as input a byte length for the new buffer, and returns the newly-created ArrayBuffer object.
         /// </summary>
         /// <param name="length">The size, in bytes, of the array buffer to create.</param>
-        public ArrayBuffer(long length)
+        public ArrayBuffer(int length)
         {
         }
 
         /// <summary>
         /// The size, in bytes, of the array. This is established when the array is constructed and cannot be changed. Read only.
         /// </summary>
-        public readonly long ByteLength;
+        public readonly int ByteLength;
 
         /// <summary>
         /// Returns a new ArrayBuffer whose contents are a copy of this ArrayBuffer's bytes from begin, inclusive, up to end, exclusive. If either begin or end is negative, it refers to an index from the end of the array, as opposed to from the beginning.
         /// </summary>
         /// <param name="begin">Byte index to start slicing.</param>
         /// <returns>A new ArrayBuffer object.</returns>
-        public virtual extern ArrayBuffer Slice(long begin);
+        public virtual extern ArrayBuffer Slice(int begin);
 
         /// <summary>
         /// Returns a new ArrayBuffer whose contents are a copy of this ArrayBuffer's bytes from begin, inclusive, up to end, exclusive. If either begin or end is negative, it refers to an index from the end of the array, as opposed to from the beginning.
@@ -40,6 +40,6 @@ namespace Bridge.Html5
         /// <param name="begin">Byte index to start slicing.</param>
         /// <param name="end">Byte index to end slicing. If end is unspecified, the new ArrayBuffer contains all bytes from begin to the end of this ArrayBuffer.</param>
         /// <returns>A new ArrayBuffer object.</returns>
-        public virtual extern ArrayBuffer Slice(long begin, long end);
+        public virtual extern ArrayBuffer Slice(int begin, int end);
     }
 }

--- a/Html5/TypedArray/DataView.cs
+++ b/Html5/TypedArray/DataView.cs
@@ -21,7 +21,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="buffer">An existing ArrayBuffer to use as the storage for the new DataView object.</param>
         /// <param name="byteOffset">The offset, in bytes, to the first byte in the specified buffer for the new view to reference. If not specified, the view of the buffer will start with the first byte.</param>
-        public DataView(ArrayBuffer buffer, long byteOffset)
+        public DataView(ArrayBuffer buffer, int byteOffset)
         {
         }
 
@@ -31,7 +31,7 @@ namespace Bridge.Html5
         /// <param name="buffer">An existing ArrayBuffer to use as the storage for the new DataView object.</param>
         /// <param name="byteOffset">The offset, in bytes, to the first byte in the specified buffer for the new view to reference. If not specified, the view of the buffer will start with the first byte.</param>
         /// <param name="byteLength">The number of elements in the byte array. If unspecified, length of the view will match the buffer's length.</param>
-        public DataView(ArrayBuffer buffer, long byteOffset, long byteLength)
+        public DataView(ArrayBuffer buffer, int byteOffset, int byteLength)
         {
         }
 
@@ -43,33 +43,33 @@ namespace Bridge.Html5
         /// <summary>
         /// The length, in bytes, of the view. Read only.
         /// </summary>
-        public readonly long ByteLength;
+        public readonly int ByteLength;
 
         /// <summary>
         /// The offset, in bytes, to the first byte of the view within the ArrayBuffer. Read only.
         /// </summary>
-        public readonly long ByteOffset;
+        public readonly int ByteOffset;
 
         /// <summary>
         /// Gets a signed 8-bit integer at the specified byte offset from the start of the view.
         /// </summary>
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <returns></returns>
-        public virtual extern sbyte GetInt8(long byteOffset);
+        public virtual extern sbyte GetInt8(int byteOffset);
 
         /// <summary>
         /// Gets an unsigned 8-bit integer at the specified byte offset from the start of the view.
         /// </summary>
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <returns></returns>
-        public virtual extern byte GetUint8(long byteOffset);
+        public virtual extern byte GetUint8(int byteOffset);
 
         /// <summary>
         /// Gets a signed 16-bit integer at the specified byte offset from the start of the view.
         /// </summary>
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <returns></returns>
-        public virtual extern short GetInt16(long byteOffset);
+        public virtual extern short GetInt16(int byteOffset);
 
         /// <summary>
         /// Gets a signed 16-bit integer at the specified byte offset from the start of the view.
@@ -77,14 +77,14 @@ namespace Bridge.Html5
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <param name="littleEndian">Indicates whether the 16-bit int is stored in little- or big-endian format. If false or undefined, a big-endian value is read.</param>
         /// <returns></returns>
-        public virtual extern short GetInt16(long byteOffset, bool littleEndian);
+        public virtual extern short GetInt16(int byteOffset, bool littleEndian);
 
         /// <summary>
         /// Gets an unsigned 16-bit integer at the specified byte offset from the start of the view.
         /// </summary>
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <returns></returns>
-        public virtual extern ushort GetUint16(long byteOffset);
+        public virtual extern ushort GetUint16(int byteOffset);
 
         /// <summary>
         /// Gets an unsigned 16-bit integer at the specified byte offset from the start of the view.
@@ -92,14 +92,14 @@ namespace Bridge.Html5
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <param name="littleEndian">Indicates whether the 16-bit int is stored in little- or big-endian format. If false or undefined, a big-endian value is read.</param>
         /// <returns></returns>
-        public virtual extern ushort GetUint16(long byteOffset, bool littleEndian);
+        public virtual extern ushort GetUint16(int byteOffset, bool littleEndian);
 
         /// <summary>
         /// Gets an signed 32-bit integer at the specified byte offset from the start of the view.
         /// </summary>
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <returns></returns>
-        public virtual extern int GetInt32(long byteOffset);
+        public virtual extern int GetInt32(int byteOffset);
 
         /// <summary>
         /// Gets an signed 32-bit integer at the specified byte offset from the start of the view.
@@ -107,14 +107,14 @@ namespace Bridge.Html5
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <param name="littleEndian">Indicates whether the 32-bit int is stored in little- or big-endian format. If false or undefined, a big-endian value is read.</param>
         /// <returns></returns>
-        public virtual extern int GetInt32(long byteOffset, bool littleEndian);
+        public virtual extern int GetInt32(int byteOffset, bool littleEndian);
 
         /// <summary>
         /// Gets an unsigned 32-bit integer at the specified byte offset from the start of the view.
         /// </summary>
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <returns></returns>
-        public virtual extern uint GetUint32(long byteOffset);
+        public virtual extern uint GetUint32(int byteOffset);
 
         /// <summary>
         /// Gets an unsigned 32-bit integer at the specified byte offset from the start of the view.
@@ -122,42 +122,42 @@ namespace Bridge.Html5
         /// <param name="byteOffset">The offset, in byte, from the start of the view where to read the data.</param>
         /// <param name="littleEndian">Indicates whether the 32-bit int is stored in little- or big-endian format. If false or undefined, a big-endian value is read.</param>
         /// <returns></returns>
-        public virtual extern uint GetUint32(long byteOffset, bool littleEndian);
+        public virtual extern uint GetUint32(int byteOffset, bool littleEndian);
 
-        public virtual extern float GetFloat32(long byteOffset);
+        public virtual extern float GetFloat32(int byteOffset);
 
-        public virtual extern float GetFloat32(long byteOffset, bool littleEndian);
+        public virtual extern float GetFloat32(int byteOffset, bool littleEndian);
 
-        public virtual extern double GetFloat64(long byteOffset);
+        public virtual extern double GetFloat64(int byteOffset);
 
-        public virtual extern double GetFloat64(long byteOffset, bool littleEndian);
+        public virtual extern double GetFloat64(int byteOffset, bool littleEndian);
 
-        public virtual extern void SetInt8(long byteOffset, sbyte value);
+        public virtual extern void SetInt8(int byteOffset, sbyte value);
 
-        public virtual extern void SetUint8(long byteOffset, byte value);
+        public virtual extern void SetUint8(int byteOffset, byte value);
 
-        public virtual extern void SetInt16(long byteOffset, short value);
+        public virtual extern void SetInt16(int byteOffset, short value);
 
-        public virtual extern void SetInt16(long byteOffset, short value, bool littleEndian);
+        public virtual extern void SetInt16(int byteOffset, short value, bool littleEndian);
 
-        public virtual extern void SetUint16(long byteOffset, ushort value);
+        public virtual extern void SetUint16(int byteOffset, ushort value);
 
-        public virtual extern void SetUint16(ulong byteOffset, ushort value, bool littleEndian);
+        public virtual extern void SetUint16(uint byteOffset, ushort value, bool littleEndian);
 
-        public virtual extern void SetInt32(long byteOffset, int value);
+        public virtual extern void SetInt32(int byteOffset, int value);
 
-        public virtual extern void SetInt32(long byteOffset, int value, bool littleEndian);
+        public virtual extern void SetInt32(int byteOffset, int value, bool littleEndian);
 
-        public virtual extern void SetUint32(long byteOffset, uint value);
+        public virtual extern void SetUint32(int byteOffset, uint value);
 
-        public virtual extern void SetUint32(ulong byteOffset, uint value, bool littleEndian);
+        public virtual extern void SetUint32(uint byteOffset, uint value, bool littleEndian);
 
-        public virtual extern void SetFloat32(long byteOffset, float value);
+        public virtual extern void SetFloat32(int byteOffset, float value);
 
-        public virtual extern void SetFloat32(long byteOffset, float value, bool littleEndian);
+        public virtual extern void SetFloat32(int byteOffset, float value, bool littleEndian);
 
-        public virtual extern void SetFloat64(long byteOffset, double value);
+        public virtual extern void SetFloat64(int byteOffset, double value);
 
-        public virtual extern void SetFloat64(long byteOffset, double value, bool littleEndian);
+        public virtual extern void SetFloat64(int byteOffset, double value, bool littleEndian);
     }
 }

--- a/Html5/TypedArray/Float32Array.cs
+++ b/Html5/TypedArray/Float32Array.cs
@@ -18,7 +18,7 @@ namespace Bridge.Html5
         /// Creates a new Float32Array of the specified length.
         /// </summary>
         /// <param name="length">Length of array to create</param>
-        public Float32Array(Any<int, long, uint, ulong> length)
+        public Float32Array(Any<int, uint> length)
         {
         }
 
@@ -53,7 +53,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="i">Index position in the array.</param>
         /// <returns>The element in the specified position.</returns>
-        public float this[Any<int, long, uint, ulong> i]
+        public float this[Any<int, uint> i]
         {
             get
             {

--- a/Html5/TypedArray/Float64Array.cs
+++ b/Html5/TypedArray/Float64Array.cs
@@ -18,7 +18,7 @@ namespace Bridge.Html5
         /// Creates a new Float64Array of the specified length.
         /// </summary>
         /// <param name="length">Length of array to create</param>
-        public Float64Array(Any<int, long, uint, ulong> length)
+        public Float64Array(Any<int, uint> length)
         {
         }
 
@@ -53,7 +53,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="i">Index position in the array.</param>
         /// <returns>The element in the specified position.</returns>
-        public double this[Any<int, long, uint, ulong> i]
+        public double this[Any<int, uint> i]
         {
             get
             {

--- a/Html5/TypedArray/Int16Array.cs
+++ b/Html5/TypedArray/Int16Array.cs
@@ -17,7 +17,7 @@ namespace Bridge.Html5
         /// Creates a new Int16Array of the specified length.
         /// </summary>
         /// <param name="length">Length of array to create</param>
-        public Int16Array(Any<int, long, uint, ulong> length)
+        public Int16Array(Any<int, uint> length)
         {
         }
 
@@ -52,7 +52,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="i">Index position in the array.</param>
         /// <returns>The element in the specified position.</returns>
-        public short this[Any<int, long, uint, ulong> i]
+        public short this[Any<int, uint> i]
         {
             get
             {

--- a/Html5/TypedArray/Int32Array.cs
+++ b/Html5/TypedArray/Int32Array.cs
@@ -17,7 +17,7 @@ namespace Bridge.Html5
         /// Creates a new Int32Array of the specified length.
         /// </summary>
         /// <param name="length">Length of array to create</param>
-        public Int32Array(Any<int, long, uint, ulong> length)
+        public Int32Array(Any<int, uint> length)
         {
         }
 
@@ -52,7 +52,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="i">Index position in the array.</param>
         /// <returns>The element in the specified position.</returns>
-        public int this[Any<int, long, uint, ulong> i]
+        public int this[Any<int, uint> i]
         {
             get
             {

--- a/Html5/TypedArray/Int8Array.cs
+++ b/Html5/TypedArray/Int8Array.cs
@@ -52,7 +52,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="i">Index position in the array.</param>
         /// <returns>The element in the specified position.</returns>
-        public SByte this[Any<int, uint, long, ulong> i]
+        public SByte this[Any<int, uint> i]
         {
             get
             {

--- a/Html5/TypedArray/Prototype.cs
+++ b/Html5/TypedArray/Prototype.cs
@@ -36,19 +36,19 @@ namespace Bridge.Html5.TypedArray
         /// Returns the length (in bytes) of the typed array from the start of its ArrayBuffer.
         /// Fixed at construction time and thus read only
         /// </summary>
-        public readonly long ByteLength;
+        public readonly int ByteLength;
 
         /// <summary>
         /// Returns the offset (in bytes) of the typed array from the start of its ArrayBuffer.
         /// Fixed at construction time and thus read only.
         /// </summary>
-        public readonly long ByteOffset;
+        public readonly int ByteOffset;
 
         /// <summary>
         /// Returns the number of elements hold in the typed array. Fixed at construction time and thus
         /// read only.
         /// </summary>
-        public readonly long Length;
+        public readonly int Length;
 
         #endregion Properties
 
@@ -62,7 +62,7 @@ namespace Bridge.Html5.TypedArray
         /// <param name="target">Target start index position where to copy the elements to.</param>
         /// <param name="start">Source start index position where to start copying elements from.</param>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public void CopyWithin(Any<int, long, uint, ulong> target, Any<int, long, uint, ulong> start)
+        public void CopyWithin(Any<int, uint> target, Any<int, uint> start)
         {
             return;
         }
@@ -76,8 +76,8 @@ namespace Bridge.Html5.TypedArray
         /// <param name="start">Source start index position where to start copying elements from.</param>
         /// <param name="end">Optional. Source end index position where to end copying elements from.</param>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public void CopyWithin(Any<int, long, uint, ulong> target, Any<int, long, uint, ulong> start,
-            Any<int, long, uint, ulong> end)
+        public void CopyWithin(Any<int, uint> target, Any<int, uint> start,
+            Any<int, uint> end)
         {
             return;
         }
@@ -101,7 +101,7 @@ namespace Bridge.Html5.TypedArray
         /// <param name="thisArg">Optional. Value to use as this when executing callback.</param>
         /// <returns>True if callback returns true for all elements on array, false otherwise.</returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public bool Every(Func<TypedElement, Any<int, long, uint, ulong>, TypedArray, bool> callback,
+        public bool Every(Func<TypedElement, Any<int, uint>, TypedArray, bool> callback,
             TypedArray thisArg = default(TypedArray))
         {
             return default(bool);
@@ -123,7 +123,7 @@ namespace Bridge.Html5.TypedArray
         /// <param name="value">Value to fill the typed array with.</param>
         /// <param name="start">Optional. Start index. Defaults to 0.</param>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public void Fill(TypedElement value, Any<int, long, uint, ulong> start)
+        public void Fill(TypedElement value, Any<int, uint> start)
         {
             return;
         }
@@ -136,7 +136,7 @@ namespace Bridge.Html5.TypedArray
         /// <param name="end">Optional. End index. Defaults to 0.</param>
         /// <remarks>Most browsers do not support this yet.</remarks>
         public void Fill(TypedElement value,
-            Any<int, long, uint, ulong> start, Any<int, long, uint, ulong> end)
+            Any<int, uint> start, Any<int, uint> end)
         {
             return;
         }
@@ -152,7 +152,7 @@ namespace Bridge.Html5.TypedArray
         /// <param name="thisArg">Value to use as this when executing callback.</param>
         /// <returns></returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public TypedArray Filter(Func<TypedElement, Any<int, long, uint, ulong>, TypedArray, bool> callback,
+        public TypedArray Filter(Func<TypedElement, Any<int, uint>, TypedArray, bool> callback,
             TypedArray thisArg = default(TypedArray))
         {
             return default(TypedArray);
@@ -172,7 +172,7 @@ namespace Bridge.Html5.TypedArray
         /// </param>
         /// <param name="thisArg">Optional. Value to use as 'this' when executing callback.</param>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public void ForEach(Func<TypedElement, Any<int, long, uint, ulong>, TypedArray, TypedElement> callback,
+        public void ForEach(Func<TypedElement, Any<int, uint>, TypedArray, TypedElement> callback,
             TypedArray thisArg = default(TypedArray))
         {
             return;
@@ -190,9 +190,9 @@ namespace Bridge.Html5.TypedArray
         /// not present.
         /// </returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public long IndexOf(TypedElement searchElement)
+        public int IndexOf(TypedElement searchElement)
         {
-            return default(long);
+            return default(int);
         }
 
         /// <summary>
@@ -213,9 +213,9 @@ namespace Bridge.Html5.TypedArray
         /// not present.
         /// </returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public long IndexOf(TypedElement searchElement, Any<int, long, uint, ulong> fromIndex)
+        public int IndexOf(TypedElement searchElement, Any<int, uint> fromIndex)
         {
-            return default(long);
+            return default(int);
         }
 
         /// <summary>
@@ -258,9 +258,9 @@ namespace Bridge.Html5.TypedArray
         /// not present.
         /// </returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public long LastIndexOf(TypedElement searchElement)
+        public int LastIndexOf(TypedElement searchElement)
         {
-            return default(long);
+            return default(int);
         }
 
         /// <summary>
@@ -281,9 +281,9 @@ namespace Bridge.Html5.TypedArray
         /// not present.
         /// </returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public long LastIndexOf(TypedElement searchElement, Any<int, long, uint, ulong> fromIndex)
+        public int LastIndexOf(TypedElement searchElement, Any<int, uint> fromIndex)
         {
-            return default(long);
+            return default(int);
         }
 
         /// <summary>
@@ -297,7 +297,7 @@ namespace Bridge.Html5.TypedArray
         /// </param>
         /// <param name="thisArg">Optional. Value to use as 'this' when executing callback.</param>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public TypedArray Map(Func<TypedElement, Any<int, long, uint, ulong>, TypedArray, TypedElement> callback,
+        public TypedArray Map(Func<TypedElement, Any<int, uint>, TypedArray, TypedElement> callback,
             TypedArray thisArg = default(TypedArray))
         {
             return default(TypedArray);
@@ -323,7 +323,7 @@ namespace Bridge.Html5.TypedArray
         /// <returns></returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
         public TypedElement Reduce(
-            Func<TypedElement, TypedElement, Any<int, long, uint, ulong>, TypedArray, TypedElement> callback,
+            Func<TypedElement, TypedElement, Any<int, uint>, TypedArray, TypedElement> callback,
             TypedElement initialValue = default(TypedElement))
         {
             return default(TypedElement);
@@ -347,7 +347,7 @@ namespace Bridge.Html5.TypedArray
         /// <returns></returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
         public TypedElement ReduceRight(
-            Func<TypedElement, TypedElement, Any<int, long, uint, ulong>, TypedArray, TypedElement> callback,
+            Func<TypedElement, TypedElement, Any<int, uint>, TypedArray, TypedElement> callback,
             TypedElement initialValue = default(TypedElement))
         {
             return default(TypedElement);
@@ -389,7 +389,7 @@ namespace Bridge.Html5.TypedArray
         /// If you omit this value, 0 is assumed (that is, the source array will overwrite values in
         /// the target array starting at index 0).
         /// </param>
-        public void Set(Array array, Any<int, long, uint, ulong> offset)
+        public void Set(Array array, Any<int, uint> offset)
         {
             return;
         }
@@ -412,7 +412,7 @@ namespace Bridge.Html5.TypedArray
         /// If you omit this value, 0 is assumed (that is, the source array will overwrite values in
         /// the target array starting at index 0).
         /// </param>
-        public void Set(TypedArray typedArray, Any<int, long, uint, ulong> offset)
+        public void Set(TypedArray typedArray, Any<int, uint> offset)
         {
             return;
         }
@@ -438,7 +438,7 @@ namespace Bridge.Html5.TypedArray
         /// </param>
         /// <returns>A shallow copy of elements from the original typed array</returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public TypedArray Slice(Any<int, long, uint, ulong> begin)
+        public TypedArray Slice(Any<int, uint> begin)
         {
             return default(TypedArray);
         }
@@ -462,7 +462,7 @@ namespace Bridge.Html5.TypedArray
         /// </param>
         /// <returns>A shallow copy of elements from the original typed array</returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public TypedArray Slice(Any<int, long, uint, ulong> begin, Any<int, long, uint, ulong> end)
+        public TypedArray Slice(Any<int, uint> begin, Any<int, uint> end)
         {
             return default(TypedArray);
         }
@@ -482,7 +482,7 @@ namespace Bridge.Html5.TypedArray
         /// False otherwise.
         /// </returns>
         /// <remarks>Most browsers do not support this yet.</remarks>
-        public bool Some(Func<TypedElement, Any<int, long, uint, ulong>, TypedArray, TypedElement> callback,
+        public bool Some(Func<TypedElement, Any<int, uint>, TypedArray, TypedElement> callback,
             TypedArray thisArg = default(TypedArray))
         {
             return default(bool);
@@ -504,7 +504,7 @@ namespace Bridge.Html5.TypedArray
         /// <param name="compareFunction">
         /// Specifies a function that defines the sort order. If omitted, the array is sorted according to
         /// each character's Unicode code point value, according to the string conversion of each element.
-        /// Example: long compareFunction(a, b) { ... };
+        /// Example: int compareFunction(a, b) { ... };
         /// </param>
         /// <remarks>
         /// Most browsers do not support this yet.
@@ -521,7 +521,7 @@ namespace Bridge.Html5.TypedArray
         ///   and b as its two arguments. If inconsistent results are returned then the sort order is undefined.
         /// </remarks>
         /// <returns>Sorted TypedArray.</returns>
-        public TypedArray Sort(Func<TypedElement, TypedElement, long> compareFunction)
+        public TypedArray Sort(Func<TypedElement, TypedElement, int> compareFunction)
         {
             return default(TypedArray);
         }
@@ -551,7 +551,7 @@ namespace Bridge.Html5.TypedArray
         /// as for this TypedArray object.
         /// </returns>
         [Name("subarray")]
-        public TypedArray SubArray(Any<int, long, uint, ulong> begin)
+        public TypedArray SubArray(Any<int, uint> begin)
         {
             return default(TypedArray);
         }
@@ -569,7 +569,7 @@ namespace Bridge.Html5.TypedArray
         /// as for this TypedArray object.
         /// </returns>
         [Name("subarray")]
-        public TypedArray SubArray(Any<int, long, uint, ulong> begin, Any<int, long, uint, ulong> end)
+        public TypedArray SubArray(Any<int, uint> begin, Any<int, uint> end)
         {
             return default(TypedArray);
         }

--- a/Html5/TypedArray/Uint16Array.cs
+++ b/Html5/TypedArray/Uint16Array.cs
@@ -17,7 +17,7 @@ namespace Bridge.Html5
         /// Creates a new Uint16Array of the specified length.
         /// </summary>
         /// <param name="length">Length of array to create</param>
-        public Uint16Array(Any<int, long, uint, ulong> length)
+        public Uint16Array(Any<int, uint> length)
         {
         }
 
@@ -52,7 +52,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="i">Index position in the array.</param>
         /// <returns>The element in the specified position.</returns>
-        public ushort this[Any<int, long, uint, ulong> i]
+        public ushort this[Any<int, uint> i]
         {
             get
             {

--- a/Html5/TypedArray/Uint32Array.cs
+++ b/Html5/TypedArray/Uint32Array.cs
@@ -17,7 +17,7 @@ namespace Bridge.Html5
         /// Creates a new Uint32Array of the specified length.
         /// </summary>
         /// <param name="length">Length of array to create</param>
-        public Uint32Array(Any<int, long, uint, ulong> length)
+        public Uint32Array(Any<int, uint> length)
         {
         }
 
@@ -52,7 +52,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="i">Index position in the array.</param>
         /// <returns>The element in the specified position.</returns>
-        public uint this[Any<int, long, uint, ulong> i]
+        public uint this[Any<int, uint> i]
         {
             get
             {

--- a/Html5/TypedArray/Uint8Array.cs
+++ b/Html5/TypedArray/Uint8Array.cs
@@ -16,7 +16,7 @@ namespace Bridge.Html5
         /// Creates a new Uint8Array of the specified length.
         /// </summary>
         /// <param name="length">Length of array to create</param>
-        public Uint8Array(Any<int, long, uint, ulong> length)
+        public Uint8Array(Any<int, uint> length)
         {
         }
 
@@ -51,7 +51,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="i">Index position in the array.</param>
         /// <returns>The element in the specified position.</returns>
-        public byte this[Any<int, long, uint, ulong> i]
+        public byte this[Any<int, uint> i]
         {
             get
             {

--- a/Html5/TypedArray/Uint8ClampedArray.cs
+++ b/Html5/TypedArray/Uint8ClampedArray.cs
@@ -18,7 +18,7 @@ namespace Bridge.Html5
         /// Creates a new Uint8ClampedArray of the specified length.
         /// </summary>
         /// <param name="length">Length of array to create</param>
-        public Uint8ClampedArray(Any<int, long, uint, ulong> length)
+        public Uint8ClampedArray(Any<int, uint> length)
         {
         }
 
@@ -55,7 +55,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="i">Index position in the array.</param>
         /// <returns>The element in the specified position.</returns>
-        public byte this[Any<int, long, uint, ulong> i]
+        public byte this[Any<int, uint> i]
         {
             get
             {

--- a/Html5/WebSocket.cs
+++ b/Html5/WebSocket.cs
@@ -122,7 +122,7 @@ namespace Bridge.Html5
 		/// transmitted to the network. This value does not reset to zero when the connection is closed;
 		/// if you keep calling Send(), this will continue to climb.
 		/// </summary>
-		public readonly ulong BufferedAmount;
+		public readonly uint BufferedAmount;
 
 		/// <summary>
 		/// The extensions selected by the server.

--- a/Html5/Window.cs
+++ b/Html5/Window.cs
@@ -542,30 +542,30 @@ namespace Bridge.Html5
         /// The window.requestAnimationFrame() method tells the browser that you wish to perform an animation and requests that the browser call a specified function to update an animation before the next repaint. The method takes as an argument a callback to be invoked before the repaint.
         /// </summary>
         /// <param name="callback">A parameter specifying a function to call when it's time to update your animation for the next repaint. The callback has one single argument, a DOMHighResTimeStamp, which indicates the current time for when requestAnimationFrame starts to fire callbacks.</param>
-        /// <returns>requestID is a long integer value that uniquely identifies the entry in the callback list. This is a non-zero value, but you may not make any other assumptions about its value. You can pass this value to window.cancelAnimationFrame() to cancel the refresh callback request.</returns>
-        public static long RequestAnimationFrame(Delegate callback)
+        /// <returns>requestID is an integer value that uniquely identifies the entry in the callback list. This is a non-zero value, but you may not make any other assumptions about its value. You can pass this value to window.cancelAnimationFrame() to cancel the refresh callback request.</returns>
+        public static int RequestAnimationFrame(Delegate callback)
         {
-            return default(long);
+            return default(int);
         }
 
         /// <summary>
         /// The window.requestAnimationFrame() method tells the browser that you wish to perform an animation and requests that the browser call a specified function to update an animation before the next repaint. The method takes as an argument a callback to be invoked before the repaint.
         /// </summary>
         /// <param name="callback">A parameter specifying a function to call when it's time to update your animation for the next repaint. The callback has one single argument, a DOMHighResTimeStamp, which indicates the current time for when requestAnimationFrame starts to fire callbacks.</param>
-        /// <returns>requestID is a long integer value that uniquely identifies the entry in the callback list. This is a non-zero value, but you may not make any other assumptions about its value. You can pass this value to window.cancelAnimationFrame() to cancel the refresh callback request.</returns>
-        public static long RequestAnimationFrame(Action<double> callback)
+        /// <returns>requestID is an integer value that uniquely identifies the entry in the callback list. This is a non-zero value, but you may not make any other assumptions about its value. You can pass this value to window.cancelAnimationFrame() to cancel the refresh callback request.</returns>
+        public static int RequestAnimationFrame(Action<double> callback)
         {
-            return default(long);
+            return default(int);
         }
 
         /// <summary>
         /// The window.requestAnimationFrame() method tells the browser that you wish to perform an animation and requests that the browser call a specified function to update an animation before the next repaint. The method takes as an argument a callback to be invoked before the repaint.
         /// </summary>
         /// <param name="callback">A parameter specifying a function to call when it's time to update your animation for the next repaint. The callback has one single argument, a DOMHighResTimeStamp, which indicates the current time for when requestAnimationFrame starts to fire callbacks.</param>
-        /// <returns>requestID is a long integer value that uniquely identifies the entry in the callback list. This is a non-zero value, but you may not make any other assumptions about its value. You can pass this value to window.cancelAnimationFrame() to cancel the refresh callback request.</returns>
-        public static long RequestAnimationFrame(Action callback)
+        /// <returns>requestID is a int integer value that uniquely identifies the entry in the callback list. This is a non-zero value, but you may not make any other assumptions about its value. You can pass this value to window.cancelAnimationFrame() to cancel the refresh callback request.</returns>
+        public static int RequestAnimationFrame(Action callback)
         {
-            return default(long);
+            return default(int);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1190 .

Changes proposed in this pull request:

- Changed erratic fields' ulong type to uint.

Unit tests are to be done yet. To test the issue I used this code:

```
public class App
{
    [Ready]
    public static void Main()
    {
        // Test Case #1
        var fileInput = new InputElement
        {
            Type = InputType.File,
            OnChange = (ev) => 
            {
                File file = ev.CurrentTarget.Files[0];

                long size = (long)file.Size; // this throws a JavaScript error at runtime
            }
        };

        Document.Body.AppendChild(fileInput);

        // Test Case #2
        ImageData imageData = new ImageData(100, 100);
        long height = (long)imageData.Height; // this throws a JavaScript error at runtime
        long width = (long)imageData.Width; // this throws a JavaScript error at runtime

        // Test Case #3
        var webSocket = new WebSocket("ws://echo.websocket.org");
        var bufferedAmount = (long)webSocket.BufferedAmount; // this throws a JavaScript error at runtime
    }
}
```

For a unit test, there is a way to test the .Size file without creating an InputElement:
```
var blob = new Blob(new BlobDataObject[] { "file text" }, new BlobPropertyBag
{
    Type = "text/plain"
});

var size = (long)blob.Size; // this throws a JavaScript error at runtime
```
