### PR TITLE
Make stock object's GetHashCode() repeatable for classes with fields

### DIFF
--- a/Bridge/Resources/Core.js
+++ b/Bridge/Resources/Core.js
@@ -214,7 +214,7 @@
             }
         },
 
-        getHashCode: function (value, safe, store) {
+        getHashCode: function (value, safe, store = true) {
             if (Bridge.isEmpty(value, true)) {
                 if (safe) {
                     return 0;
@@ -299,7 +299,7 @@
                     delete Bridge.$$hashCodeCache;
                 }
 
-                if (result !== 0) {
+                if (result !== 0 && !store) {
                     return result;
                 }
             }

--- a/Bridge/Resources/Core.js
+++ b/Bridge/Resources/Core.js
@@ -214,7 +214,14 @@
             }
         },
 
-        getHashCode: function (value, safe, store = true) {
+        getHashCode: function (value, safe, store) {
+            //in CLR: mutable object should keep on returning same value
+            //bridge.net goals: make it deterministic (to make testing easier) without breaking CLR contracts
+            // thus:
+            //     for value types it returns deterministic values (f.e. for int 3 it returns 3) 
+            //     for reference types it returns value derived recursively from its properties
+            var store = (typeof store === 'undefined') ? true : store; 
+
             if (Bridge.isEmpty(value, true)) {
                 if (safe) {
                     return 0;
@@ -299,7 +306,11 @@
                     delete Bridge.$$hashCodeCache;
                 }
 
-                if (result !== 0 && !store) {
+                if (store) {
+                    value.$$hashCode = result;
+                }
+
+                if (result !== 0) {
                     return result;
                 }
             }


### PR DESCRIPTION
Fixes #1264

Changes proposed in this pull request:
- Core.js behavior when fields are detected