### PR TITLE
Rename logging settings

### DIFF
--- a/Compiler/Contract/IAssemblyInfo.cs
+++ b/Compiler/Contract/IAssemblyInfo.cs
@@ -276,9 +276,9 @@ namespace Bridge.Contract
 
     public class LoggingOptions
     {
-        public LoggerLevel? LoggerLevel { get; set; }
-        public bool? NoLoggerTimeStamps { get; set; }
-        public long?  MaxLogFileSize { get; set; }
+        public LoggerLevel? Level { get; set; }
+        public bool? TimeStamps { get; set; }
+        public long?  MaxSize { get; set; }
         public string Folder { get; set; }
         public string FileName { get; set; }
     }

--- a/Compiler/Translator/Translator/TranslatorProcessor.cs
+++ b/Compiler/Translator/Translator/TranslatorProcessor.cs
@@ -169,7 +169,7 @@ namespace Bridge.Translator
 
             try
             {
-                logger.LoggerLevel = assemblyConfig.Logging.LoggerLevel ?? LoggerLevel.None;
+                logger.LoggerLevel = assemblyConfig.Logging.Level ?? LoggerLevel.None;
 
                 logger.Info("Read config file: " + AssemblyConfigHelper.ConfigToString(assemblyConfig));
 
@@ -179,9 +179,9 @@ namespace Bridge.Translator
                 {
                     logger.UseTimeStamp = !bridgeOptions.NoTimeStamp.Value;
                 }
-                else if (assemblyConfig.Logging.NoLoggerTimeStamps.HasValue)
+                else if (assemblyConfig.Logging.TimeStamps.HasValue)
                 {
-                    logger.UseTimeStamp = !assemblyConfig.Logging.NoLoggerTimeStamps.Value;
+                    logger.UseTimeStamp = assemblyConfig.Logging.TimeStamps.Value;
                 }else
                 {
                     logger.UseTimeStamp = true;
@@ -201,7 +201,7 @@ namespace Bridge.Translator
                         logFileFolder = Path.Combine(this.GetOutputFolder(true, false), logFileFolder);
                     }
 
-                    fileLoggerWriter.SetParameters(logFileFolder, assemblyConfig.Logging.FileName, assemblyConfig.Logging.MaxLogFileSize);
+                    fileLoggerWriter.SetParameters(logFileFolder, assemblyConfig.Logging.FileName, assemblyConfig.Logging.MaxSize);
                 }
 
                 logger.Flush();

--- a/Tests/Batch1/Bridge/bridge.Debug.json
+++ b/Tests/Batch1/Bridge/bridge.Debug.json
@@ -1,7 +1,7 @@
 ﻿{
   "logging": {
-    "loggerLevel": "Info",
-    "maxLogFileSize": 1048576,
+    "level": "Info",
+    "maxSize": 1048576,
     "folder": "bin/Debug"
   }
 }

--- a/Tests/Batch1/Bridge/bridge.Release.json
+++ b/Tests/Batch1/Bridge/bridge.Release.json
@@ -1,7 +1,7 @@
 ﻿{
   "logging": {
-    "loggerLevel": "Info",
-    "maxLogFileSize": 1048576,
+    "level": "Info",
+    "maxSize": 1048576,
     "folder": "bin/Release"
   }
 }

--- a/Tests/Batch2/Bridge/bridge.json
+++ b/Tests/Batch2/Bridge/bridge.json
@@ -4,7 +4,9 @@
   "outputFormatting": "Formatted",
   "fileName": "code.js",
   "outputBy": "Project",
-  "loggerLevel": "Info",
+  "logging": {
+    "level": "None"
+  },
 
   "useTypedArrays": true,
   "overflowMode": "Javascript",

--- a/Transpiled/Bridge/bridge.json
+++ b/Transpiled/Bridge/bridge.json
@@ -3,5 +3,7 @@
   "cleanOutputFolderBeforeBuild": true,
   "outputFormatting": "Formatted",
   "outputBy": "ClassPath",
-  "loggerLevel": "Info"
+  "logging": {
+    "level": "None"
+  }
 }


### PR DESCRIPTION
Addresses #1237 .

Logging section option names to be:
```
"logging": {
  "level": "Info",
  "timeStamps": true,
  "maxSize": 1048576,
  "folder": "Bridge/Logs",
  "fileName" : "myBridge.log"
}
```