### PR TITLE
Issue1284 "outputBy" configuration option results in an empty filename

### DIFF
--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -133,6 +133,7 @@ namespace Bridge.Build
             {
                 ProjectLocation = this.ProjectPath,
                 OutputLocation = this.OutputPath,
+                DefaultFileName = Path.GetFileNameWithoutExtension(this.Assembly.ItemSpec),
                 BridgeLocation = Path.Combine(this.AssembliesPath, "Bridge.dll"),
                 Rebuild = false,
                 ExtractCore = !NoCore,

--- a/Compiler/Builder/Program.cs
+++ b/Compiler/Builder/Program.cs
@@ -286,6 +286,8 @@ namespace Bridge.Builder
                     ? Path.GetFileNameWithoutExtension(bridgeOptions.ProjectLocation) : bridgeOptions.Folder;
             }
 
+            bridgeOptions.DefaultFileName = Path.GetFileName(bridgeOptions.OutputLocation);
+
             return bridgeOptions;
         }
     }

--- a/Compiler/Translator/Translator/TranslatorProcessor.cs
+++ b/Compiler/Translator/Translator/TranslatorProcessor.cs
@@ -72,7 +72,7 @@ namespace Bridge.Translator
                 translator.ExtractCore(outputPath);
             }
 
-            var fileName = Path.GetFileName(bridgeOptions.OutputLocation);
+            var fileName = bridgeOptions.DefaultFileName;
 
             logger.Info("Saving to " + outputPath);
             translator.SaveTo(outputPath, fileName);

--- a/Compiler/Translator/Utils/BridgeOptions.cs
+++ b/Compiler/Translator/Utils/BridgeOptions.cs
@@ -8,6 +8,7 @@ namespace Bridge.Translator
 
         public string ProjectLocation { get; set; }
         public string OutputLocation { get; set; }
+        public string DefaultFileName { get; set; }
         public string BridgeLocation { get; set; }
         public bool Rebuild { get; set; }
         public bool ExtractCore { get; set; }

--- a/Compiler/TranslatorTests/TranslatorRunner.cs
+++ b/Compiler/TranslatorTests/TranslatorRunner.cs
@@ -82,6 +82,7 @@ namespace Bridge.Translator.Tests
                 ProjectLocation = ProjectLocation,
                 OutputLocation = outputLocation,
                 BridgeLocation = bridgeLocation,
+                DefaultFileName = Path.GetFileName(outputLocation),
                 Rebuild = true,
                 ExtractCore = true,
                 Configuration = configuration,


### PR DESCRIPTION
Fixes #1284 .

Changes proposed in this pull request:
- setting default name separately for Console and Task - `BridgeOptions.DefaultFileName`

Task: `Path.GetFileNameWithoutExtension(this.Assembly.ItemSpec)`
Console: `Path.GetFileName(bridgeOptions.OutputLocation)`