### PR TITLE
Only allow Any<> types to be instantiated via casts, never via the co…

### DIFF
--- a/Bridge/System/Any.cs
+++ b/Bridge/System/Any.cs
@@ -6,6 +6,8 @@ namespace Bridge
     [Name("Object")]
     public class Any<T1, T2>
     {
+        private Any() { }
+
         public static implicit operator Any<T1, T2>(T1 t)
         {
             return null;
@@ -33,6 +35,8 @@ namespace Bridge
     [Name("Object")]
     public class Any<T1, T2, T3>
     {
+        private Any() { }
+
         public static implicit operator Any<T1, T2, T3>(T1 t)
         {
             return null;
@@ -70,6 +74,8 @@ namespace Bridge
     [Name("Object")]
     public class Any<T1, T2, T3, T4>
     {
+        private Any() { }
+
         public static implicit operator Any<T1, T2, T3, T4>(T1 t)
         {
             return null;
@@ -117,6 +123,8 @@ namespace Bridge
     [Name("Object")]
     public class Any<T1, T2, T3, T4, T5>
     {
+        private Any() { }
+
         public static implicit operator Any<T1, T2, T3, T4, T5>(T1 t)
         {
             return null;
@@ -174,6 +182,8 @@ namespace Bridge
     [Name("Object")]
     public class Any<T1, T2, T3, T4, T5, T6>
     {
+        private Any() { }
+
         public static implicit operator Any<T1, T2, T3, T4, T5, T6>(T1 t)
         {
             return null;
@@ -241,6 +251,8 @@ namespace Bridge
     [Name("Object")]
     public class Any<T1, T2, T3, T4, T5, T6, T7>
     {
+        private Any() { }
+
         public static implicit operator Any<T1, T2, T3, T4, T5, T6, T7>(T1 t)
         {
             return null;
@@ -318,6 +330,8 @@ namespace Bridge
     [Name("Object")]
     public class Any<T1, T2, T3, T4, T5, T6, T7, T8>
     {
+        private Any() { }
+
         public static implicit operator Any<T1, T2, T3, T4, T5, T6, T7, T8>(T1 t)
         {
             return null;


### PR DESCRIPTION
Fixes #1327

Changes proposed in this pull request:

Just added private constructors to prevent the classes from being directly instantiated, as suggested in [Any<T1, ..> classes shouldn't have public constructors](http://forums.bridge.net/forum/bridge-net-pro/bugs/2278-open-1327-any-t1-classes-shouldn-t-have-public-constructors).