### PR TITLE
Issue1316 String (+) operator doesn't work on empty string (s)

### DIFF
--- a/Bridge/System/String.cs
+++ b/Bridge/System/String.cs
@@ -140,6 +140,14 @@ namespace System
         public extern bool Equals(string value);
 
         /// <summary>
+        /// Concatenates the members of a constructed IEnumerable collection of type String.
+        /// </summary>
+        /// <param name="values">A collection object that implements IEnumerable and whose generic type argument is String.</param>
+        /// <returns>The concatenated strings in values, or String.Empty if values is an empty IEnumerable(Of String).</returns>
+        [Template("Bridge.toArray({values}).join('')")]
+        public static extern string Concat(IEnumerable<string> values);
+
+        /// <summary>
         /// The concat() method combines the text of two or more strings and returns a new string.
         /// </summary>
         /// <param name="string1">Strings to concatenate to this string.</param>
@@ -178,6 +186,14 @@ namespace System
         public static extern string Concat(params string[] strings);
 
         /// <summary>
+        /// Creates the string representation of a specified object.
+        /// </summary>
+        /// <param name="arg0">The object to represent, or null.</param>
+        /// <returns>The string representation of the value of arg0, or String.Empty if arg0 is null.</returns>
+        [Template("[{arg0}].join('')")]
+        public static extern string Concat(object arg0);
+
+        /// <summary>
         /// The concat() method combines the text of two or more strings and returns a new string.
         /// </summary>
         /// <param name="object1">Strings to concatenate to this string.</param>
@@ -214,6 +230,14 @@ namespace System
         /// <returns></returns>
         [Template("{objects:array}.toString().split(',').join('')")]
         public static extern string Concat(params object[] objects);
+
+        /// <summary>
+        /// Concatenates the members of a constructed generic IEnumerable collection.
+        /// </summary>
+        /// <param name="values">A collection object that implements generic IEnumerable.</param>
+        /// <returns>The concatenated members in values.</returns>
+        [Template("Bridge.toArray({values}).join('')")]
+        public static extern string Concat<T>(IEnumerable<T> values);
 
         /// <summary>
         /// The compare() method compares two specified String objects and returns an integer that indicates their relative position in the sort order.

--- a/Tests/Batch1/Batch1.csproj
+++ b/Tests/Batch1/Batch1.csproj
@@ -259,6 +259,7 @@
     <Compile Include="BridgeIssues\1200\N1264.cs" />
     <Compile Include="BridgeIssues\1200\N1260.cs" />
     <Compile Include="BridgeIssues\1200\N1241.cs" />
+    <Compile Include="BridgeIssues\1300\N1316.cs" />
     <Compile Include="BridgeIssues\1300\N1343.cs" />
     <Compile Include="BridgeIssues\1300\N1341.cs" />
     <Compile Include="BridgeIssues\1300\N1305.cs" />

--- a/Tests/Batch1/BridgeIssues/1300/N1316.cs
+++ b/Tests/Batch1/BridgeIssues/1300/N1316.cs
@@ -1,0 +1,72 @@
+using Bridge.Test;
+
+using System.Collections.Generic;
+
+namespace Bridge.ClientTest.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#1316 - {0}")]
+    public class Bridge1316
+    {
+        [Test]
+        public static void TestUseCase()
+        {
+            int v = 0;
+            var s = v + "";
+
+            Assert.AreEqual("0", s);
+        }
+
+        [Test]
+        public static void TestStringConcatObject()
+        {
+            object o1 = 3;
+            var s1 = string.Concat(o1);
+
+            Assert.AreEqual("3", s1);
+
+            object o2 = null;
+            var s2 = string.Concat(o2);
+
+            Assert.AreEqual("", s2);
+        }
+
+        [Test]
+        public static void TestStringConcatEnumerableString()
+        {
+            IEnumerable<string> e1 = new string[] { "1", "2" };
+            var s1 = string.Concat(e1);
+
+            Assert.AreEqual("12", s1, "All not null");
+
+            IEnumerable<string> e2 = new string[] { "3", null, "4" };
+            var s2 = string.Concat(e2);
+
+            Assert.AreEqual("34", s2, "One is null");
+
+            IEnumerable<string> e3 = new string[] { };
+            var s3 = string.Concat(e3);
+
+            Assert.AreEqual("", s3, "Empty");
+        }
+
+        [Test]
+        public static void TestStringConcatEnumerableGeneric()
+        {
+            IEnumerable<object> e1 = new object[] { 1, "2" };
+            var s1 = string.Concat(e1);
+
+            Assert.AreEqual("12", s1, "All not null");
+
+            IEnumerable<object> e2 = new object[] { "3", null, 4 };
+            var s2 = string.Concat(e2);
+
+            Assert.AreEqual("34", s2, "One is null");
+
+            IEnumerable<object> e3 = new object[] { };
+            var s3 = string.Concat(e3);
+
+            Assert.AreEqual("", s3, "Empty");
+        }
+    }
+}

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -6606,6 +6606,60 @@ SomeExternalNamespace.SomeNonBridgeClass.prototype.foo = function(){return 1;};
         }
     });
     
+    Bridge.define('Bridge.ClientTest.BridgeIssues.Bridge1316', {
+        statics: {
+            testUseCase: function () {
+                var v = 0;
+                var s = v + "";
+    
+                Bridge.Test.Assert.areEqual("0", s);
+            },
+            testStringConcatObject: function () {
+                var o1 = 3;
+                var s1 = [o1].join('');
+    
+                Bridge.Test.Assert.areEqual("3", s1);
+    
+                var o2 = null;
+                var s2 = [o2].join('');
+    
+                Bridge.Test.Assert.areEqual("", s2);
+            },
+            testStringConcatEnumerableString: function () {
+                var e1 = ["1", "2"];
+                var s1 = Bridge.toArray(e1).join('');
+    
+                Bridge.Test.Assert.areEqual$1("12", s1, "All not null");
+    
+                var e2 = ["3", null, "4"];
+                var s2 = Bridge.toArray(e2).join('');
+    
+                Bridge.Test.Assert.areEqual$1("34", s2, "One is null");
+    
+                var e3 = [];
+                var s3 = Bridge.toArray(e3).join('');
+    
+                Bridge.Test.Assert.areEqual$1("", s3, "Empty");
+            },
+            testStringConcatEnumerableGeneric: function () {
+                var e1 = [1, "2"];
+                var s1 = Bridge.toArray(e1).join('');
+    
+                Bridge.Test.Assert.areEqual$1("12", s1, "All not null");
+    
+                var e2 = ["3", null, 4];
+                var s2 = Bridge.toArray(e2).join('');
+    
+                Bridge.Test.Assert.areEqual$1("34", s2, "One is null");
+    
+                var e3 = [];
+                var s3 = Bridge.toArray(e3).join('');
+    
+                Bridge.Test.Assert.areEqual$1("", s3, "Empty");
+            }
+        }
+    });
+    
     Bridge.define('Bridge.ClientTest.BridgeIssues.Bridge1341', {
         statics: {
             testPlainObject: function () {
@@ -27279,7 +27333,7 @@ SomeExternalNamespace.SomeNonBridgeClass.prototype.foo = function(){return 1;};
             Bridge.Test.Assert.areEqual("abcdefghi", ["a", "b", "c", "d", "e", "f", "g", "h", "i"].toString().split(',').join(''));
         },
         concatWithObjectsWorks: function () {
-            Bridge.Test.Assert.areEqual("1", [1].toString().split(',').join(''));
+            Bridge.Test.Assert.areEqual("1", [1].join(''));
             Bridge.Test.Assert.areEqual("12", [1, 2].join(''));
             Bridge.Test.Assert.areEqual("123", [1, 2, 3].join(''));
             Bridge.Test.Assert.areEqual("1234", [1, 2, 3, 4].join(''));

--- a/Tests/Runner/Batch1/test.js
+++ b/Tests/Runner/Batch1/test.js
@@ -1165,6 +1165,10 @@
                 QUnit.test("#1305 - TestAsyncIntReturnWithAssigmentFromResult", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1305.testAsyncIntReturnWithAssigmentFromResult);
                 QUnit.test("#1305 - TestAsyncDataClassReturnWithAssigmentFromResult", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1305.testAsyncDataClassReturnWithAssigmentFromResult);
                 QUnit.test("#1305 - TestAsyncDataStructReturnWithAssigmentFromResult", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1305.testAsyncDataStructReturnWithAssigmentFromResult);
+                QUnit.test("#1316 - TestUseCase", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1316.testUseCase);
+                QUnit.test("#1316 - TestStringConcatObject", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1316.testStringConcatObject);
+                QUnit.test("#1316 - TestStringConcatEnumerableString", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1316.testStringConcatEnumerableString);
+                QUnit.test("#1316 - TestStringConcatEnumerableGeneric", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1316.testStringConcatEnumerableGeneric);
                 QUnit.test("#1341 - TestPlainObject", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1341.testPlainObject);
                 QUnit.test("#1341 - TestAnonymousTypeCreation", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1341.testAnonymousTypeCreation);
                 QUnit.test("#1341 - TestDiffStructHashCode", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1341.testDiffStructHashCode);
@@ -3533,6 +3537,28 @@
             testAsyncDataStructReturnWithAssigmentFromResult: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.BridgeIssues.Bridge1305).beforeTest(false, assert, Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1305);
                 Bridge.ClientTest.BridgeIssues.Bridge1305.testAsyncDataStructReturnWithAssigmentFromResult();
+            }
+        }
+    });
+    
+    Bridge.define('Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1316', {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.BridgeIssues.Bridge1316)],
+        statics: {
+            testUseCase: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.BridgeIssues.Bridge1316).beforeTest(false, assert, Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1316);
+                Bridge.ClientTest.BridgeIssues.Bridge1316.testUseCase();
+            },
+            testStringConcatObject: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.BridgeIssues.Bridge1316).beforeTest(false, assert, Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1316);
+                Bridge.ClientTest.BridgeIssues.Bridge1316.testStringConcatObject();
+            },
+            testStringConcatEnumerableString: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.BridgeIssues.Bridge1316).beforeTest(false, assert, Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1316);
+                Bridge.ClientTest.BridgeIssues.Bridge1316.testStringConcatEnumerableString();
+            },
+            testStringConcatEnumerableGeneric: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.BridgeIssues.Bridge1316).beforeTest(false, assert, Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_BridgeIssues_Bridge1316);
+                Bridge.ClientTest.BridgeIssues.Bridge1316.testStringConcatEnumerableGeneric();
             }
         }
     });


### PR DESCRIPTION
Fixes #1316.

Changes proposed in this pull request:

Adds missing `string.Concat` overrides
- `Concat(IEnumerable<String>)`
- `Concat<T>(IEnumerable<T>)`
- `Concat(Object)`
