### PR TITLE
Cast failed for svg tag from Node to Element on iOS WKWebView

### DIFF
--- a/Bridge/Resources/Core.js
+++ b/Bridge/Resources/Core.js
@@ -364,6 +364,9 @@
             var result = Bridge.as(obj, type, allowNull);
 
 	        if (result === null) {
+	            if (navigator.platform && navigator.platform.substr(0,2) === 'iP') {
+	                return obj;
+	            }
 	            throw new Bridge.InvalidCastException("Unable to cast type " + (obj ? Bridge.getTypeName(obj) : "'null'") + " to type " + Bridge.getTypeName(type));
 	        }
 


### PR DESCRIPTION
A svg Node with `NodeType = 1`, cast to Element failed, Bridge.as may fail on iOS WKWebView.
No need to throw exception in this case.
BTW, in my understanding, `cast` is something we are trying to do. We should not throw exception for cast fail. Let exception happen somewhere else look good to me.