### PR TITLE
Bridge Builder: Default to a single csproj if found

### DIFF
--- a/Compiler/Builder/Program.cs
+++ b/Compiler/Builder/Program.cs
@@ -16,10 +16,11 @@ namespace Bridge.Builder
         {
             var logger = new Logger(null, false, LoggerLevel.Info, true, new ConsoleLoggerWriter(), new FileLoggerWriter());
 
-            var bridgeOptions = GetBridgeOptionsFromCommandLine(args, logger);
+            var bridgeOptions = GetBridgeOptionsFromCommandLine(ref args, logger);
 
             if (bridgeOptions == null)
             {
+                ShowHelp(logger);
                 return 1;
             }
 
@@ -129,14 +130,8 @@ namespace Bridge.Builder
             return false; // didn't bind anywhere
         }
 
-        private static BridgeOptions GetBridgeOptionsFromCommandLine(string[] args, ILogger logger)
+        private static BridgeOptions GetBridgeOptionsFromCommandLine(ref string[] args, ILogger logger)
         {
-            if (args.Length == 0)
-            {
-                ShowHelp(logger);
-                return null; // error: arguments not provided, so can't guess what to do
-            }
-
             var bridgeOptions = new BridgeOptions();
 
             bridgeOptions.Name = "Bridge.Builder.Console";
@@ -153,7 +148,6 @@ namespace Bridge.Builder
                         if (bridgeOptions.Lib != null)
                         {
                             logger.Error("Error: Project and assembly file specification is mutually exclusive.");
-                            ShowHelp(logger);
                             return null;
                         };
                         bridgeOptions.ProjectLocation = args[++i];
@@ -218,7 +212,6 @@ namespace Bridge.Builder
                         if (bridgeOptions.ProjectLocation != null)
                         {
                             logger.Error("Error: Project and assembly file specification is mutually exclusive.");
-                            ShowHelp(logger);
                             return null;
                         }
                         bridgeOptions.Lib = args[++i];
@@ -264,7 +257,6 @@ namespace Bridge.Builder
                         if (!BindCmdArgumentToOption(args[i], bridgeOptions, logger))
                         {
                             logger.Error("Invalid argument: " + args[i]);
-                            ShowHelp(logger);
                             return null;
                         }
                         break;
@@ -275,9 +267,28 @@ namespace Bridge.Builder
 
             if (bridgeOptions.ProjectLocation == null && bridgeOptions.Lib == null)
             {
-                logger.Error("Error: Project or assembly file name must be specified.");
-                ShowHelp(logger);
-                return null;
+                var folder = bridgeOptions.Folder ?? Environment.CurrentDirectory;
+
+                var csprojs = Directory.GetFiles(folder, "*.csproj", SearchOption.TopDirectoryOnly);
+                if (csprojs.Length > 1)
+                {
+                    logger.Error("Could not default to a csproj because multiple were found:");
+                    logger.Info(string.Join(", ", csprojs.Select(path => Path.GetFileName(path))));
+                    return null; // error: arguments not provided, so can't guess what to do
+                }
+
+                if (csprojs.Length == 1)
+                {
+                    var csproj = csprojs[0];
+                    bridgeOptions.ProjectLocation = csproj;
+                    logger.Info("Defaulting to " + csproj);
+                }
+                else if (csprojs.Length == 0)
+                {
+                    logger.Warn("Could not default to a csproj because none were found.");
+                    logger.Error("Error: Project or assembly file name must be specified.");
+                    return null;
+                }
             }
 
             if (string.IsNullOrEmpty(bridgeOptions.OutputLocation))


### PR DESCRIPTION
Closes #1132

Changes proposed in this pull request:

- Change the signature of `GetBridgeOptionsFromCommandLine` to `(ref string[], ILogger)` so that we may output the modified args instead of whatever was passed in.
- Only call `ShowHelp` when `GetBridgeOptionsFromCommandLine` returns `null`
- `Bridge.Builder.exe` will now default to a `csproj` in the target folder (either with the `-f` flag, or the cwd) if a single `csproj` is found

I will need help with this:
> (it would have to support reading *.csproj.user files for current configuration, or maybe reading environment variables if VS makes them available on events/tasks calls).