### PR TITLE
Issue1406 Warning for generic auto-run methods

### DIFF
--- a/Compiler/Build/Bridge.Build.csproj
+++ b/Compiler/Build/Bridge.Build.csproj
@@ -55,6 +55,7 @@
     <Compile Include="..\..\.build\common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="VSLoggerWriter.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Contract\Bridge.Contract.csproj">

--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -6,7 +6,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
 using System.IO;
-using System.Linq;
 
 namespace Bridge.Build
 {
@@ -82,7 +81,7 @@ namespace Bridge.Build
                 System.Diagnostics.Debugger.Launch();
             };
 #endif
-            var logger = new Translator.Logging.Logger(null, false, LoggerLevel.Info, true, new ConsoleLoggerWriter(), new FileLoggerWriter());
+            var logger = new Translator.Logging.Logger(null, false, LoggerLevel.Info, true, new VSLoggerWriter(this.Log), new FileLoggerWriter());
             var bridgeOptions = this.GetBridgeOptions();
 
             var processor = new TranslatorProcessor(bridgeOptions, logger);

--- a/Compiler/Build/VSLoggerWriter.cs
+++ b/Compiler/Build/VSLoggerWriter.cs
@@ -1,0 +1,68 @@
+﻿using Bridge.Contract;
+
+using Microsoft.Build.Utilities;
+
+using System;
+
+
+namespace Bridge.Build
+{
+    public class VSLoggerWriter : ILogger
+    {
+        public bool BufferedMode { get; set; }
+
+        public LoggerLevel LoggerLevel { get; set; }
+
+        public TaskLoggingHelper Log { get; set; }
+
+        public VSLoggerWriter(TaskLoggingHelper taskLoggingHelper)
+        {
+            if (taskLoggingHelper == null)
+            {
+                throw new ArgumentNullException("taskLoggingHelper");
+            }
+
+            this.Log = taskLoggingHelper;
+        }
+
+        public void Flush()
+        {
+
+        }
+
+        public void Error(string message)
+        {
+            if (!this.CheckLoggerLevel(LoggerLevel.Error))
+            {
+                return;
+            }
+
+            this.Log.LogError(message);
+        }
+
+        public void Warn(string message)
+        {
+            if (!this.CheckLoggerLevel(LoggerLevel.Warning))
+            {
+                return;
+            }
+
+            this.Log.LogWarning(message);
+        }
+
+        public void Info(string message)
+        {
+
+        }
+
+        public void Trace(string message)
+        {
+
+        }
+
+        private bool CheckLoggerLevel(LoggerLevel level)
+        {
+            return level <= this.LoggerLevel;
+        }
+    }
+}

--- a/Compiler/Translator/Emitter/Blocks/ConstructorBlock.Events.cs
+++ b/Compiler/Translator/Emitter/Blocks/ConstructorBlock.Events.cs
@@ -20,21 +20,43 @@ namespace Bridge.Translator
             List<string> list = new List<string>();
 
             bool hasReadyAttribute;
+            var isGenericType = this.IsGenericType();
 
             foreach (var methodGroup in methods)
             {
                 foreach (var method in methodGroup.Value)
                 {
+                    var isGenericMethod = this.IsGenericMethod(method);
+
                     HandleAttributes(list, methodGroup, method, out hasReadyAttribute);
 
-                    if (this.StaticBlock && !hasReadyAttribute)
+                    if (hasReadyAttribute)
                     {
-                        if (method.Name == CS.Methods.AUTO_STARTUP_METHOD_NAME && method.HasModifier(Modifiers.Static) && !method.HasModifier(Modifiers.Abstract))
+                        if (isGenericType || isGenericMethod)
                         {
-                            this.Emitter.AutoStartupMethods.Add(this.TypeInfo.Name + "." + method.Name);
-                            list.Add(string.Format(JS.Funcs.BRIDGE_AUTO_STARTUP_METHOD_TEMPLATE, this.Emitter.GetEntityName(method)));
+                            hasReadyAttribute = false;
+                        }
+                    }
+                    else
+                    {
+                        if (this.StaticBlock && !hasReadyAttribute)
+                        {
+                            if (method.Name == CS.Methods.AUTO_STARTUP_METHOD_NAME
+                                && method.HasModifier(Modifiers.Static)
+                                && !method.HasModifier(Modifiers.Abstract))
+                            {
+                                if (isGenericType || isGenericMethod)
+                                {
+                                    LogAutoStartupWarning(method);
+                                }
+                                else
+                                {
+                                    this.Emitter.AutoStartupMethods.Add(this.TypeInfo.Name + "." + method.Name);
+                                    list.Add(string.Format(JS.Funcs.BRIDGE_AUTO_STARTUP_METHOD_TEMPLATE, this.Emitter.GetEntityName(method)));
 
-                            hasReadyAttribute = true;
+                                    hasReadyAttribute = true;
+                                }
+                            }
                         }
                     }
 
@@ -51,21 +73,29 @@ namespace Bridge.Translator
         private void HandleAttributes(List<string> list, KeyValuePair<string, List<MethodDeclaration>> methodGroup, MethodDeclaration method, out bool hasReadyAttribute)
         {
             hasReadyAttribute = false;
+            var isGenericType = this.IsGenericType();
+            var isGenericMethod = this.IsGenericMethod(method);
 
             foreach (var attrSection in method.Attributes)
             {
                 foreach (var attr in attrSection.Attributes)
                 {
-                    var resolveresult = this.Emitter.Resolver.ResolveNode(attr, this.Emitter) as InvocationResolveResult;
+                    var resolveResult = this.Emitter.Resolver.ResolveNode(attr, this.Emitter) as InvocationResolveResult;
 
-                    if (resolveresult != null)
+                    if (resolveResult != null)
                     {
-                        if (resolveresult.Type.FullName == CS.Attributes.READY_ATTRIBUTE_NAME)
+                        if (resolveResult.Type.FullName == CS.Attributes.READY_ATTRIBUTE_NAME)
                         {
                             hasReadyAttribute = true;
+
+                            if (isGenericType || isGenericMethod)
+                            {
+                                LogAutoStartupWarning(method);
+                                continue;
+                            }
                         }
 
-                        var baseTypes = resolveresult.Type.GetAllBaseTypes().ToArray();
+                        var baseTypes = resolveResult.Type.GetAllBaseTypes().ToArray();
 
                         if (baseTypes.Any(t => t.FullName == "Bridge.AdapterAttribute"))
                         {
@@ -74,7 +104,7 @@ namespace Bridge.Translator
                                 throw new EmitterException(attr, "Overloaded method cannot be event handler");
                             }
 
-                            var staticFlagField = resolveresult.Type.GetFields(f => f.Name == "StaticOnly");
+                            var staticFlagField = resolveResult.Type.GetFields(f => f.Name == "StaticOnly");
 
                             if (staticFlagField.Count() > 0)
                             {
@@ -82,12 +112,12 @@ namespace Bridge.Translator
 
                                 if (staticValue is bool && ((bool)staticValue) && !method.HasModifier(Modifiers.Static))
                                 {
-                                    throw new EmitterException(attr, resolveresult.Type.FullName + " can be applied for static methods only");
+                                    throw new EmitterException(attr, resolveResult.Type.FullName + " can be applied for static methods only");
                                 }
                             }
 
                             string eventName = methodGroup.Key;
-                            var eventField = resolveresult.Type.GetFields(f => f.Name == "Event");
+                            var eventField = resolveResult.Type.GetFields(f => f.Name == "Event");
 
                             if (eventField.Count() > 0)
                             {
@@ -96,7 +126,7 @@ namespace Bridge.Translator
 
                             string format = null;
                             string formatName = this.StaticBlock ? "Format" : "FormatScope";
-                            var formatField = resolveresult.Type.GetFields(f => f.Name == formatName, GetMemberOptions.IgnoreInheritedMembers);
+                            var formatField = resolveResult.Type.GetFields(f => f.Name == formatName, GetMemberOptions.IgnoreInheritedMembers);
 
                             if (formatField.Count() > 0)
                             {
@@ -117,7 +147,7 @@ namespace Bridge.Translator
                             }
 
                             bool isCommon = false;
-                            var commonField = resolveresult.Type.GetFields(f => f.Name == "IsCommonEvent");
+                            var commonField = resolveResult.Type.GetFields(f => f.Name == "IsCommonEvent");
 
                             if (commonField.Count() > 0)
                             {
@@ -158,7 +188,7 @@ namespace Bridge.Translator
                             }
                             else
                             {
-                                var resolvedmethod = resolveresult.Member as IMethod;
+                                var resolvedmethod = resolveResult.Member as IMethod;
 
                                 if (resolvedmethod.Parameters.Count > selectorIndex)
                                 {
@@ -182,7 +212,7 @@ namespace Bridge.Translator
                             }
                             else
                             {
-                                var resolvedmethod = resolveresult.Member as IMethod;
+                                var resolvedmethod = resolveResult.Member as IMethod;
 
                                 if (resolvedmethod.Parameters.Count > (selectorIndex + 1))
                                 {
@@ -225,6 +255,30 @@ namespace Bridge.Translator
                     }
                 }
             }
+        }
+
+        private void LogWarning(string message)
+        {
+            var logger = this.Emitter.Log as Bridge.Translator.Logging.Logger;
+            bool? wrappingValue = null;
+
+            if (logger != null && logger.UseTimeStamp)
+            {
+                wrappingValue = logger.UseTimeStamp;
+                logger.UseTimeStamp = false;
+            }
+
+            this.Emitter.Log.Warn(message);
+
+            if (wrappingValue.HasValue)
+            {
+                logger.UseTimeStamp = wrappingValue.Value;
+            }
+        }
+
+        private void LogAutoStartupWarning(MethodDeclaration method)
+        {
+            this.LogWarning(string.Format("'{0}.{1}': an entry point cannot be generic or in a generic type", this.TypeInfo.Type.ReflectionName, method.Name));
         }
     }
 }

--- a/Compiler/Translator/Emitter/Blocks/ConstructorBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/ConstructorBlock.cs
@@ -440,5 +440,15 @@ namespace Bridge.Translator
             this.WriteSemiColon();
             this.WriteNewLine();
         }
+
+        protected virtual bool IsGenericType()
+        {
+            return this.TypeInfo.Type.TypeParameterCount > 0;
+        }
+
+        private bool IsGenericMethod(MethodDeclaration methodDeclaration)
+        {
+            return methodDeclaration.TypeParameters.Any();
+        }
     }
 }


### PR DESCRIPTION
Fixes #1406

Changes proposed in this pull request:
- implement VS logger for errors and warnings
- auto-run methods ([Ready] and #1303 methods) to show VS warnings if the class or the method is generic