### PR TITLE
Issue1424 Properties with setter or getter implementation and [FieldProperty] should not compile

### DIFF
--- a/Compiler/TranslatorTests/TestProjects/02/Bridge/reference/TestProject.js
+++ b/Compiler/TranslatorTests/TestProjects/02/Bridge/reference/TestProject.js
@@ -19828,6 +19828,20 @@ Bridge.define("System.Text.RegularExpressions.RegexNetEngineParser", {
 (function (globals) {
     "use strict";
 
+    Bridge.define('Test.BridgeIssues.N1424.A');
+    
+    Bridge.define('Test.BridgeIssues.N1424.Alpha', {
+        data: 0
+    });
+    
+    Bridge.define('Test.BridgeIssues.N1424.B', {
+        getData: function () {
+            return 8;
+        },
+        setData: function (value) {
+        }
+    });
+    
     Bridge.define('Test.BridgeIssues.N770.IBase', {
         $interface: true
     });

--- a/Compiler/TranslatorTests/TestProjects/02/BridgeIssues/N1424.cs
+++ b/Compiler/TranslatorTests/TestProjects/02/BridgeIssues/N1424.cs
@@ -1,0 +1,51 @@
+﻿//#1424
+namespace Test.BridgeIssues.N1424
+{
+    using Bridge;
+
+    public class Alpha
+    {
+        // "autoPropertyToField" config option with not implemented getter and setter should be compilable
+        public int Data
+        {
+            get;
+            set;
+        }
+    }
+
+    public class A
+    {
+        // "autoPropertyToField" config option with implemented getter and setter should be compilable with [External] on property declaration
+        [External]
+        public int Data
+        {
+            get { return 7; }
+            set { }
+        }
+    }
+
+    public class B
+    {
+        // "autoPropertyToField" config option with implemented getter and setter should be compilable with [Template]
+        public int Data
+        {
+            [Template("Q")]
+            get
+            { return 8; }
+            [Template("W")]
+            set
+            { }
+        }
+    }
+
+    [External]
+    public class C
+    {
+        // "autoPropertyToField" config option with implemented getter and setter should be compilable with [External] on class declaration
+        public int Data
+        {
+            get { return 8; }
+            set { }
+        }
+    }
+}

--- a/Compiler/TranslatorTests/TestProjects/02/test.csproj
+++ b/Compiler/TranslatorTests/TestProjects/02/test.csproj
@@ -33,6 +33,7 @@
     <NoStdLib>True</NoStdLib>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="BridgeIssues\N1424.cs" />
     <Compile Include="BridgeIssues\N770.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestClassB.cs" />

--- a/Compiler/TranslatorTests/TestProjects/16/Bridge/reference/test.bridgeIssues.n1424.js
+++ b/Compiler/TranslatorTests/TestProjects/16/Bridge/reference/test.bridgeIssues.n1424.js
@@ -1,0 +1,15 @@
+﻿(function (globals) {
+    "use strict";
+
+    Bridge.define('Test.BridgeIssues.N1424.A');
+    
+    Bridge.define('Test.BridgeIssues.N1424.Alpha', {
+        data: 0
+    });
+    
+    Bridge.define('Test.BridgeIssues.N1424.B');
+    
+    
+    
+    Bridge.init();
+})(this);

--- a/Compiler/TranslatorTests/TestProjects/16/BridgeIssues/1500/N1424.cs
+++ b/Compiler/TranslatorTests/TestProjects/16/BridgeIssues/1500/N1424.cs
@@ -1,0 +1,53 @@
+﻿//#1424
+namespace Test.BridgeIssues.N1424
+{
+    using Bridge;
+
+    public class Alpha
+    {
+        // [FieldProperty] with not implemented getter and setter should be compilable
+        [FieldProperty]
+        public int Data
+        {
+            get;
+            set;
+        }
+    }
+
+    public class A
+    {
+        // [FieldProperty] with implemented getter and setter should be compilable with [External] on property declaration
+        [FieldProperty]
+        [External]
+        public int Data
+        {
+            get { return 7; }
+            set { }
+        }
+    }
+
+    public class B
+    {
+        // [FieldProperty] with implemented getter and setter should be compilable with [Template]
+        [FieldProperty]
+        public int Data
+        {
+            [Template("Q")]
+            get { return 8; }
+            [Template("W")]
+            set { }
+        }
+    }
+
+    [External]
+    public class C
+    {
+        // [FieldProperty] with implemented getter and setter should be compilable with [External] on class declaration
+        [FieldProperty]
+        public int Data
+        {
+            get { return 8; }
+            set { }
+        }
+    }
+}

--- a/Compiler/TranslatorTests/TestProjects/16/test.csproj
+++ b/Compiler/TranslatorTests/TestProjects/16/test.csproj
@@ -60,6 +60,7 @@
     <Compile Include="BridgeIssues\1000\N883.cs" />
     <Compile Include="BridgeIssues\1000\N882.cs" />
     <Compile Include="BridgeIssues\1000\N856.cs" />
+    <Compile Include="BridgeIssues\1500\N1424.cs" />
     <Compile Include="BridgeIssues\1500\N1412.cs" />
     <Compile Include="BridgeIssues\1500\N1215.cs" />
     <Compile Include="BridgeIssues\1500\N1212.cs" />


### PR DESCRIPTION
Fixes #1424

Changes proposed in this pull request:

- If property has `[FieldPropery]` attribute but has a getter/setter implementation then the Compiler throws error like `[Property TestApp.A.K] is marked with [FieldProperty] attribute but implements getter and setter. To fix the problem either remove [FieldProperty] (swith off bridge.json option `autoPropertyToField`) or add [External]/[Template] attributes`;
- The same thing when bridge.json option `autoPropertyToField` turned on.