### PR TITLE
[#706] Support FieldProperty with initializer

### DIFF
--- a/Compiler/Translator/Inspector/Inspector.Visitor.cs
+++ b/Compiler/Translator/Inspector/Inspector.Visitor.cs
@@ -237,6 +237,12 @@ namespace Bridge.Translator
                     {
                         collection = this.CurrentType.StaticConfig.AutoPropertyInitializers;
                         var prop = this.CurrentType.StaticConfig.Properties.FirstOrDefault(p => p.Name == name);
+
+                        if (prop == null)
+                        {
+                            prop = this.CurrentType.StaticConfig.Fields.FirstOrDefault(p => p.Name == name);
+                        }
+
                         if (prop != null)
                         {
                             prop.Initializer = initializer;
@@ -259,6 +265,12 @@ namespace Bridge.Translator
                     {
                         collection = this.CurrentType.InstanceConfig.AutoPropertyInitializers;
                         var prop = this.CurrentType.InstanceConfig.Properties.FirstOrDefault(p => p.Name == name);
+
+                        if (prop == null)
+                        {
+                            prop = this.CurrentType.InstanceConfig.Fields.FirstOrDefault(p => p.Name == name);
+                        }
+
                         if (prop != null)
                         {
                             prop.Initializer = initializer;

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -119,6 +119,7 @@
     <Compile Include="BridgeIssues\0600\N694.cs" />
     <Compile Include="BridgeIssues\0600\N696.cs" />
     <Compile Include="BridgeIssues\0600\N699.cs" />
+    <Compile Include="BridgeIssues\0700\N706.cs" />
     <Compile Include="BridgeIssues\0700\N708.cs" />
     <Compile Include="BridgeIssues\0700\N721.cs" />
     <Compile Include="BridgeIssues\0700\N722.cs" />

--- a/Tests/Batch3/BridgeIssues/0700/N706.cs
+++ b/Tests/Batch3/BridgeIssues/0700/N706.cs
@@ -3,7 +3,6 @@ using System;
 
 namespace Bridge.ClientTest.Batch3.BridgeIssues
 {
-    // Bridge[#706]
     [Category(Constants.MODULE_ISSUES)]
     [TestFixture(TestNameFormat = "#706 - {0}")]
     public class Bridge706

--- a/Tests/Batch3/BridgeIssues/0700/N706.cs
+++ b/Tests/Batch3/BridgeIssues/0700/N706.cs
@@ -1,0 +1,24 @@
+using Bridge.Test;
+using System;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    // Bridge[#706]
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#706 - {0}")]
+    public class Bridge706
+    {
+        [FieldProperty]
+        public static object Value
+        {
+            get;
+            set;
+        } = 7;
+
+        [Test(ExpectedCount = 1)]
+        public static void TestFieldPropertyWithInitializer()
+        {
+            Assert.AreEqual(7, Bridge706.Value);
+        }
+    }
+}

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -6772,8 +6772,6 @@ Bridge.initAssembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                                 done = Bridge.Test.Assert.async();
 
                                 foo = null; /// Async method lacks 'await' operators and will run synchronously
-
-
                                 bar = function () {
                                     var $step = 0,
                                         $jumpFromFinally, 
@@ -6803,7 +6801,7 @@ Bridge.initAssembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
 
                                     $asyncBody();
                                     return $tcs.task;
-                                };
+                                }; /// Async method lacks 'await' operators and will run synchronously
                                 $task1 = bar();
                                 $step = 1;
                                 $task1.continueWith($asyncBody, true);
@@ -11489,6 +11487,15 @@ Bridge.initAssembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 var blob2 = new Blob(["data2"]);
                 Bridge.Test.Assert.areNotEqual$1(null, blob2, "blob2 is not null");
                 Bridge.Test.Assert.areEqual$1(5, blob2.size, "blob2.Size equals 5");
+            }
+        }
+    });
+
+    Bridge.define('Bridge.ClientTest.Batch3.BridgeIssues.Bridge706', {
+        statics: {
+            value: 7,
+            testFieldPropertyWithInitializer: function () {
+                Bridge.Test.Assert.areEqual(7, Bridge.ClientTest.Batch3.BridgeIssues.Bridge706.value);
             }
         }
     });

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -6772,6 +6772,8 @@ Bridge.initAssembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                                 done = Bridge.Test.Assert.async();
 
                                 foo = null; /// Async method lacks 'await' operators and will run synchronously
+
+
                                 bar = function () {
                                     var $step = 0,
                                         $jumpFromFinally, 
@@ -6801,7 +6803,7 @@ Bridge.initAssembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
 
                                     $asyncBody();
                                     return $tcs.task;
-                                }; /// Async method lacks 'await' operators and will run synchronously
+                                };
                                 $task1 = bar();
                                 $step = 1;
                                 $task1.continueWith($asyncBody, true);

--- a/Tests/Runner/Batch3/test.js
+++ b/Tests/Runner/Batch3/test.js
@@ -514,6 +514,7 @@
                 QUnit.test("#694 - TestUseCase", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge694.testUseCase);
                 QUnit.test("#696 - TestUseCase", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge696.testUseCase);
                 QUnit.test("#699 - TestUseCase", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge699.testUseCase);
+                QUnit.test("#706 - TestFieldPropertyWithInitializer", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge706.testFieldPropertyWithInitializer);
                 QUnit.test("#708 - TestUseCase", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge708.testUseCase);
                 QUnit.test("#721 - TestUseCase", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge721.testUseCase);
                 QUnit.test("#722 - TestUseCase", Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge722.testUseCase);
@@ -3260,6 +3261,16 @@
             testUseCase: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge699).beforeTest(false, assert, Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge699, 5);
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge699.testUseCase();
+            }
+        }
+    });
+
+    Bridge.define('Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge706', {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge706)],
+        statics: {
+            testFieldPropertyWithInitializer: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge706).beforeTest(false, assert, Bridge.Test.QUnit.TestRunner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge706, 1);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge706.testFieldPropertyWithInitializer();
             }
         }
     });


### PR DESCRIPTION
 #706
Field initializer implemented in #1435.
This PR fixes a case when `[FieldProperty]` used.