### PR TITLE
[1725] Use `Translator.DefaultNamespace` if no namespace provided

### DIFF
--- a/Compiler/Contract/BridgeType.cs
+++ b/Compiler/Contract/BridgeType.cs
@@ -794,21 +794,7 @@ namespace Bridge.Contract
 
         public static Tuple<string, string> GetNamespaceFilename(ITypeInfo typeInfo, IEmitter emitter)
         {
-            var cas = emitter.BridgeTypes.Get(typeInfo.Key).TypeDefinition.CustomAttributes;
-            var fileName = typeInfo.Namespace;
-
-            // Search for an 'NamespaceAttribute' entry
-            foreach (var ca in cas)
-            {
-                if (ca.AttributeType.Name == "NamespaceAttribute" &&
-                    ca.ConstructorArguments.Count > 0 &&
-                    ca.ConstructorArguments[0].Value is string &&
-                    !string.IsNullOrWhiteSpace(ca.ConstructorArguments[0].Value.ToString()))
-                {
-                    fileName = ca.ConstructorArguments[0].Value.ToString();
-                    break;
-                }
-            }
+            var fileName = typeInfo.GetNamespace(emitter);
 
             var ns = fileName;
 

--- a/Compiler/Contract/ITranslator.cs
+++ b/Compiler/Contract/ITranslator.cs
@@ -34,6 +34,12 @@ namespace Bridge.Contract
             set;
         }
 
+        string DefaultNamespace
+        {
+            get;
+            set;
+        }
+
         string GetCode();
 
         string Location

--- a/Compiler/Contract/ITypeInfo.cs
+++ b/Compiler/Contract/ITypeInfo.cs
@@ -170,5 +170,7 @@ namespace Bridge.Contract
         List<AstType> GetBaseTypes(IEmitter emitter);
 
         AstType GetBaseClass(IEmitter emitter);
+
+        string GetNamespace(IEmitter emitter);
     }
 }

--- a/Compiler/Translator/Emitter/Blocks/EmitBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/EmitBlock.cs
@@ -53,7 +53,7 @@ namespace Bridge.Translator
 
                     case OutputBy.NamespacePath:
                     case OutputBy.Namespace:
-                        fileName = this.GetNamespaceFilename(typeInfo);
+                        fileName = typeInfo.GetNamespace(this.Emitter);
                         break;
 
                     default:
@@ -193,25 +193,6 @@ namespace Bridge.Translator
             this.Emitter.CurrentDependencies = dependencies;
 
             return moduleOutput;
-        }
-
-        private string GetNamespaceFilename(ITypeInfo typeInfo)
-        {
-            var cas = this.Emitter.BridgeTypes.Get(typeInfo.Key).TypeDefinition.CustomAttributes;
-
-            // Search for an 'NamespaceAttribute' entry
-            foreach (var ca in cas)
-            {
-                if (ca.AttributeType.Name == "NamespaceAttribute" &&
-                    ca.ConstructorArguments.Count > 0 &&
-                    ca.ConstructorArguments[0].Value is string &&
-                    !string.IsNullOrWhiteSpace(ca.ConstructorArguments[0].Value.ToString()))
-                {
-                    return ca.ConstructorArguments[0].Value.ToString();
-                }
-            }
-
-            return typeInfo.Namespace;
         }
 
         /// <summary>
@@ -383,7 +364,7 @@ namespace Bridge.Translator
                 this.Write(string.Format("Bridge.setMetadata({0}, function ({2}) {{ return {1}; }});", BridgeTypes.ToJsName(meta.Key, this.Emitter, true), metaData.ToString(Formatting.None), typeArgs));
                 this.WriteNewLine();
             }
-            
+
             if (scriptableAttributes.Count > 0)
             {
                 JArray attrArr = new JArray();

--- a/Compiler/Translator/Emitter/Emitter.cs
+++ b/Compiler/Translator/Emitter/Emitter.cs
@@ -48,6 +48,9 @@ namespace Bridge.Translator
             foreach (var block in blocks)
             {
                 this.JsDoc.Init();
+
+                this.Log.Trace("Emitting block " + block.GetType());
+
                 block.Emit();
             }
 

--- a/Compiler/Translator/Translator/Translator.Properties.cs
+++ b/Compiler/Translator/Translator/Translator.Properties.cs
@@ -61,6 +61,12 @@ namespace Bridge.Translator
             set;
         }
 
+        public string DefaultNamespace
+        {
+            get;
+            set;
+        }
+
         private string msbuildVersion = "4.0.30319";
 
         public string MSBuildVersion

--- a/Compiler/Translator/Translator/Translator.cs
+++ b/Compiler/Translator/Translator/Translator.cs
@@ -18,6 +18,7 @@ namespace Bridge.Translator
         public const string BridgeResourcesList = "Bridge.Resources.list";
         public const string LocalesPrefix = "Bridge.Resources.Locales.";
         public const string SupportedProjectType = "Library";
+        public const string DefaultRootNamespace = "ClassLibrary";
 
         private static readonly Encoding OutputEncoding = Encoding.UTF8;
         private static readonly string[] MinifierCodeSettingsInternalFileNames = new string[] { "bridge.js", "bridge.min.js", "bridge.collections.js", "bridge.collections.min.js" };

--- a/Compiler/Translator/Utils/CaptureAnalyzer.cs
+++ b/Compiler/Translator/Utils/CaptureAnalyzer.cs
@@ -337,16 +337,19 @@ namespace Bridge.Translator
 
         public override void VisitInvocationExpression(InvocationExpression invocationExpression)
         {
-            var rr = resolver.Resolve(invocationExpression) as CSharpInvocationResolveResult;
-            
-            foreach (var argument in rr.Arguments)
+            var rr = resolver.Resolve(invocationExpression) as InvocationResolveResult;
+
+            if (rr != null)
             {
-                if (argument.Type.Kind == TypeKind.TypeParameter)
+                foreach (var argument in rr.Arguments)
                 {
-                    var ivar = new TypeVariable(argument.Type);
-                    if (!_usedVariables.Contains(ivar))
+                    if (argument.Type != null && argument.Type.Kind == TypeKind.TypeParameter)
                     {
-                        _usedVariables.Add(ivar);
+                        var ivar = new TypeVariable(argument.Type);
+                        if (!_usedVariables.Contains(ivar))
+                        {
+                            _usedVariables.Add(ivar);
+                        }
                     }
                 }
             }

--- a/Compiler/Translator/Utils/TypeInfo.cs
+++ b/Compiler/Translator/Utils/TypeInfo.cs
@@ -314,5 +314,40 @@ namespace Bridge.Translator
 
             return this.baseTypes;
         }
+
+        public string GetNamespace(IEmitter emitter)
+        {
+            if (emitter == null)
+            {
+                throw new System.ArgumentNullException("emitter");
+            }
+
+            var name = this.Namespace;
+
+            var bridgeType = emitter.BridgeTypes.Get(this.Key);
+            var cas = bridgeType.TypeDefinition.CustomAttributes;
+
+            // Search for an 'NamespaceAttribute' entry
+            foreach (var ca in cas)
+            {
+                if (ca.AttributeType.Name == "NamespaceAttribute" && ca.ConstructorArguments.Count > 0)
+                {
+                    var constructorArgumentValue = ca.ConstructorArguments[0].Value as string;
+
+                    if (!string.IsNullOrWhiteSpace(constructorArgumentValue))
+                    {
+                        name = constructorArgumentValue;
+                        break;
+                    }
+                }
+            }
+
+            if (name == null)
+            {
+                name = emitter.Translator.DefaultNamespace;
+            }
+
+            return name;
+        }
     }
 }


### PR DESCRIPTION
Fixes #1725.