### PR TITLE
Fixes Document.Body and Document.DocumentElement return types

### DIFF
--- a/Html5/Document.cs
+++ b/Html5/Document.cs
@@ -902,7 +902,7 @@ namespace Bridge.Html5
         /// <summary>
         /// Returns the body or frameset node of the current document, or null if no such element exists.
         /// </summary>
-        public static HTMLElement Body;
+        public static HTMLBodyElement Body;
 
         /// <summary>
         /// Get and set the cookies associated with the current document.

--- a/Html5/Document.cs
+++ b/Html5/Document.cs
@@ -837,7 +837,7 @@ namespace Bridge.Html5
         /// <summary>
         /// Returns the Element that is the root element of the document (for example, the &lt;html&gt; element for HTML documents).
         /// </summary>
-        public static readonly HTMLElement DocumentElement;
+        public static readonly HTMLHtmlElement DocumentElement;
 
         /// <summary>
         /// Returns the document location as string.


### PR DESCRIPTION
Modify Document.Body to return an HTMLBodyElement object. Issue #1516.

Modify Document.DocumentElement to return an HTMLHtmlElement object. Issue #1771. 