### PR TITLE
[1622] `FormattableString` tests

### DIFF
--- a/Tests/Batch1/Batch1.csproj
+++ b/Tests/Batch1/Batch1.csproj
@@ -46,6 +46,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BridgeConsoleTests.cs" />
+    <Compile Include="FormattableStringTests.cs" />
     <Compile Include="MixinTests.cs" />
     <Compile Include="ArgumentsTests.cs" />
     <Compile Include="BasicCSharp\TestMethodParametersClass.cs" />

--- a/Tests/Batch1/Constants.cs
+++ b/Tests/Batch1/Constants.cs
@@ -30,7 +30,7 @@
 
         public const string MODULE_DATETIME = "Date and time"; // "DateTime, TimeSpan";
         public const string MODULE_NULLABLE = "Nullable";
-        public const string MODULE_STRING = "String";// "String, StringBuilder"
+        public const string MODULE_STRING = "String";// "String, StringBuilder, FormattableString"
         public const string MODULE_REGEX = "Regex";
         public const string MODULE_REGEX_JS = "RegexJS";
         public const string MODULE_ENUM = "Enum";

--- a/Tests/Batch1/FormattableStringTests.cs
+++ b/Tests/Batch1/FormattableStringTests.cs
@@ -1,0 +1,119 @@
+// #1622
+using Bridge.Test;
+using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace Bridge.ClientTest
+{
+    [Category(Constants.MODULE_STRING)]
+    [TestFixture(TestNameFormat = "FormattableString - {0}")]
+    public class FormattableStringTests
+    {
+        private class MyFormattable : IFormattable
+        {
+            public string Format(string format, IFormatProvider formatProvider)
+            {
+                return "Formatted: " + (!string.IsNullOrEmpty(format) ? format + ", " : "") + formatProvider.GetType().Name;
+            }
+        }
+
+        private class MyFormatProvider : IFormatProvider
+        {
+            public object GetFormat(Type type)
+            {
+                return CultureInfo.InvariantCulture.GetFormat(type);
+            }
+        }
+
+        [Test]
+        public void TypePropertiesAreCorrect()
+        {
+            var s = (object)FormattableStringFactory.Create("s");
+            Assert.True(s is FormattableString, "is FormattableString");
+            Assert.True(s is IFormattable, "is IFormattable");
+
+            Assert.True(typeof(FormattableString).IsClass, "IsClass");
+            Assert.True(typeof(IFormattable).IsAssignableFrom(typeof(FormattableString)), "IFormattable.IsAssignableFrom");
+            var interfaces = typeof(FormattableString).GetInterfaces();
+            Assert.AreEqual(1, interfaces.Length, "interfaces length");
+            Assert.True(interfaces.Contains(typeof(IFormattable)), "interfaces contains IFormattable");
+        }
+
+        [Test]
+        public void ArgumentCountWorks()
+        {
+            var s1 = FormattableStringFactory.Create("{0}", "x");
+            Assert.AreEqual(1, s1.ArgumentCount, "#1");
+            var s2 = FormattableStringFactory.Create("{0}, {1}", "x", "y");
+            Assert.AreEqual(2, s2.ArgumentCount, "#2");
+        }
+
+        [Test]
+        public void FormatWorks()
+        {
+            var s = FormattableStringFactory.Create("x = {0}, y = {1}", "x", "y");
+            Assert.AreEqual("x = {0}, y = {1}", s.Format);
+        }
+
+        [Test]
+        public void GetArgumentWorks()
+        {
+            var s = FormattableStringFactory.Create("x = {0}, y = {1}", "x", "y");
+            Assert.AreEqual("x", s.GetArgument(0), "0");
+            Assert.AreEqual("y", s.GetArgument(1), "1");
+        }
+
+        [Test]
+        public void GetArgumentsWorks()
+        {
+            var s = FormattableStringFactory.Create("x = {0}, y = {1}", "x", "y");
+            var args = s.GetArguments();
+            Assert.AreEqual("x", args[0], "0");
+            Assert.AreEqual("y", args[1], "1");
+        }
+
+        [Test]
+        public void ArrayReturnedByGetArgumentsCanBeModified()
+        {
+            var s = FormattableStringFactory.Create("x = {0}, y = {1}", "x", "y");
+            var args = s.GetArguments();
+            Assert.AreEqual("x", args[0], "#1");
+            args[0] = "z";
+            var args2 = s.GetArguments();
+            Assert.AreEqual("z", args2[0], "#2");
+            Assert.AreEqual("x = z, y = y", s.ToString(), "#3");
+        }
+
+        [Test]
+        public void ToStringWorks()
+        {
+            var s = FormattableStringFactory.Create("x = {0}, y = {1:x}", "x", 291);
+            Assert.AreEqual("x = x, y = 123", s.ToString());
+        }
+
+        //[Test]
+        //public void ToStringWithFormatProviderWorks_SPI_1651()
+        //{
+        //    var s = FormattableStringFactory.Create("x = {0}, y = {0:FMT}", new MyFormattable());
+        //    // #1651
+        //    Assert.AreEqual("x = Formatted: MyFormatProvider, y = Formatted: FMT, MyFormatProvider", s.ToString(new MyFormatProvider()));
+        //}
+
+        //[Test]
+        //public void IFormattableToStringWorks_SPI_1633_1651()
+        //{
+        //    IFormattable s = FormattableStringFactory.Create("x = {0}, y = {0:FMT}", new MyFormattable());
+        //    // #1633
+        //    // #1651
+        //    Assert.AreEqual("x = Formatted: MyFormatProvider, y = Formatted: FMT, MyFormatProvider", s.Format(null, new MyFormatProvider()));
+        //}
+
+        [Test]
+        public void InvariantWorks()
+        {
+            var s = FormattableStringFactory.Create("x = {0}, y = {1:x}", "x", 291);
+            Assert.AreEqual("x = x, y = 123", FormattableString.Invariant(s));
+        }
+    }
+}

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -10672,6 +10672,82 @@
         }
     });
 
+    Bridge.define('Bridge.ClientTest.FormattableStringTests', {
+        typePropertiesAreCorrect: function () {
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("s");
+            Bridge.Test.Assert.true$1(Bridge.is(s, System.FormattableString), "is FormattableString");
+            Bridge.Test.Assert.true$1(Bridge.is(s, System.IFormattable), "is IFormattable");
+
+            Bridge.Test.Assert.true$1(Bridge.Reflection.isClass(System.FormattableString), "IsClass");
+            Bridge.Test.Assert.true$1(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.FormattableString), "IFormattable.IsAssignableFrom");
+            var interfaces = Bridge.Reflection.getInterfaces(System.FormattableString);
+            Bridge.Test.Assert.areEqual$1(1, interfaces.length, "interfaces length");
+            Bridge.Test.Assert.true$1(System.Array.contains(interfaces, System.IFormattable, Function), "interfaces contains IFormattable");
+        },
+        argumentCountWorks: function () {
+            var s1 = System.Runtime.CompilerServices.FormattableStringFactory.create("{0}", ["x"]);
+            Bridge.Test.Assert.areEqual$1(1, s1.getArgumentCount(), "#1");
+            var s2 = System.Runtime.CompilerServices.FormattableStringFactory.create("{0}, {1}", ["x", "y"]);
+            Bridge.Test.Assert.areEqual$1(2, s2.getArgumentCount(), "#2");
+        },
+        formatWorks: function () {
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
+            Bridge.Test.Assert.areEqual("x = {0}, y = {1}", s.getFormat());
+        },
+        getArgumentWorks: function () {
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
+            Bridge.Test.Assert.areEqual$1("x", s.getArgument(0), "0");
+            Bridge.Test.Assert.areEqual$1("y", s.getArgument(1), "1");
+        },
+        getArgumentsWorks: function () {
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
+            var args = s.getArguments();
+            Bridge.Test.Assert.areEqual$1("x", args[0], "0");
+            Bridge.Test.Assert.areEqual$1("y", args[1], "1");
+        },
+        arrayReturnedByGetArgumentsCanBeModified: function () {
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
+            var args = s.getArguments();
+            Bridge.Test.Assert.areEqual$1("x", args[0], "#1");
+            args[0] = "z";
+            var args2 = s.getArguments();
+            Bridge.Test.Assert.areEqual$1("z", args2[0], "#2");
+            Bridge.Test.Assert.areEqual$1("x = z, y = y", s.toString(), "#3");
+        },
+        toStringWorks: function () {
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", 291]);
+            Bridge.Test.Assert.areEqual("x = x, y = 123", s.toString());
+        },
+        invariantWorks: function () {
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", 291]);
+            Bridge.Test.Assert.areEqual("x = x, y = 123", System.FormattableString.invariant(s));
+        }
+    });
+
+    Bridge.define('Bridge.ClientTest.FormattableStringTests.MyFormatProvider', {
+        inherits: [System.IFormatProvider],
+        config: {
+            alias: [
+            "getFormat", "System$IFormatProvider$getFormat"
+            ]
+        },
+        getFormat: function (type) {
+            return System.Globalization.CultureInfo.invariantCulture.getFormat(type);
+        }
+    });
+
+    Bridge.define('Bridge.ClientTest.FormattableStringTests.MyFormattable', {
+        inherits: [System.IFormattable],
+        config: {
+            alias: [
+            "format", "System$IFormattable$format"
+            ]
+        },
+        format: function (format, formatProvider) {
+            return System.String.concat(System.String.concat("Formatted: ", (!System.String.isNullOrEmpty(format) ? System.String.concat(format, ", ") : "")), Bridge.Reflection.getTypeName(Bridge.getType(formatProvider)));
+        }
+    });
+
     Bridge.define('Bridge.ClientTest.GuidTests', {
         typePropertiesAreCorrect: function () {
             Bridge.Test.Assert.areEqual(Bridge.Reflection.getTypeFullName(System.Guid), "System.Guid");

--- a/Tests/Runner/Batch1/test.js
+++ b/Tests/Runner/Batch1/test.js
@@ -1984,6 +1984,14 @@
             QUnit.test("StringFormatTests - PadIntegerWithSpecificNumberLeadingZeros", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Format_StringFormatTests.padIntegerWithSpecificNumberLeadingZeros);
             QUnit.test("StringFormatTests - PadNumericWithLeadingZerosToLength", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Format_StringFormatTests.padNumericWithLeadingZerosToLength);
             QUnit.test("StringFormatTests - PadNumericWithSpecificNumberOfLeadingZeros", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Format_StringFormatTests.padNumericWithSpecificNumberOfLeadingZeros);
+            QUnit.test("FormattableString - TypePropertiesAreCorrect", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests.typePropertiesAreCorrect);
+            QUnit.test("FormattableString - ArgumentCountWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests.argumentCountWorks);
+            QUnit.test("FormattableString - FormatWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests.formatWorks);
+            QUnit.test("FormattableString - GetArgumentWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests.getArgumentWorks);
+            QUnit.test("FormattableString - GetArgumentsWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests.getArgumentsWorks);
+            QUnit.test("FormattableString - ArrayReturnedByGetArgumentsCanBeModified", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests.arrayReturnedByGetArgumentsCanBeModified);
+            QUnit.test("FormattableString - ToStringWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests.toStringWorks);
+            QUnit.test("FormattableString - InvariantWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests.invariantWorks);
             QUnit.test("String - TypePropertiesAreCorrect", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_StringTests.typePropertiesAreCorrect);
             QUnit.test("String - StringInterfaces", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_StringTests.stringInterfaces);
             QUnit.test("String - DefaultConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_StringTests.defaultConstructorWorks);
@@ -5853,6 +5861,44 @@
             padNumericWithSpecificNumberOfLeadingZeros: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Format.StringFormatTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Format_StringFormatTests);
                 t.getFixture().padNumericWithSpecificNumberOfLeadingZeros();
+            }
+        }
+    });
+
+    Bridge.define('Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests', {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.FormattableStringTests)],
+        statics: {
+            typePropertiesAreCorrect: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.FormattableStringTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests);
+                t.getFixture().typePropertiesAreCorrect();
+            },
+            argumentCountWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.FormattableStringTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests);
+                t.getFixture().argumentCountWorks();
+            },
+            formatWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.FormattableStringTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests);
+                t.getFixture().formatWorks();
+            },
+            getArgumentWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.FormattableStringTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests);
+                t.getFixture().getArgumentWorks();
+            },
+            getArgumentsWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.FormattableStringTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests);
+                t.getFixture().getArgumentsWorks();
+            },
+            arrayReturnedByGetArgumentsCanBeModified: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.FormattableStringTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests);
+                t.getFixture().arrayReturnedByGetArgumentsCanBeModified();
+            },
+            toStringWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.FormattableStringTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests);
+                t.getFixture().toStringWorks();
+            },
+            invariantWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.FormattableStringTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_FormattableStringTests);
+                t.getFixture().invariantWorks();
             }
         }
     });


### PR DESCRIPTION
Fixes #1622 

`FormattableString` was added as part of Reflection support.
This PR is to add tests.
