### PR TITLE
[1621] AmbiguousMatchException tests

### DIFF
--- a/Tests/Batch1/Batch1.csproj
+++ b/Tests/Batch1/Batch1.csproj
@@ -46,6 +46,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BridgeConsoleTests.cs" />
+    <Compile Include="Exceptions\AmbiguousMatchExceptionTests.cs" />
     <Compile Include="FormattableStringTests.cs" />
     <Compile Include="MixinTests.cs" />
     <Compile Include="ArgumentsTests.cs" />

--- a/Tests/Batch1/Exceptions/AmbiguousMatchExceptionTests.cs
+++ b/Tests/Batch1/Exceptions/AmbiguousMatchExceptionTests.cs
@@ -1,0 +1,54 @@
+// #1621
+using Bridge.Test;
+using System;
+using System.Reflection;
+
+namespace Bridge.ClientTest.Exceptions
+{
+    [Category(Constants.PREFIX_EXCEPTIONS)]
+    [TestFixture(TestNameFormat = "AmbiguousMatchException - {0}")]
+    public class AmbiguousMatchExceptionTests
+    {
+        [Test]
+        public void TypePropertiesAreCorrect()
+        {
+            Assert.AreEqual("System.Reflection.AmbiguousMatchException", typeof(AmbiguousMatchException).FullName, "Name");
+            Assert.True(typeof(AmbiguousMatchException).IsClass, "IsClass");
+            Assert.AreEqual(typeof(Exception), typeof(AmbiguousMatchException).BaseType, "BaseType");
+            object d = new AmbiguousMatchException();
+            Assert.True(d is AmbiguousMatchException, "is AmbiguousMatchException");
+            Assert.True(d is Exception, "is Exception");
+
+            var interfaces = typeof(AmbiguousMatchException).GetInterfaces();
+            Assert.AreEqual(0, interfaces.Length, "Interfaces length");
+        }
+
+        [Test]
+        public void DefaultConstructorWorks()
+        {
+            var ex = new AmbiguousMatchException();
+            Assert.True((object)ex is AmbiguousMatchException, "is AmbiguousMatchException");
+            Assert.True(ex.InnerException == null, "InnerException");
+            Assert.AreEqual("Ambiguous match.", ex.Message);
+        }
+
+        [Test]
+        public void ConstructorWithMessageWorks()
+        {
+            var ex = new AmbiguousMatchException("The message");
+            Assert.True((object)ex is AmbiguousMatchException, "is AmbiguousMatchException");
+            Assert.True(ex.InnerException == null, "InnerException");
+            Assert.AreEqual("The message", ex.Message);
+        }
+
+        [Test]
+        public void ConstructorWithMessageAndInnerExceptionWorks()
+        {
+            var inner = new Exception("a");
+            var ex = new AmbiguousMatchException("The message", inner);
+            Assert.True((object)ex is AmbiguousMatchException, "is AmbiguousMatchException");
+            Assert.True(ReferenceEquals(ex.InnerException, inner), "InnerException");
+            Assert.AreEqual("The message", ex.Message);
+        }
+    }
+}

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -9281,6 +9281,39 @@
         }
     });
 
+    Bridge.define('Bridge.ClientTest.Exceptions.AmbiguousMatchExceptionTests', {
+        typePropertiesAreCorrect: function () {
+            Bridge.Test.Assert.areEqual$1("System.Reflection.AmbiguousMatchException", Bridge.Reflection.getTypeFullName(System.Reflection.AmbiguousMatchException), "Name");
+            Bridge.Test.Assert.true$1(Bridge.Reflection.isClass(System.Reflection.AmbiguousMatchException), "IsClass");
+            Bridge.Test.Assert.areEqual$1(System.Exception, Bridge.Reflection.getBaseType(System.Reflection.AmbiguousMatchException), "BaseType");
+            var d = new System.Reflection.AmbiguousMatchException();
+            Bridge.Test.Assert.true$1(Bridge.is(d, System.Reflection.AmbiguousMatchException), "is AmbiguousMatchException");
+            Bridge.Test.Assert.true$1(Bridge.is(d, System.Exception), "is Exception");
+
+            var interfaces = Bridge.Reflection.getInterfaces(System.Reflection.AmbiguousMatchException);
+            Bridge.Test.Assert.areEqual$1(0, interfaces.length, "Interfaces length");
+        },
+        defaultConstructorWorks: function () {
+            var ex = new System.Reflection.AmbiguousMatchException();
+            Bridge.Test.Assert.true$1(Bridge.is(ex, System.Reflection.AmbiguousMatchException), "is AmbiguousMatchException");
+            Bridge.Test.Assert.true$1(ex.getInnerException() == null, "InnerException");
+            Bridge.Test.Assert.areEqual("Ambiguous match.", ex.getMessage());
+        },
+        constructorWithMessageWorks: function () {
+            var ex = new System.Reflection.AmbiguousMatchException("The message");
+            Bridge.Test.Assert.true$1(Bridge.is(ex, System.Reflection.AmbiguousMatchException), "is AmbiguousMatchException");
+            Bridge.Test.Assert.true$1(ex.getInnerException() == null, "InnerException");
+            Bridge.Test.Assert.areEqual("The message", ex.getMessage());
+        },
+        constructorWithMessageAndInnerExceptionWorks: function () {
+            var inner = new System.Exception("a");
+            var ex = new System.Reflection.AmbiguousMatchException("The message", inner);
+            Bridge.Test.Assert.true$1(Bridge.is(ex, System.Reflection.AmbiguousMatchException), "is AmbiguousMatchException");
+            Bridge.Test.Assert.true$1(Bridge.referenceEquals(ex.getInnerException(), inner), "InnerException");
+            Bridge.Test.Assert.areEqual("The message", ex.getMessage());
+        }
+    });
+
     Bridge.define('Bridge.ClientTest.Exceptions.ArgumentExceptionTests', {
         statics: {
             DefaultMessage: "Value does not fall within the expected range."

--- a/Tests/Runner/Batch1/test.js
+++ b/Tests/Runner/Batch1/test.js
@@ -739,6 +739,10 @@
             QUnit.test("AggregateException - ConstructorWithMessageAndIEnumerableInnerExceptionsWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AggregateExceptionTests.constructorWithMessageAndIEnumerableInnerExceptionsWorks);
             QUnit.test("AggregateException - ConstructorWithMessageAndInnerExceptionArrayWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AggregateExceptionTests.constructorWithMessageAndInnerExceptionArrayWorks);
             QUnit.test("AggregateException - FlattenWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AggregateExceptionTests.flattenWorks);
+            QUnit.test("AmbiguousMatchException - TypePropertiesAreCorrect", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AmbiguousMatchExceptionTests.typePropertiesAreCorrect);
+            QUnit.test("AmbiguousMatchException - DefaultConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AmbiguousMatchExceptionTests.defaultConstructorWorks);
+            QUnit.test("AmbiguousMatchException - ConstructorWithMessageWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AmbiguousMatchExceptionTests.constructorWithMessageWorks);
+            QUnit.test("AmbiguousMatchException - ConstructorWithMessageAndInnerExceptionWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AmbiguousMatchExceptionTests.constructorWithMessageAndInnerExceptionWorks);
             QUnit.test("ArgumentException - TypePropertiesAreCorrect", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_ArgumentExceptionTests.typePropertiesAreCorrect);
             QUnit.test("ArgumentException - DefaultConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_ArgumentExceptionTests.defaultConstructorWorks);
             QUnit.test("ArgumentException - ConstructorWithMessageWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_ArgumentExceptionTests.constructorWithMessageWorks);
@@ -5087,6 +5091,28 @@
             flattenWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Exceptions.AggregateExceptionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AggregateExceptionTests);
                 t.getFixture().flattenWorks();
+            }
+        }
+    });
+
+    Bridge.define('Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AmbiguousMatchExceptionTests', {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Exceptions.AmbiguousMatchExceptionTests)],
+        statics: {
+            typePropertiesAreCorrect: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Exceptions.AmbiguousMatchExceptionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AmbiguousMatchExceptionTests);
+                t.getFixture().typePropertiesAreCorrect();
+            },
+            defaultConstructorWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Exceptions.AmbiguousMatchExceptionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AmbiguousMatchExceptionTests);
+                t.getFixture().defaultConstructorWorks();
+            },
+            constructorWithMessageWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Exceptions.AmbiguousMatchExceptionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AmbiguousMatchExceptionTests);
+                t.getFixture().constructorWithMessageWorks();
+            },
+            constructorWithMessageAndInnerExceptionWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Exceptions.AmbiguousMatchExceptionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Exceptions_AmbiguousMatchExceptionTests);
+                t.getFixture().constructorWithMessageAndInnerExceptionWorks();
             }
         }
     });


### PR DESCRIPTION
Fixes #1621

`AmbiguousMatchException` was added as part of Reflection support.
This PR is to add tests.