### PR TITLE
[1509] Performance.Now should return double

### DIFF
--- a/Html5/Performance.cs
+++ b/Html5/Performance.cs
@@ -15,7 +15,7 @@ namespace Bridge.Html5
         /// Returns a DOMHighResTimeStamp representing the amount of miliseconds elapsed since the start of the navigation, as give by PerformanceTiming.navigationStart to the call of the method.
         /// </summary>
         /// <returns></returns>
-        public virtual extern int Now();
+        public virtual extern double Now();
 
         /// <summary>
         /// Is a PerformanceTiming object containing latency-related performance information.

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -293,6 +293,7 @@
     <Compile Include="BridgeIssues\1400\N1493.cs" />
     <Compile Include="BridgeIssues\1400\N1499.cs" />
     <Compile Include="BridgeIssues\1500\N1501.cs" />
+    <Compile Include="BridgeIssues\1500\N1509.cs" />
     <Compile Include="BridgeIssues\1500\N1510.cs" />
     <Compile Include="BridgeIssues\1500\N1512.cs" />
     <Compile Include="BridgeIssues\1500\N1517.cs" />

--- a/Tests/Batch3/BridgeIssues/1500/N1509.cs
+++ b/Tests/Batch3/BridgeIssues/1500/N1509.cs
@@ -1,0 +1,31 @@
+﻿using Bridge.Test;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#1509 - {0}")]
+    public class Bridge1509
+    {
+        [Test]
+        public void TestPreformanceNowIsDouble()
+        {
+            double p;
+            for (int i = 0; i < 10; i++)
+            {
+                p = Bridge.Html5.Global.Performance.Now();
+                if (!HasNoFraction(p))
+                {
+                    Assert.True(true, "performance.now() returns float");
+                    return;
+                }
+            }
+
+            Assert.Fail("performance.now() did 10 attemps to check if it returns float");
+        }
+
+        private bool HasNoFraction(double n)
+        {
+            return n % 1 == 0;
+        }
+    }
+}

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -6455,6 +6455,24 @@ Bridge.initAssembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
         }
     });
 
+    Bridge.define('Bridge.ClientTest.Batch3.BridgeIssues.Bridge1509', {
+        testPreformanceNowIsDouble: function () {
+            var p;
+            for (var i = 0; i < 10; i = (i + 1) | 0) {
+                p = Bridge.global.performance.now();
+                if (!this.hasNoFraction(p)) {
+                    Bridge.Test.Assert.true$1(true, "performance.now() returns float");
+                    return;
+                }
+            }
+
+            Bridge.Test.Assert.fail$1("performance.now() did 10 attemps to check if it returns float");
+        },
+        hasNoFraction: function (n) {
+            return n % 1 === 0;
+        }
+    });
+
     Bridge.define('Bridge.ClientTest.Batch3.BridgeIssues.Bridge1510', {
         statics: {
             function: function (wrap) {

--- a/Tests/Runner/Batch3/test.js
+++ b/Tests/Runner/Batch3/test.js
@@ -216,6 +216,7 @@
             QUnit.test("#1493 - TestEnumLong", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1493.testEnumLong);
             QUnit.test("#1499 - TestObjectStringCoalesceWorks", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1499.testObjectStringCoalesceWorks);
             QUnit.test("#1501 - TestPropertyChangedEventArgs", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1501.testPropertyChangedEventArgs);
+            QUnit.test("#1509 - TestPreformanceNowIsDouble", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1509.testPreformanceNowIsDouble);
             QUnit.test("#1510 - TestPropertyChangedEventArgs", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1510.testPropertyChangedEventArgs);
             QUnit.test("#1512 - TestParametersReservedNames", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1512.testParametersReservedNames);
             QUnit.test("#1517 - TestEqualTuples", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1517.testEqualTuples);
@@ -2033,6 +2034,16 @@
             testPropertyChangedEventArgs: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1501).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1501);
                 t.getFixture().testPropertyChangedEventArgs();
+            }
+        }
+    });
+
+    Bridge.define('Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1509', {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1509)],
+        statics: {
+            testPreformanceNowIsDouble: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1509).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1509);
+                t.getFixture().testPreformanceNowIsDouble();
             }
         }
     });


### PR DESCRIPTION
Fixes #1509

Changes proposed in this pull request:
- `Performance.Now()` returns `double`
- Client test

