### PR TITLE
Added Platform property to translator and MsBuild task, use MsBuild evaluate API

### DIFF
--- a/.build/targets/Bridge.targets
+++ b/.build/targets/Bridge.targets
@@ -17,6 +17,7 @@
     <GenerateScript
       OutputPath="$(OutputPath)"
       Configuration="$(Configuration)"
+      Platform="$(Platform)"
       Assembly="@(IntermediateAssembly)"
       AssembliesPath="$(MSBuildThisFileDirectory)"
       ProjectPath="$(MSBuildProjectFullPath)"

--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -44,6 +44,12 @@ namespace Bridge.Build
             set;
         }
 
+        public string Platform
+        {
+            get;
+            set;
+        }
+
         public string Configuration
         {
             get;
@@ -139,6 +145,7 @@ namespace Bridge.Build
                 Rebuild = false,
                 ExtractCore = !NoCore,
                 Configuration = this.Configuration,
+                Platform = this.Platform,
                 Source = null,
                 Folder = null,
                 Recursive = false,

--- a/Compiler/Translator/Bridge.Translator.csproj
+++ b/Compiler/Translator/Bridge.Translator.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Utils\AssemblyConfigHelper.cs" />
     <Compile Include="Utils\BridgeOptions.cs" />
     <Compile Include="Utils\AnonymousTypeConfig.cs" />
+    <Compile Include="Utils\MsBuildConditionEvaluator.cs" />
     <Compile Include="Utils\ReflectionConfig.cs" />
     <Compile Include="Utils\MetadataUtils.cs" />
     <Compile Include="Utils\Preconverter.cs" />

--- a/Compiler/Translator/Translator/Translator.Build.cs
+++ b/Compiler/Translator/Translator/Translator.Build.cs
@@ -31,7 +31,7 @@ namespace Bridge.Translator
                 case PlatformID.Win32NT:
                 case PlatformID.Unix:
                 case PlatformID.MacOSX:
-                    return String.Format(" \"{0}\" /t:Rebuild /p:Configuration={1} {2}", Location, this.Configuration, this.BuildArguments);
+                    return String.Format(" \"{0}\" /t:Rebuild /p:Configuration={1} /p:Platform={2} {3}", Location, this.Configuration, this.Platform, this.BuildArguments);
 
                 default:
                     throw (TranslatorException)Bridge.Translator.TranslatorException.Create("Unsupported platform - {0}", Environment.OSVersion.Platform);

--- a/Compiler/Translator/Translator/Translator.Properties.cs
+++ b/Compiler/Translator/Translator/Translator.Properties.cs
@@ -173,6 +173,12 @@ namespace Bridge.Translator
             set;
         }
 
+        public string Platform
+        {
+            get;
+            set;
+        }
+
         public List<string> DefineConstants
         {
             get;

--- a/Compiler/Translator/Translator/TranslatorProcessor.cs
+++ b/Compiler/Translator/Translator/TranslatorProcessor.cs
@@ -296,6 +296,7 @@ namespace Bridge.Translator
 
                 translator.AssemblyInfo = assemblyConfig;
                 translator.Configuration = bridgeOptions.Configuration;
+                translator.Platform = bridgeOptions.Platform;
 
                 if (string.IsNullOrEmpty(bridgeOptions.BridgeLocation))
                 {
@@ -316,6 +317,7 @@ namespace Bridge.Translator
                 translator.Log.Info("\tBridgeLocation:" + translator.BridgeLocation ?? "");
                 translator.Log.Info("\tBuildArguments:" + translator.BuildArguments ?? "");
                 translator.Log.Info("\tConfiguration:" + translator.Configuration ?? "");
+                translator.Log.Info("\tPlatform:" + translator.Platform ?? "");
                 translator.Log.Info("\tDefineConstants:" + (translator.DefineConstants != null ? string.Join(" ", translator.DefineConstants) : ""));
                 translator.Log.Info("\tRebuild:" + translator.Rebuild);
 

--- a/Compiler/Translator/Utils/BridgeOptions.cs
+++ b/Compiler/Translator/Utils/BridgeOptions.cs
@@ -13,6 +13,7 @@ namespace Bridge.Translator
         public bool Rebuild { get; set; }
         public bool ExtractCore { get; set; }
         public string Configuration { get; set; }
+        public string Platform { get; set; }
         public string Source { get; set; }
         public string Folder { get; set; }
         public bool Recursive { get; set; }

--- a/Compiler/Translator/Utils/MsBuildConditionEvaluator.cs
+++ b/Compiler/Translator/Utils/MsBuildConditionEvaluator.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+
+namespace Bridge.Translator.Utils
+{
+    public class MsBuildConditionEvaluator
+    {
+        public static bool EvaluateCondition(string condition, Dictionary<string, string> conditionParameters)
+        {
+            var projectInstance = new ProjectInstance(ProjectRootElement.Create(), conditionParameters, null, ProjectCollection.GlobalProjectCollection);
+            return projectInstance.EvaluateCondition(condition);
+        }
+    }
+}

--- a/Compiler/TranslatorTests/Bridge.Translator.Tests.csproj
+++ b/Compiler/TranslatorTests/Bridge.Translator.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Comparence.cs" />
     <Compile Include="DiffMatchPatch.cs" />
     <Compile Include="FileHelper.cs" />
+    <Compile Include="MsBuildConditionEvaluatorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\.build\common\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>

--- a/Compiler/TranslatorTests/MsBuildConditionEvaluatorTests.cs
+++ b/Compiler/TranslatorTests/MsBuildConditionEvaluatorTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using Bridge.Translator.Utils;
+using NUnit.Framework;
+
+namespace Bridge.Translator.Tests
+{
+    [TestFixture]
+    internal class MsBuildConditionEvaluatorTests
+    {
+        [TestCase]
+        public void TestProjectConfigurations()
+        {
+            var properties1 = new Dictionary<string, string>
+            {
+                ["Configuration"] = "Debug",
+                ["Platform"] = "AnyCPU"
+            };
+            Assert.IsTrue(MsBuildConditionEvaluator.EvaluateCondition("'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'", properties1));
+            Assert.IsFalse(MsBuildConditionEvaluator.EvaluateCondition("'$(Configuration)|$(Platform)' == 'DebugWithPostBuild|AnyCPU'", properties1));
+            Assert.IsFalse(MsBuildConditionEvaluator.EvaluateCondition("'$(Configuration)|$(Platform)' == 'Debug|x64'", properties1));
+
+            var properties2 = new Dictionary<string, string>
+            {
+                ["Configuration"] = "DebugWithPostBuild",
+                ["Platform"] = "AnyCPU"
+            };
+            Assert.IsFalse(MsBuildConditionEvaluator.EvaluateCondition("'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'", properties2));
+            Assert.IsTrue(MsBuildConditionEvaluator.EvaluateCondition("'$(Configuration)|$(Platform)' == 'DebugWithPostBuild|AnyCPU'", properties2));
+            Assert.IsFalse(MsBuildConditionEvaluator.EvaluateCondition("'$(Configuration)|$(Platform)' == 'Debug|x64'", properties2));
+
+            var properties3 = new Dictionary<string, string>
+            {
+                ["Configuration"] = "Debug",
+                ["Platform"] = "x64"
+            };
+            Assert.IsFalse(MsBuildConditionEvaluator.EvaluateCondition("'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'", properties3));
+            Assert.IsFalse(MsBuildConditionEvaluator.EvaluateCondition("'$(Configuration)|$(Platform)' == 'DebugWithPostBuild|AnyCPU'", properties3));
+            Assert.IsTrue(MsBuildConditionEvaluator.EvaluateCondition("'$(Configuration)|$(Platform)' == 'Debug|x64'", properties3));
+        }
+    }
+}

--- a/Compiler/TranslatorTests/TranslatorRunner.cs
+++ b/Compiler/TranslatorTests/TranslatorRunner.cs
@@ -20,13 +20,13 @@ namespace Bridge.Translator.Tests
             set;
         }
 
-        private string FindBridgeDllPathByConfiguration(string configurationName)
+        private string FindBridgeDllPathByConfiguration(string configurationName, string platform)
         {
             var bridgeProjectPath = FileHelper.GetRelativeToCurrentDirPath(Path.Combine("..", "..", "..", "..", "Bridge", "Bridge.csproj"));
 
             this.Logger.Info("Searching Bridge assembly in " + bridgeProjectPath);
 
-            var outputPath = FileHelper.ReadProjectOutputFolder(configurationName, bridgeProjectPath);
+            var outputPath = FileHelper.ReadProjectOutputFolder(configurationName, platform, bridgeProjectPath);
 
             this.Logger.Info("Output path " + outputPath + " in project " + bridgeProjectPath + " for configuration " + configurationName);
 
@@ -59,7 +59,7 @@ namespace Bridge.Translator.Tests
 #if DEBUG
             configuration = "Debug";
 #endif
-            var path = FindBridgeDllPathByConfiguration(configuration);
+            var path = FindBridgeDllPathByConfiguration(configuration, "AnyCPU");
 
             //if (path == null)
             //{


### PR DESCRIPTION
I changed the way how the conditionals are checked in Bridge. Now it uses now some classes provided by MsBuild to evaluate the conditions using a given list of properties. 

Additionally I added the Platform property beside the configuration to ensure the conditionals for project configurations are properly evaluated. 

This fixes issue #1605 .