### PR TITLE
[1810] Add ICollection<T>.IsReadOnly

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -8780,6 +8780,21 @@
             return 0;
         },
 
+        getIsReadOnly: function (obj, T) {
+            var name;
+            if (Bridge.isArray(obj)) {
+                return T ? true : false;
+            } else if (Bridge.isFunction(obj[name = "System$Collections$ICollection$getIsReadOnly"])) {
+                return obj[name]();
+            } else if (T && Bridge.isFunction(obj[name = "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly"])) {
+                return obj[name]();
+            } else if (Bridge.isFunction(obj.getIsReadOnly)) {
+                return obj.getIsReadOnly();
+            }
+
+            return 0;
+        },
+
         add: function (obj, item, T) {
             var name;
             if (Bridge.isArray(obj)) {
@@ -8853,7 +8868,7 @@
             } else if (Bridge.isFunction(obj.copyTo)) {
                 obj.copyTo(dest, index);
             } else if (T && Bridge.isFunction(obj[name = "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$copyTo"])) {
-                return obj[name](dest, index);
+                obj[name](dest, index);
             } else {
                 throw new System.NotImplementedException("copyTo");
             }
@@ -10015,6 +10030,7 @@
                 "getItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$getItem",
                 "setItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$setItem",
                 "getCount", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getCount",
+                "getIsReadOnly", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly",
                 "add", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$add",
                 "clear", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$clear",
                 "contains", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$contains",
@@ -10046,6 +10062,10 @@
 
             getCount: function () {
                 return this.items.length;
+            },
+
+            getIsReadOnly: function () {
+                return !!this.readOnly;
             },
 
             get: function (index) {

--- a/Bridge/Resources/Array.js
+++ b/Bridge/Resources/Array.js
@@ -205,6 +205,21 @@
             return 0;
         },
 
+        getIsReadOnly: function (obj, T) {
+            var name;
+            if (Bridge.isArray(obj)) {
+                return T ? true : false;
+            } else if (Bridge.isFunction(obj[name = "System$Collections$ICollection$getIsReadOnly"])) {
+                return obj[name]();
+            } else if (T && Bridge.isFunction(obj[name = "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly"])) {
+                return obj[name]();
+            } else if (Bridge.isFunction(obj.getIsReadOnly)) {
+                return obj.getIsReadOnly();
+            }
+
+            return 0;
+        },
+
         add: function (obj, item, T) {
             var name;
             if (Bridge.isArray(obj)) {

--- a/Bridge/Resources/Array.js
+++ b/Bridge/Resources/Array.js
@@ -278,7 +278,7 @@
             } else if (Bridge.isFunction(obj.copyTo)) {
                 obj.copyTo(dest, index);
             } else if (T && Bridge.isFunction(obj[name = "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$copyTo"])) {
-                return obj[name](dest, index);
+                obj[name](dest, index);
             } else {
                 throw new System.NotImplementedException("copyTo");
             }

--- a/Bridge/Resources/Collections/List.js
+++ b/Bridge/Resources/Collections/List.js
@@ -7,6 +7,7 @@
                 "getItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$getItem",
                 "setItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$setItem",
                 "getCount", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getCount",
+                "getIsReadOnly", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly",
                 "add", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$add",
                 "clear", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$clear",
                 "contains", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$contains",
@@ -38,6 +39,10 @@
 
             getCount: function () {
                 return this.items.length;
+            },
+
+            getIsReadOnly: function () {
+                return !!this.readOnly;
             },
 
             get: function (index) {

--- a/Bridge/System/Collections/Generic/ICollection.cs
+++ b/Bridge/System/Collections/Generic/ICollection.cs
@@ -5,12 +5,19 @@ namespace System.Collections.Generic
     [External]
     public interface ICollection<T> : IEnumerable<T>, IBridgeClass
     {
+        /// <summary>
+        /// Gets the number of elements contained in the ICollection.
+        /// </summary>
         int Count
         {
             [Template("System.Array.getCount({this}, {T})")]
             get;
         }
 
+        /// <summary>
+        /// Adds an item to the ICollection.
+        /// </summary>
+        /// <param name="item">The object to add to the ICollection</param>
         [Template("System.Array.add({this}, {item}, {T})")]
         void Add(T item);
 
@@ -22,12 +29,25 @@ namespace System.Collections.Generic
         [Template("System.Array.copyTo({this}, {array}, {arrayIndex}, {T})")]
         void CopyTo(T[] array, int arrayIndex);
 
+        /// <summary>
+        /// Removes all items from the ICollection.
+        /// </summary>
         [Template("System.Array.clear({this}, {T})")]
         void Clear();
 
+        /// <summary>
+        /// Determines whether the ICollection contains a specific value.
+        /// </summary>
+        /// <param name="item">The object to locate in the ICollection.</param>
+        /// <returns>true if item is found in the ICollection; otherwise, false.</returns>
         [Template("System.Array.contains({this}, {item}, {T})")]
         bool Contains(T item);
 
+        /// <summary>
+        /// Removes the first occurrence of a specific object from the ICollection.
+        /// </summary>
+        /// <param name="item">The object to remove from the ICollection.</param>
+        /// <returns>true if item was successfully removed from the ICollection; otherwise, false. This method also returns false if item is not found in the original ICollection.</returns>
         [Template("System.Array.remove({this}, {item}, {T})")]
         bool Remove(T item);
     }

--- a/Bridge/System/Collections/Generic/ICollection.cs
+++ b/Bridge/System/Collections/Generic/ICollection.cs
@@ -15,6 +15,15 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
+        /// Gets a value indicating whether the ICollection is read-only.
+        /// </summary>
+        bool IsReadOnly
+        {
+            [Template("System.Array.getIsReadOnly({this}, {T})")]
+            get;
+        }
+
+        /// <summary>
         /// Adds an item to the ICollection.
         /// </summary>
         /// <param name="item">The object to add to the ICollection</param>

--- a/Bridge/System/Collections/Generic/List.cs
+++ b/Bridge/System/Collections/Generic/List.cs
@@ -23,6 +23,14 @@ namespace System.Collections.Generic
             get;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the List is read-only.
+        /// </summary>
+        extern bool ICollection<T>.IsReadOnly
+        {
+            get;
+        }
+
         private extern T Items(int index);
 
         public extern T Get(int index);

--- a/Bridge/System/Collections/ICollection.cs
+++ b/Bridge/System/Collections/ICollection.cs
@@ -5,9 +5,21 @@ namespace System.Collections
     [External]
     public interface ICollection : IEnumerable, IBridgeClass
     {
+        /// <summary>
+        /// Gets the number of elements contained in the ICollection.
+        /// </summary>
         int Count
         {
             [Template("System.Array.getCount({this})")]
+            get;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the ICollection is read-only.
+        /// </summary>
+        bool IsReadOnly
+        {
+            [Template("System.Array.getIsReadOnly({this})")]
             get;
         }
     }

--- a/Bridge/System/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/Bridge/System/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -14,6 +14,14 @@ namespace System.Collections.ObjectModel
             private set;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the ReadOnlyCollection is read-only.
+        /// </summary>
+        extern bool ICollection<T>.IsReadOnly
+        {
+            get;
+        }
+
         [AccessorsIndexer]
         public extern T this[int index]
         {

--- a/Compiler/TranslatorTests/TestProjects/02/Bridge/reference/TestProject.js
+++ b/Compiler/TranslatorTests/TestProjects/02/Bridge/reference/TestProject.js
@@ -8780,6 +8780,21 @@
             return 0;
         },
 
+        getIsReadOnly: function (obj, T) {
+            var name;
+            if (Bridge.isArray(obj)) {
+                return T ? true : false;
+            } else if (Bridge.isFunction(obj[name = "System$Collections$ICollection$getIsReadOnly"])) {
+                return obj[name]();
+            } else if (T && Bridge.isFunction(obj[name = "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly"])) {
+                return obj[name]();
+            } else if (Bridge.isFunction(obj.getIsReadOnly)) {
+                return obj.getIsReadOnly();
+            }
+
+            return 0;
+        },
+
         add: function (obj, item, T) {
             var name;
             if (Bridge.isArray(obj)) {
@@ -8853,7 +8868,7 @@
             } else if (Bridge.isFunction(obj.copyTo)) {
                 obj.copyTo(dest, index);
             } else if (T && Bridge.isFunction(obj[name = "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$copyTo"])) {
-                return obj[name](dest, index);
+                obj[name](dest, index);
             } else {
                 throw new System.NotImplementedException("copyTo");
             }
@@ -10015,6 +10030,7 @@
                 "getItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$getItem",
                 "setItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$setItem",
                 "getCount", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getCount",
+                "getIsReadOnly", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly",
                 "add", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$add",
                 "clear", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$clear",
                 "contains", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$contains",
@@ -10046,6 +10062,10 @@
 
             getCount: function () {
                 return this.items.length;
+            },
+
+            getIsReadOnly: function () {
+                return !!this.readOnly;
             },
 
             get: function (index) {

--- a/Html5/TypedArray/Prototype.cs
+++ b/Html5/TypedArray/Prototype.cs
@@ -597,6 +597,14 @@ namespace Bridge.Html5.TypedArray
             get;
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the TypedArray is read-only.
+        /// </summary>
+        extern bool ICollection<TypedElement>.IsReadOnly
+        {
+            get;
+        }
+
         extern void ICollection<TypedElement>.Add(TypedElement item);
 
         extern void ICollection<TypedElement>.Clear();

--- a/Tests/Batch1/ArrayTests.cs
+++ b/Tests/Batch1/ArrayTests.cs
@@ -404,6 +404,13 @@ namespace Bridge.ClientTest
             }
 
             [Test]
+            public void ICollectionIsReadOnlyWorks()
+            {
+                ICollection<string> l = new[] { "x", "y", "z" };
+                Assert.True(l.IsReadOnly);
+            }
+
+            [Test]
             public void ICollectionAddWorks()
             {
                 IList<string> l = new[] { "x", "y", "z" };
@@ -489,6 +496,13 @@ namespace Bridge.ClientTest
                 Assert.True(l.Remove("y"));
                 Assert.False(l.Remove("a"));
                 Assert.AreDeepEqual(new[] { "x", "z" }, l);
+            }
+
+            [Test]
+            public void IListIsReadOnlyWorks()
+            {
+                IList<string> l = new[] { "x", "y", "z" };
+                Assert.True(l.IsReadOnly);
             }
 
             [Test]

--- a/Tests/Batch1/Collections/Generic/ICollectionTests.cs
+++ b/Tests/Batch1/Collections/Generic/ICollectionTests.cs
@@ -30,6 +30,14 @@ namespace Bridge.ClientTest.Collections.Generic
 
             public int Count { get { return Items.Count; } }
 
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
             public void CopyTo(string[] array, int arrayIndex)
             {
                 Items.CopyTo(array, arrayIndex);
@@ -104,6 +112,24 @@ namespace Bridge.ClientTest.Collections.Generic
         public void ClassImplementingICollectionCastToICollectionCountWorks()
         {
             Assert.AreEqual(3, ((ICollection<string>)new MyCollection(new[] { "x", "y", "z" })).Count);
+        }
+
+        [Test]
+        public void ArrayCastToICollectionIsReadOnlyWorks()
+        {
+            Assert.AreEqual(true, ((ICollection<string>)new[] { "x", "y", "z" }).IsReadOnly);
+        }
+
+        [Test]
+        public void ClassImplementingICollectionIsReadOnlyWorks()
+        {
+            Assert.AreEqual(true, new MyCollection(new[] { "x", "y" }).IsReadOnly);
+        }
+
+        [Test]
+        public void ClassImplementingICollectionCastToICollectionIsReadOnlyWorks()
+        {
+            Assert.AreEqual(true, ((ICollection<string>)new MyCollection(new[] { "x", "y", "z" })).IsReadOnly);
         }
 
         [Test]

--- a/Tests/Batch1/Collections/Generic/IListTests.cs
+++ b/Tests/Batch1/Collections/Generic/IListTests.cs
@@ -30,6 +30,14 @@ namespace Bridge.ClientTest.Collections.Generic
 
             public int Count { get { return Items.Count; } }
 
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
             public void Add(string item)
             {
                 Items.Add(item);
@@ -159,6 +167,27 @@ namespace Bridge.ClientTest.Collections.Generic
             IList<string> l = new MyList(new[] { "x", "y", "z" });
             l[1] = "a";
             Assert.AreEqual("a", l[1]);
+        }
+
+        [Test]
+        public void ArrayCastToIListIsReadOnlyWorks()
+        {
+            IList<C> arr = new[] { new C(1), new C(2), new C(3) };
+            Assert.AreEqual(true, arr.IsReadOnly);
+        }
+
+        [Test]
+        public void ClassImplementingIListIsReadOnlyWorks()
+        {
+            MyList c = new MyList(new[] { "x", "y" });
+            Assert.AreEqual(true, c.IsReadOnly);
+        }
+
+        [Test]
+        public void ClassImplementingIListCastToIListIsReadOnlyWorks()
+        {
+            IList<string> l = new MyList(new[] { "x", "y" });
+            Assert.AreEqual(true, l.IsReadOnly);
         }
 
         [Test]

--- a/Tests/Batch1/Collections/Native/Float32ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Float32ArrayTests.cs
@@ -308,5 +308,37 @@ namespace Bridge.ClientTest.Collections.Native
             var list = (ICollection<float>)new Float32Array(new float[0]);
             Assert.True(list.IsReadOnly);
         }
+
+        [Test]
+        public void ICollectionCopyTo()
+        {
+            ICollection<float> l = new Float32Array(new float[] { 0, 1, 2 });
+
+            var a1 = new float[3];
+            l.CopyTo(a1, 0);
+
+            Assert.AreEqual(0, a1[0], "1.Element 0");
+            Assert.AreEqual(1, a1[1], "1.Element 1");
+            Assert.AreEqual(2, a1[2], "1.Element 2");
+
+            var a2 = new float[5];
+            l.CopyTo(a2, 1);
+
+            Assert.AreEqual(0, a2[0], "2.Element 0");
+            Assert.AreEqual(0, a2[1], "2.Element 1");
+            Assert.AreEqual(1, a2[2], "2.Element 2");
+            Assert.AreEqual(2, a2[3], "2.Element 3");
+            Assert.AreEqual(0, a2[4], "2.Element 4");
+
+            Assert.Throws<ArgumentNullException>(() => { l.CopyTo(null, 0); }, "3.null");
+
+            var a3 = new float[2];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a3, 0); }, "3.Short array");
+
+            var a4 = new float[3];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 1); }, "3.Start index 1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { l.CopyTo(a4, -1); }, "3.Negative start index");
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 3); }, "3.Start index 3");
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Float32ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Float32ArrayTests.cs
@@ -294,5 +294,19 @@ namespace Bridge.ClientTest.Collections.Native
         //    var list = (IReadOnlyList<float>)new Float32Array(new float[] { 3, 6, 2, 9, 5 });
         //    Assert.AreEqual(list[3], 9, "Get item");
         //}
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            var list = (IList<float>)new Float32Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
+
+        [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            var list = (ICollection<float>)new Float32Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Float64ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Float64ArrayTests.cs
@@ -294,5 +294,19 @@ namespace Bridge.ClientTest.Collections.Native
         //    var list = (IReadOnlyList<double>)new Float64Array(new double[] { 3, 6, 2, 9, 5 });
         //    Assert.AreEqual(list[3], 9, "Get item");
         //}
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            var list = (IList<float>)new Float64Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
+
+        [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            var list = (ICollection<float>)new Float64Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Float64ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Float64ArrayTests.cs
@@ -308,5 +308,37 @@ namespace Bridge.ClientTest.Collections.Native
             var list = (ICollection<float>)new Float64Array(new float[0]);
             Assert.True(list.IsReadOnly);
         }
+
+        [Test]
+        public void ICollectionCopyTo()
+        {
+            ICollection<double> l = new Float64Array(new double[] { 0, 1, 2 });
+
+            var a1 = new double[3];
+            l.CopyTo(a1, 0);
+
+            Assert.AreEqual(0, a1[0], "1.Element 0");
+            Assert.AreEqual(1, a1[1], "1.Element 1");
+            Assert.AreEqual(2, a1[2], "1.Element 2");
+
+            var a2 = new double[5];
+            l.CopyTo(a2, 1);
+
+            Assert.AreEqual(0, a2[0], "2.Element 0");
+            Assert.AreEqual(0, a2[1], "2.Element 1");
+            Assert.AreEqual(1, a2[2], "2.Element 2");
+            Assert.AreEqual(2, a2[3], "2.Element 3");
+            Assert.AreEqual(0, a2[4], "2.Element 4");
+
+            Assert.Throws<ArgumentNullException>(() => { l.CopyTo(null, 0); }, "3.null");
+
+            var a3 = new double[2];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a3, 0); }, "3.Short array");
+
+            var a4 = new double[3];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 1); }, "3.Start index 1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { l.CopyTo(a4, -1); }, "3.Negative start index");
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 3); }, "3.Start index 3");
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Int16ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Int16ArrayTests.cs
@@ -294,5 +294,19 @@ namespace Bridge.ClientTest.Collections.Native
         //    var list = (IReadOnlyList<short>)new Int16Array(new short[] { 3, 6, 2, 9, 5 });
         //    Assert.AreEqual(list[3], 9, "Get item");
         //}
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            var list = (IList<float>)new Int16Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
+
+        [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            var list = (ICollection<float>)new Int16Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Int16ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Int16ArrayTests.cs
@@ -308,5 +308,37 @@ namespace Bridge.ClientTest.Collections.Native
             var list = (ICollection<float>)new Int16Array(new float[0]);
             Assert.True(list.IsReadOnly);
         }
+
+        [Test]
+        public void ICollectionCopyTo()
+        {
+            ICollection<short> l = new Int16Array(new short[] { 0, 1, 2 });
+
+            var a1 = new short[3];
+            l.CopyTo(a1, 0);
+
+            Assert.AreEqual(0, a1[0], "1.Element 0");
+            Assert.AreEqual(1, a1[1], "1.Element 1");
+            Assert.AreEqual(2, a1[2], "1.Element 2");
+
+            var a2 = new short[5];
+            l.CopyTo(a2, 1);
+
+            Assert.AreEqual(0, a2[0], "2.Element 0");
+            Assert.AreEqual(0, a2[1], "2.Element 1");
+            Assert.AreEqual(1, a2[2], "2.Element 2");
+            Assert.AreEqual(2, a2[3], "2.Element 3");
+            Assert.AreEqual(0, a2[4], "2.Element 4");
+
+            Assert.Throws<ArgumentNullException>(() => { l.CopyTo(null, 0); }, "3.null");
+
+            var a3 = new short[2];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a3, 0); }, "3.Short array");
+
+            var a4 = new short[3];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 1); }, "3.Start index 1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { l.CopyTo(a4, -1); }, "3.Negative start index");
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 3); }, "3.Start index 3");
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Int32ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Int32ArrayTests.cs
@@ -308,5 +308,37 @@ namespace Bridge.ClientTest.Collections.Native
             var list = (ICollection<float>)new Int32Array(new float[0]);
             Assert.True(list.IsReadOnly);
         }
+
+        [Test]
+        public void ICollectionCopyTo()
+        {
+            ICollection<int> l = new Int32Array(new int[] { 0, 1, 2 });
+
+            var a1 = new int[3];
+            l.CopyTo(a1, 0);
+
+            Assert.AreEqual(0, a1[0], "1.Element 0");
+            Assert.AreEqual(1, a1[1], "1.Element 1");
+            Assert.AreEqual(2, a1[2], "1.Element 2");
+
+            var a2 = new int[5];
+            l.CopyTo(a2, 1);
+
+            Assert.AreEqual(0, a2[0], "2.Element 0");
+            Assert.AreEqual(0, a2[1], "2.Element 1");
+            Assert.AreEqual(1, a2[2], "2.Element 2");
+            Assert.AreEqual(2, a2[3], "2.Element 3");
+            Assert.AreEqual(0, a2[4], "2.Element 4");
+
+            Assert.Throws<ArgumentNullException>(() => { l.CopyTo(null, 0); }, "3.null");
+
+            var a3 = new int[2];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a3, 0); }, "3.Short array");
+
+            var a4 = new int[3];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 1); }, "3.Start index 1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { l.CopyTo(a4, -1); }, "3.Negative start index");
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 3); }, "3.Start index 3");
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Int32ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Int32ArrayTests.cs
@@ -294,5 +294,19 @@ namespace Bridge.ClientTest.Collections.Native
         //    var list = (IReadOnlyList<int>)new Int32Array(new int[] { 3, 6, 2, 9, 5 });
         //    Assert.AreEqual(list[3], 9, "Get item");
         //}
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            var list = (IList<float>)new Int32Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
+
+        [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            var list = (ICollection<float>)new Int32Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Int8ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Int8ArrayTests.cs
@@ -294,5 +294,19 @@ namespace Bridge.ClientTest.Collections.Native
         //    var list = (IReadOnlyList<sbyte>)new Int8Array(new sbyte[] { 3, 6, 2, 9, 5 });
         //    Assert.AreEqual(list[3], 9, "Get item");
         //}
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            var list = (IList<float>)new Int8Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
+
+        [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            var list = (ICollection<float>)new Int8Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Int8ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Int8ArrayTests.cs
@@ -308,5 +308,37 @@ namespace Bridge.ClientTest.Collections.Native
             var list = (ICollection<float>)new Int8Array(new float[0]);
             Assert.True(list.IsReadOnly);
         }
+
+        [Test]
+        public void ICollectionCopyTo()
+        {
+            ICollection<sbyte> l = new Int8Array(new sbyte[] { 0, 1, 2 });
+
+            var a1 = new sbyte[3];
+            l.CopyTo(a1, 0);
+
+            Assert.AreEqual(0, a1[0], "1.Element 0");
+            Assert.AreEqual(1, a1[1], "1.Element 1");
+            Assert.AreEqual(2, a1[2], "1.Element 2");
+
+            var a2 = new sbyte[5];
+            l.CopyTo(a2, 1);
+
+            Assert.AreEqual(0, a2[0], "2.Element 0");
+            Assert.AreEqual(0, a2[1], "2.Element 1");
+            Assert.AreEqual(1, a2[2], "2.Element 2");
+            Assert.AreEqual(2, a2[3], "2.Element 3");
+            Assert.AreEqual(0, a2[4], "2.Element 4");
+
+            Assert.Throws<ArgumentNullException>(() => { l.CopyTo(null, 0); }, "3.null");
+
+            var a3 = new sbyte[2];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a3, 0); }, "3.Short array");
+
+            var a4 = new sbyte[3];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 1); }, "3.Start index 1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { l.CopyTo(a4, -1); }, "3.Negative start index");
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 3); }, "3.Start index 3");
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Uint16ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Uint16ArrayTests.cs
@@ -294,5 +294,19 @@ namespace Bridge.ClientTest.Collections.Native
         //    var list = (IReadOnlyList<ushort>)new Uint16Array(new ushort[] { 3, 6, 2, 9, 5 });
         //    Assert.AreEqual(list[3], 9, "Get item");
         //}
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            var list = (IList<float>)new Uint16Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
+
+        [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            var list = (ICollection<float>)new Uint16Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Uint16ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Uint16ArrayTests.cs
@@ -308,5 +308,37 @@ namespace Bridge.ClientTest.Collections.Native
             var list = (ICollection<float>)new Uint16Array(new float[0]);
             Assert.True(list.IsReadOnly);
         }
+
+        [Test]
+        public void ICollectionCopyTo()
+        {
+            ICollection<ushort> l = new Uint16Array(new ushort[] { 0, 1, 2 });
+
+            var a1 = new ushort[3];
+            l.CopyTo(a1, 0);
+
+            Assert.AreEqual(0, a1[0], "1.Element 0");
+            Assert.AreEqual(1, a1[1], "1.Element 1");
+            Assert.AreEqual(2, a1[2], "1.Element 2");
+
+            var a2 = new ushort[5];
+            l.CopyTo(a2, 1);
+
+            Assert.AreEqual(0, a2[0], "2.Element 0");
+            Assert.AreEqual(0, a2[1], "2.Element 1");
+            Assert.AreEqual(1, a2[2], "2.Element 2");
+            Assert.AreEqual(2, a2[3], "2.Element 3");
+            Assert.AreEqual(0, a2[4], "2.Element 4");
+
+            Assert.Throws<ArgumentNullException>(() => { l.CopyTo(null, 0); }, "3.null");
+
+            var a3 = new ushort[2];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a3, 0); }, "3.Short array");
+
+            var a4 = new ushort[3];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 1); }, "3.Start index 1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { l.CopyTo(a4, -1); }, "3.Negative start index");
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 3); }, "3.Start index 3");
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Uint32ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Uint32ArrayTests.cs
@@ -308,5 +308,37 @@ namespace Bridge.ClientTest.Collections.Native
             var list = (ICollection<float>)new Uint32Array(new float[0]);
             Assert.True(list.IsReadOnly);
         }
+
+        [Test]
+        public void ICollectionCopyTo()
+        {
+            ICollection<uint> l = new Uint32Array(new uint[] { 0, 1, 2 });
+
+            var a1 = new uint[3];
+            l.CopyTo(a1, 0);
+
+            Assert.AreEqual(0, a1[0], "1.Element 0");
+            Assert.AreEqual(1, a1[1], "1.Element 1");
+            Assert.AreEqual(2, a1[2], "1.Element 2");
+
+            var a2 = new uint[5];
+            l.CopyTo(a2, 1);
+
+            Assert.AreEqual(0, a2[0], "2.Element 0");
+            Assert.AreEqual(0, a2[1], "2.Element 1");
+            Assert.AreEqual(1, a2[2], "2.Element 2");
+            Assert.AreEqual(2, a2[3], "2.Element 3");
+            Assert.AreEqual(0, a2[4], "2.Element 4");
+
+            Assert.Throws<ArgumentNullException>(() => { l.CopyTo(null, 0); }, "3.null");
+
+            var a3 = new uint[2];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a3, 0); }, "3.Short array");
+
+            var a4 = new uint[3];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 1); }, "3.Start index 1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { l.CopyTo(a4, -1); }, "3.Negative start index");
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 3); }, "3.Start index 3");
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Uint32ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Uint32ArrayTests.cs
@@ -294,5 +294,19 @@ namespace Bridge.ClientTest.Collections.Native
         //    var list = (IReadOnlyList<uint>)new Uint32Array(new uint[] { 3, 6, 2, 9, 5 });
         //    Assert.AreEqual(list[3], 9, "Get item");
         //}
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            var list = (IList<float>)new Uint32Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
+
+        [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            var list = (ICollection<float>)new Uint32Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Uint8ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Uint8ArrayTests.cs
@@ -294,5 +294,19 @@ namespace Bridge.ClientTest.Collections.Native
         //    var list = (IReadOnlyList<byte>)new Uint8Array(new byte[] { 3, 6, 2, 9, 5 });
         //    Assert.AreEqual(list[3], 9, "Get item");
         //}
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            var list = (IList<float>)new Uint8Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
+
+        [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            var list = (ICollection<float>)new Uint8Array(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Uint8ArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Uint8ArrayTests.cs
@@ -308,5 +308,37 @@ namespace Bridge.ClientTest.Collections.Native
             var list = (ICollection<float>)new Uint8Array(new float[0]);
             Assert.True(list.IsReadOnly);
         }
+
+        [Test]
+        public void ICollectionCopyTo()
+        {
+            ICollection<byte> l = new Uint8Array(new byte[] { 0, 1, 2 });
+
+            var a1 = new byte[3];
+            l.CopyTo(a1, 0);
+
+            Assert.AreEqual(0, a1[0], "1.Element 0");
+            Assert.AreEqual(1, a1[1], "1.Element 1");
+            Assert.AreEqual(2, a1[2], "1.Element 2");
+
+            var a2 = new byte[5];
+            l.CopyTo(a2, 1);
+
+            Assert.AreEqual(0, a2[0], "2.Element 0");
+            Assert.AreEqual(0, a2[1], "2.Element 1");
+            Assert.AreEqual(1, a2[2], "2.Element 2");
+            Assert.AreEqual(2, a2[3], "2.Element 3");
+            Assert.AreEqual(0, a2[4], "2.Element 4");
+
+            Assert.Throws<ArgumentNullException>(() => { l.CopyTo(null, 0); }, "3.null");
+
+            var a3 = new byte[2];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a3, 0); }, "3.Short array");
+
+            var a4 = new byte[3];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 1); }, "3.Start index 1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { l.CopyTo(a4, -1); }, "3.Negative start index");
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 3); }, "3.Start index 3");
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Uint8ClampedArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Uint8ClampedArrayTests.cs
@@ -320,5 +320,19 @@ namespace Bridge.ClientTest.Collections.Native
         //    var list = (IReadOnlyList<byte>)new Uint8ClampedArray(new byte[] { 3, 6, 2, 9, 5 });
         //    Assert.AreEqual(list[3], 9, "Get item");
         //}
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            var list = (IList<float>)new Uint8ClampedArray(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
+
+        [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            var list = (ICollection<float>)new Uint8ClampedArray(new float[0]);
+            Assert.True(list.IsReadOnly);
+        }
     }
 }

--- a/Tests/Batch1/Collections/Native/Uint8ClampedArrayTests.cs
+++ b/Tests/Batch1/Collections/Native/Uint8ClampedArrayTests.cs
@@ -334,5 +334,37 @@ namespace Bridge.ClientTest.Collections.Native
             var list = (ICollection<float>)new Uint8ClampedArray(new float[0]);
             Assert.True(list.IsReadOnly);
         }
+
+        [Test]
+        public void ICollectionCopyTo()
+        {
+            ICollection<byte> l = new Uint8ClampedArray(new byte[] { 0, 1, 2 });
+
+            var a1 = new byte[3];
+            l.CopyTo(a1, 0);
+
+            Assert.AreEqual(0, a1[0], "1.Element 0");
+            Assert.AreEqual(1, a1[1], "1.Element 1");
+            Assert.AreEqual(2, a1[2], "1.Element 2");
+
+            var a2 = new byte[5];
+            l.CopyTo(a2, 1);
+
+            Assert.AreEqual(0, a2[0], "2.Element 0");
+            Assert.AreEqual(0, a2[1], "2.Element 1");
+            Assert.AreEqual(1, a2[2], "2.Element 2");
+            Assert.AreEqual(2, a2[3], "2.Element 3");
+            Assert.AreEqual(0, a2[4], "2.Element 4");
+
+            Assert.Throws<ArgumentNullException>(() => { l.CopyTo(null, 0); }, "3.null");
+
+            var a3 = new byte[2];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a3, 0); }, "3.Short array");
+
+            var a4 = new byte[3];
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 1); }, "3.Start index 1");
+            Assert.Throws<ArgumentOutOfRangeException>(() => { l.CopyTo(a4, -1); }, "3.Negative start index");
+            Assert.Throws<ArgumentException>(() => { l.CopyTo(a4, 3); }, "3.Start index 3");
+        }
     }
 }

--- a/Tests/Batch1/Collections/ObjectModel/ReadOnlyCollectionTests.cs
+++ b/Tests/Batch1/Collections/ObjectModel/ReadOnlyCollectionTests.cs
@@ -276,6 +276,13 @@ namespace Bridge.ClientTest.Collections.Generic
         }
 
         [Test]
+        public void ICollectionIsReadOnlyWorks()
+        {
+            ICollection<string> l = new ReadOnlyCollection<string>(new string[0]);
+            Assert.True(l.IsReadOnly);
+        }
+
+        [Test]
         public void ICollectionContainsWorks()
         {
             IList<string> l = new ReadOnlyCollection<string>(new[] { "x", "y", "z" });
@@ -312,6 +319,13 @@ namespace Bridge.ClientTest.Collections.Generic
             IList<C> l = new ReadOnlyCollection<C>(new[] { new C(1), new C(2), new C(3) });
             Assert.AreEqual(1, l.IndexOf(new C(2)));
             Assert.AreEqual(-1, l.IndexOf(new C(4)));
+        }
+
+        [Test]
+        public void IListIsReadOnlyWorks()
+        {
+            IList<string> l = new ReadOnlyCollection<string>(new string[0]);
+            Assert.True(l.IsReadOnly);
         }
     }
 }

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -339,6 +339,7 @@
     <Compile Include="BridgeIssues\1800\N1802.cs" />
     <Compile Include="BridgeIssues\1800\N1803.cs" />
     <Compile Include="BridgeIssues\1800\N1804.cs" />
+    <Compile Include="BridgeIssues\1800\N1810.cs" />
     <Compile Include="BridgeIssues\1800\N1812.cs" />
     <Compile Include="BridgeIssues\1800\N1813.cs" />
     <Compile Include="BridgeIssues\1800\N1814.cs" />

--- a/Tests/Batch3/BridgeIssues/1700/N1768.cs
+++ b/Tests/Batch3/BridgeIssues/1700/N1768.cs
@@ -91,6 +91,14 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
                 }
             }
 
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
             void ICollection<T>.Add(T item)
             {
             }
@@ -158,6 +166,14 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
                 get
                 {
                     return 1000;
+                }
+            }
+
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return false;
                 }
             }
 
@@ -238,6 +254,7 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             Assert.AreEqual(0, list[0]);
             Assert.True(list.Contains(0));
             Assert.AreEqual(100, list.Count);
+            Assert.True(list.IsReadOnly);
             Assert.Null(list.GetEnumerator());
             Assert.AreEqual(200, list.IndexOf(0));
             Assert.True(list.Remove(0));
@@ -254,6 +271,7 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             Assert.AreEqual(0, list[0]);
             Assert.True(list.Contains(0));
             Assert.AreEqual(1000, list.Count);
+            Assert.False(list.IsReadOnly);
             Assert.Null(list.GetEnumerator());
             Assert.AreEqual(2000, list.IndexOf(0));
             Assert.True(list.Remove(0));
@@ -265,6 +283,7 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             Assert.AreEqual(0, list2[0]);
             Assert.True(list2.Contains(0));
             Assert.AreEqual(1000, list2.Count);
+            Assert.False(list.IsReadOnly);
             Assert.Null(list2.GetEnumerator());
             Assert.AreEqual(2000, list2.IndexOf(0));
             Assert.True(list2.Remove(0));

--- a/Tests/Batch3/BridgeIssues/1800/N1810.cs
+++ b/Tests/Batch3/BridgeIssues/1800/N1810.cs
@@ -1,0 +1,111 @@
+using Bridge.Test;
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#1810 - {0}")]
+    public class Bridge1810
+    {
+        // https://github.com/bridgedotnet/Bridge/issues/1025#issuecomment-245424630
+        // https://github.com/bridgedotnet/Bridge/issues/1025#issuecomment-246532630
+        [Test]
+        public void TestInterfaceIndexersAndCopyToAndIsReadOnly()
+        {
+            var l = new C<int>();
+            Assert.NotNull(l, "IList created");
+
+            var c = l as ICollection<int>;
+            Assert.True(c.IsReadOnly, "IsReadOnly");
+
+            var a = new int[] { 1, 2 };
+            c.CopyTo(a, 0);
+            Assert.AreEqual(0, a[0], "CopyTo()");
+        }
+
+        class C<T> : IList<T>
+        {
+            T IList<T>.this[int index]
+            {
+                get
+                {
+                    return default(T);
+                }
+
+                set
+                {
+
+                }
+            }
+
+            int ICollection<T>.Count
+            {
+                get
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            bool ICollection<T>.IsReadOnly
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            void ICollection<T>.Add(T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            void ICollection<T>.Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            bool ICollection<T>.Contains(T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            void ICollection<T>.CopyTo(T[] array, int arrayIndex)
+            {
+                array[0] = default(T);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator<T> IEnumerable<T>.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            int IList<T>.IndexOf(T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IList<T>.Insert(int index, T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            bool ICollection<T>.Remove(T item)
+            {
+                throw new NotImplementedException();
+            }
+
+            void IList<T>.RemoveAt(int index)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Tests/Batch4/Collections/Generic/ICollectionTests.cs
+++ b/Tests/Batch4/Collections/Generic/ICollectionTests.cs
@@ -38,6 +38,14 @@ namespace Bridge.ClientTest.Batch4.Collections.Generic
                 }
             }
 
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
             public void Add(string item)
             {
                 Items.Add(item);

--- a/Tests/Batch4/Collections/Generic/IListTests.cs
+++ b/Tests/Batch4/Collections/Generic/IListTests.cs
@@ -39,6 +39,14 @@ namespace Bridge.ClientTest.Batch4.Collections.Generic
                 }
             }
 
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
             public void Add(string item)
             {
                 Items.Add(item);

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -8780,6 +8780,21 @@
             return 0;
         },
 
+        getIsReadOnly: function (obj, T) {
+            var name;
+            if (Bridge.isArray(obj)) {
+                return T ? true : false;
+            } else if (Bridge.isFunction(obj[name = "System$Collections$ICollection$getIsReadOnly"])) {
+                return obj[name]();
+            } else if (T && Bridge.isFunction(obj[name = "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly"])) {
+                return obj[name]();
+            } else if (Bridge.isFunction(obj.getIsReadOnly)) {
+                return obj.getIsReadOnly();
+            }
+
+            return 0;
+        },
+
         add: function (obj, item, T) {
             var name;
             if (Bridge.isArray(obj)) {
@@ -8853,7 +8868,7 @@
             } else if (Bridge.isFunction(obj.copyTo)) {
                 obj.copyTo(dest, index);
             } else if (T && Bridge.isFunction(obj[name = "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$copyTo"])) {
-                return obj[name](dest, index);
+                obj[name](dest, index);
             } else {
                 throw new System.NotImplementedException("copyTo");
             }
@@ -10015,6 +10030,7 @@
                 "getItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$getItem",
                 "setItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$setItem",
                 "getCount", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getCount",
+                "getIsReadOnly", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly",
                 "add", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$add",
                 "clear", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$clear",
                 "contains", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$contains",
@@ -10046,6 +10062,10 @@
 
             getCount: function () {
                 return this.items.length;
+            },
+
+            getIsReadOnly: function () {
+                return !!this.readOnly;
             },
 
             get: function (index) {

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -325,6 +325,10 @@
             var l = ["x", "y", "z"];
             Bridge.Test.Assert.areEqual(3, System.Array.getCount(l, String));
         },
+        iCollectionIsReadOnlyWorks: function () {
+            var l = ["x", "y", "z"];
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(l, String));
+        },
         iCollectionAddWorks: function () {
             var l = ["x", "y", "z"];
             System.Array.add(l, "a", String);
@@ -398,6 +402,10 @@
             Bridge.Test.Assert.true(System.Array.remove(l, "y", String));
             Bridge.Test.Assert.false(System.Array.remove(l, "a", String));
             Bridge.Test.Assert.areDeepEqual(["x", "z"], l);
+        },
+        iListIsReadOnlyWorks: function () {
+            var l = ["x", "y", "z"];
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(l, String));
         },
         iListIndexingWorks: function () {
             var l = ["x", "y", "z"];
@@ -5202,6 +5210,15 @@
         classImplementingICollectionCastToICollectionCountWorks: function () {
             Bridge.Test.Assert.areEqual(3, System.Array.getCount(Bridge.cast(new Bridge.ClientTest.Collections.Generic.ICollectionTests.MyCollection(["x", "y", "z"]), System.Collections.Generic.ICollection$1(String)), String));
         },
+        arrayCastToICollectionIsReadOnlyWorks: function () {
+            Bridge.Test.Assert.areEqual(true, System.Array.getIsReadOnly(Bridge.cast(["x", "y", "z"], System.Collections.Generic.ICollection$1(String)), String));
+        },
+        classImplementingICollectionIsReadOnlyWorks: function () {
+            Bridge.Test.Assert.areEqual(true, new Bridge.ClientTest.Collections.Generic.ICollectionTests.MyCollection(["x", "y"]).getIsReadOnly());
+        },
+        classImplementingICollectionCastToICollectionIsReadOnlyWorks: function () {
+            Bridge.Test.Assert.areEqual(true, System.Array.getIsReadOnly(Bridge.cast(new Bridge.ClientTest.Collections.Generic.ICollectionTests.MyCollection(["x", "y", "z"]), System.Collections.Generic.ICollection$1(String)), String));
+        },
         classImplementingICollectionAddWorks: function () {
             var c = new Bridge.ClientTest.Collections.Generic.ICollectionTests.MyCollection(["x", "y"]);
             c.add("z");
@@ -5352,6 +5369,7 @@
             alias: [
             "getEnumerator", "System$Collections$Generic$IEnumerable$1$String$getEnumerator",
             "getCount", "System$Collections$Generic$ICollection$1$String$getCount",
+            "getIsReadOnly", "System$Collections$Generic$ICollection$1$String$getIsReadOnly",
             "copyTo", "System$Collections$Generic$ICollection$1$String$copyTo",
             "add", "System$Collections$Generic$ICollection$1$String$add",
             "clear", "System$Collections$Generic$ICollection$1$String$clear",
@@ -5365,6 +5383,9 @@
         },
         getCount: function () {
             return this.getItems().getCount();
+        },
+        getIsReadOnly: function () {
+            return true;
         },
         System$Collections$IEnumerable$getEnumerator: function () {
             return this.getEnumerator();
@@ -5787,6 +5808,18 @@
             System.Array.setItem(l, 1, "a", String);
             Bridge.Test.Assert.areEqual("a", System.Array.getItem(l, 1, String));
         },
+        arrayCastToIListIsReadOnlyWorks: function () {
+            var arr = [new Bridge.ClientTest.Collections.Generic.IListTests.C(1), new Bridge.ClientTest.Collections.Generic.IListTests.C(2), new Bridge.ClientTest.Collections.Generic.IListTests.C(3)];
+            Bridge.Test.Assert.areEqual(true, System.Array.getIsReadOnly(arr, Bridge.ClientTest.Collections.Generic.IListTests.C));
+        },
+        classImplementingIListIsReadOnlyWorks: function () {
+            var c = new Bridge.ClientTest.Collections.Generic.IListTests.MyList(["x", "y"]);
+            Bridge.Test.Assert.areEqual(true, c.getIsReadOnly());
+        },
+        classImplementingIListCastToIListIsReadOnlyWorks: function () {
+            var l = new Bridge.ClientTest.Collections.Generic.IListTests.MyList(["x", "y"]);
+            Bridge.Test.Assert.areEqual(true, System.Array.getIsReadOnly(l, String));
+        },
         arrayCastToIListIndexOfWorks: function () {
             var arr = [new Bridge.ClientTest.Collections.Generic.IListTests.C(1), new Bridge.ClientTest.Collections.Generic.IListTests.C(2), new Bridge.ClientTest.Collections.Generic.IListTests.C(3)];
             Bridge.Test.Assert.areEqual(1, System.Array.indexOf(arr, new Bridge.ClientTest.Collections.Generic.IListTests.C(2), 0, null, Bridge.ClientTest.Collections.Generic.IListTests.C));
@@ -5921,6 +5954,7 @@
             alias: [
             "getEnumerator", "System$Collections$Generic$IEnumerable$1$String$getEnumerator",
             "getCount", "System$Collections$Generic$ICollection$1$String$getCount",
+            "getIsReadOnly", "System$Collections$Generic$ICollection$1$String$getIsReadOnly",
             "add", "System$Collections$Generic$ICollection$1$String$add",
             "clear", "System$Collections$Generic$ICollection$1$String$clear",
             "contains", "System$Collections$Generic$ICollection$1$String$contains",
@@ -5939,6 +5973,9 @@
         },
         getCount: function () {
             return this.getItems().getCount();
+        },
+        getIsReadOnly: function () {
+            return true;
         },
         getItem: function (index) {
             return this.getItems().getItem(index);
@@ -7179,6 +7216,10 @@
             var l = new (System.Collections.ObjectModel.ReadOnlyCollection$1(String))(["x", "y", "z"]);
             Bridge.Test.Assert.areEqual(3, System.Array.getCount(l, String));
         },
+        iCollectionIsReadOnlyWorks: function () {
+            var l = new (System.Collections.ObjectModel.ReadOnlyCollection$1(String))(System.Array.init(0, null));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(l, String));
+        },
         iCollectionContainsWorks: function () {
             var l = new (System.Collections.ObjectModel.ReadOnlyCollection$1(String))(["x", "y", "z"]);
             Bridge.Test.Assert.true(System.Array.contains(l, "y", String));
@@ -7202,6 +7243,10 @@
             var l = new (System.Collections.ObjectModel.ReadOnlyCollection$1(Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests.C))([new Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests.C(1), new Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests.C(2), new Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests.C(3)]);
             Bridge.Test.Assert.areEqual(1, System.Array.indexOf(l, new Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests.C(2), 0, null, Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests.C));
             Bridge.Test.Assert.areEqual(-1, System.Array.indexOf(l, new Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests.C(4), 0, null, Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests.C));
+        },
+        iListIsReadOnlyWorks: function () {
+            var l = new (System.Collections.ObjectModel.ReadOnlyCollection$1(String))(System.Array.init(0, null));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(l, String));
         }
     });
 
@@ -7674,6 +7719,14 @@
 
             //Assert.Throws<NotSupportedException>(() => list.Insert(2, 2), "Insert");
             //Assert.Throws<NotSupportedException>(() => list.RemoveAt(2), "RemoveAt");
+        },
+        iListIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Float32Array(System.Array.init(0, 0)), System.Collections.Generic.IList$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Float32Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
         }
     });
 
@@ -7855,6 +7908,14 @@
 
             //Assert.Throws<NotSupportedException>(() => list.Insert(2, 2), "Insert");
             //Assert.Throws<NotSupportedException>(() => list.RemoveAt(2), "RemoveAt");
+        },
+        iListIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Float64Array(System.Array.init(0, 0)), System.Collections.Generic.IList$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Float64Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
         }
     });
 
@@ -8036,6 +8097,14 @@
 
             //Assert.Throws<NotSupportedException>(() => list.Insert(2, 2), "Insert");
             //Assert.Throws<NotSupportedException>(() => list.RemoveAt(2), "RemoveAt");
+        },
+        iListIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Int16Array(System.Array.init(0, 0)), System.Collections.Generic.IList$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Int16Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
         }
     });
 
@@ -8217,6 +8286,14 @@
 
             //Assert.Throws<NotSupportedException>(() => list.Insert(2, 2), "Insert");
             //Assert.Throws<NotSupportedException>(() => list.RemoveAt(2), "RemoveAt");
+        },
+        iListIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Int32Array(System.Array.init(0, 0)), System.Collections.Generic.IList$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Int32Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
         }
     });
 
@@ -8398,6 +8475,14 @@
 
             //Assert.Throws<NotSupportedException>(() => list.Insert(2, 2), "Insert");
             //Assert.Throws<NotSupportedException>(() => list.RemoveAt(2), "RemoveAt");
+        },
+        iListIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Int8Array(System.Array.init(0, 0)), System.Collections.Generic.IList$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Int8Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
         }
     });
 
@@ -8579,6 +8664,14 @@
 
             //Assert.Throws<NotSupportedException>(() => list.Insert(2, 2), "Insert");
             //Assert.Throws(() => list.RemoveAt(2), "RemoveAt");
+        },
+        iListIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Uint16Array(System.Array.init(0, 0)), System.Collections.Generic.IList$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Uint16Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
         }
     });
 
@@ -8760,6 +8853,14 @@
 
             //Assert.Throws<NotSupportedException>(() => list.Insert(2, 2), "Insert");
             //Assert.Throws<NotSupportedException>(() => list.RemoveAt(2), "RemoveAt");
+        },
+        iListIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Uint32Array(System.Array.init(0, 0)), System.Collections.Generic.IList$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Uint32Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
         }
     });
 
@@ -8941,6 +9042,14 @@
 
             //Assert.Throws<NotSupportedException>(() => list.Insert(2, 2), "Insert");
             //Assert.Throws(() => list.RemoveAt(2), "RemoveAt");
+        },
+        iListIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Uint8Array(System.Array.init(0, 0)), System.Collections.Generic.IList$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Uint8Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
         }
     });
 
@@ -9125,6 +9234,14 @@
 
             //Assert.Throws<NotSupportedException>(() => list.Insert(2, 2), "Insert");
             //Assert.Throws<NotSupportedException>(() => list.RemoveAt(2), "RemoveAt");
+        },
+        iListIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Uint8ClampedArray(System.Array.init(0, 0)), System.Collections.Generic.IList$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionIsReadOnlyWorks: function () {
+            var list = Bridge.cast(new Uint8ClampedArray(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
         }
     });
 

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -7727,6 +7727,45 @@
         iCollectionIsReadOnlyWorks: function () {
             var list = Bridge.cast(new Float32Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
             Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionCopyTo: function () {
+            var l = new Float32Array([0, 1, 2]);
+
+            var a1 = System.Array.init(3, 0);
+            System.Array.copyTo(l, a1, 0, System.Single);
+
+            Bridge.Test.Assert.areEqual$1(0, a1[0], "1.Element 0");
+            Bridge.Test.Assert.areEqual$1(1, a1[1], "1.Element 1");
+            Bridge.Test.Assert.areEqual$1(2, a1[2], "1.Element 2");
+
+            var a2 = System.Array.init(5, 0);
+            System.Array.copyTo(l, a2, 1, System.Single);
+
+            Bridge.Test.Assert.areEqual$1(0, a2[0], "2.Element 0");
+            Bridge.Test.Assert.areEqual$1(0, a2[1], "2.Element 1");
+            Bridge.Test.Assert.areEqual$1(1, a2[2], "2.Element 2");
+            Bridge.Test.Assert.areEqual$1(2, a2[3], "2.Element 3");
+            Bridge.Test.Assert.areEqual$1(0, a2[4], "2.Element 4");
+
+            Bridge.Test.Assert.throws$7(System.ArgumentNullException, function () {
+                System.Array.copyTo(l, null, 0, System.Single);
+            }, "3.null");
+
+            var a3 = System.Array.init(2, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a3, 0, System.Single);
+            }, "3.Short array");
+
+            var a4 = System.Array.init(3, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 1, System.Single);
+            }, "3.Start index 1");
+            Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, function () {
+                System.Array.copyTo(l, a4, -1, System.Single);
+            }, "3.Negative start index");
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 3, System.Single);
+            }, "3.Start index 3");
         }
     });
 
@@ -7916,6 +7955,45 @@
         iCollectionIsReadOnlyWorks: function () {
             var list = Bridge.cast(new Float64Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
             Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionCopyTo: function () {
+            var l = new Float64Array([0, 1, 2]);
+
+            var a1 = System.Array.init(3, 0);
+            System.Array.copyTo(l, a1, 0, System.Double);
+
+            Bridge.Test.Assert.areEqual$1(0, a1[0], "1.Element 0");
+            Bridge.Test.Assert.areEqual$1(1, a1[1], "1.Element 1");
+            Bridge.Test.Assert.areEqual$1(2, a1[2], "1.Element 2");
+
+            var a2 = System.Array.init(5, 0);
+            System.Array.copyTo(l, a2, 1, System.Double);
+
+            Bridge.Test.Assert.areEqual$1(0, a2[0], "2.Element 0");
+            Bridge.Test.Assert.areEqual$1(0, a2[1], "2.Element 1");
+            Bridge.Test.Assert.areEqual$1(1, a2[2], "2.Element 2");
+            Bridge.Test.Assert.areEqual$1(2, a2[3], "2.Element 3");
+            Bridge.Test.Assert.areEqual$1(0, a2[4], "2.Element 4");
+
+            Bridge.Test.Assert.throws$7(System.ArgumentNullException, function () {
+                System.Array.copyTo(l, null, 0, System.Double);
+            }, "3.null");
+
+            var a3 = System.Array.init(2, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a3, 0, System.Double);
+            }, "3.Short array");
+
+            var a4 = System.Array.init(3, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 1, System.Double);
+            }, "3.Start index 1");
+            Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, function () {
+                System.Array.copyTo(l, a4, -1, System.Double);
+            }, "3.Negative start index");
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 3, System.Double);
+            }, "3.Start index 3");
         }
     });
 
@@ -8105,6 +8183,45 @@
         iCollectionIsReadOnlyWorks: function () {
             var list = Bridge.cast(new Int16Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
             Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionCopyTo: function () {
+            var l = new Int16Array([0, 1, 2]);
+
+            var a1 = System.Array.init(3, 0);
+            System.Array.copyTo(l, a1, 0, System.Int16);
+
+            Bridge.Test.Assert.areEqual$1(0, a1[0], "1.Element 0");
+            Bridge.Test.Assert.areEqual$1(1, a1[1], "1.Element 1");
+            Bridge.Test.Assert.areEqual$1(2, a1[2], "1.Element 2");
+
+            var a2 = System.Array.init(5, 0);
+            System.Array.copyTo(l, a2, 1, System.Int16);
+
+            Bridge.Test.Assert.areEqual$1(0, a2[0], "2.Element 0");
+            Bridge.Test.Assert.areEqual$1(0, a2[1], "2.Element 1");
+            Bridge.Test.Assert.areEqual$1(1, a2[2], "2.Element 2");
+            Bridge.Test.Assert.areEqual$1(2, a2[3], "2.Element 3");
+            Bridge.Test.Assert.areEqual$1(0, a2[4], "2.Element 4");
+
+            Bridge.Test.Assert.throws$7(System.ArgumentNullException, function () {
+                System.Array.copyTo(l, null, 0, System.Int16);
+            }, "3.null");
+
+            var a3 = System.Array.init(2, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a3, 0, System.Int16);
+            }, "3.Short array");
+
+            var a4 = System.Array.init(3, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 1, System.Int16);
+            }, "3.Start index 1");
+            Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, function () {
+                System.Array.copyTo(l, a4, -1, System.Int16);
+            }, "3.Negative start index");
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 3, System.Int16);
+            }, "3.Start index 3");
         }
     });
 
@@ -8294,6 +8411,45 @@
         iCollectionIsReadOnlyWorks: function () {
             var list = Bridge.cast(new Int32Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
             Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionCopyTo: function () {
+            var l = new Int32Array([0, 1, 2]);
+
+            var a1 = System.Array.init(3, 0);
+            System.Array.copyTo(l, a1, 0, System.Int32);
+
+            Bridge.Test.Assert.areEqual$1(0, a1[0], "1.Element 0");
+            Bridge.Test.Assert.areEqual$1(1, a1[1], "1.Element 1");
+            Bridge.Test.Assert.areEqual$1(2, a1[2], "1.Element 2");
+
+            var a2 = System.Array.init(5, 0);
+            System.Array.copyTo(l, a2, 1, System.Int32);
+
+            Bridge.Test.Assert.areEqual$1(0, a2[0], "2.Element 0");
+            Bridge.Test.Assert.areEqual$1(0, a2[1], "2.Element 1");
+            Bridge.Test.Assert.areEqual$1(1, a2[2], "2.Element 2");
+            Bridge.Test.Assert.areEqual$1(2, a2[3], "2.Element 3");
+            Bridge.Test.Assert.areEqual$1(0, a2[4], "2.Element 4");
+
+            Bridge.Test.Assert.throws$7(System.ArgumentNullException, function () {
+                System.Array.copyTo(l, null, 0, System.Int32);
+            }, "3.null");
+
+            var a3 = System.Array.init(2, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a3, 0, System.Int32);
+            }, "3.Short array");
+
+            var a4 = System.Array.init(3, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 1, System.Int32);
+            }, "3.Start index 1");
+            Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, function () {
+                System.Array.copyTo(l, a4, -1, System.Int32);
+            }, "3.Negative start index");
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 3, System.Int32);
+            }, "3.Start index 3");
         }
     });
 
@@ -8483,6 +8639,45 @@
         iCollectionIsReadOnlyWorks: function () {
             var list = Bridge.cast(new Int8Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
             Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionCopyTo: function () {
+            var l = new Int8Array([0, 1, 2]);
+
+            var a1 = System.Array.init(3, 0);
+            System.Array.copyTo(l, a1, 0, System.SByte);
+
+            Bridge.Test.Assert.areEqual$1(0, a1[0], "1.Element 0");
+            Bridge.Test.Assert.areEqual$1(1, a1[1], "1.Element 1");
+            Bridge.Test.Assert.areEqual$1(2, a1[2], "1.Element 2");
+
+            var a2 = System.Array.init(5, 0);
+            System.Array.copyTo(l, a2, 1, System.SByte);
+
+            Bridge.Test.Assert.areEqual$1(0, a2[0], "2.Element 0");
+            Bridge.Test.Assert.areEqual$1(0, a2[1], "2.Element 1");
+            Bridge.Test.Assert.areEqual$1(1, a2[2], "2.Element 2");
+            Bridge.Test.Assert.areEqual$1(2, a2[3], "2.Element 3");
+            Bridge.Test.Assert.areEqual$1(0, a2[4], "2.Element 4");
+
+            Bridge.Test.Assert.throws$7(System.ArgumentNullException, function () {
+                System.Array.copyTo(l, null, 0, System.SByte);
+            }, "3.null");
+
+            var a3 = System.Array.init(2, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a3, 0, System.SByte);
+            }, "3.Short array");
+
+            var a4 = System.Array.init(3, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 1, System.SByte);
+            }, "3.Start index 1");
+            Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, function () {
+                System.Array.copyTo(l, a4, -1, System.SByte);
+            }, "3.Negative start index");
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 3, System.SByte);
+            }, "3.Start index 3");
         }
     });
 
@@ -8672,6 +8867,45 @@
         iCollectionIsReadOnlyWorks: function () {
             var list = Bridge.cast(new Uint16Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
             Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionCopyTo: function () {
+            var l = new Uint16Array([0, 1, 2]);
+
+            var a1 = System.Array.init(3, 0);
+            System.Array.copyTo(l, a1, 0, System.UInt16);
+
+            Bridge.Test.Assert.areEqual$1(0, a1[0], "1.Element 0");
+            Bridge.Test.Assert.areEqual$1(1, a1[1], "1.Element 1");
+            Bridge.Test.Assert.areEqual$1(2, a1[2], "1.Element 2");
+
+            var a2 = System.Array.init(5, 0);
+            System.Array.copyTo(l, a2, 1, System.UInt16);
+
+            Bridge.Test.Assert.areEqual$1(0, a2[0], "2.Element 0");
+            Bridge.Test.Assert.areEqual$1(0, a2[1], "2.Element 1");
+            Bridge.Test.Assert.areEqual$1(1, a2[2], "2.Element 2");
+            Bridge.Test.Assert.areEqual$1(2, a2[3], "2.Element 3");
+            Bridge.Test.Assert.areEqual$1(0, a2[4], "2.Element 4");
+
+            Bridge.Test.Assert.throws$7(System.ArgumentNullException, function () {
+                System.Array.copyTo(l, null, 0, System.UInt16);
+            }, "3.null");
+
+            var a3 = System.Array.init(2, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a3, 0, System.UInt16);
+            }, "3.Short array");
+
+            var a4 = System.Array.init(3, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 1, System.UInt16);
+            }, "3.Start index 1");
+            Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, function () {
+                System.Array.copyTo(l, a4, -1, System.UInt16);
+            }, "3.Negative start index");
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 3, System.UInt16);
+            }, "3.Start index 3");
         }
     });
 
@@ -8861,6 +9095,45 @@
         iCollectionIsReadOnlyWorks: function () {
             var list = Bridge.cast(new Uint32Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
             Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionCopyTo: function () {
+            var l = new Uint32Array([0, 1, 2]);
+
+            var a1 = System.Array.init(3, 0);
+            System.Array.copyTo(l, a1, 0, System.UInt32);
+
+            Bridge.Test.Assert.areEqual$1(0, a1[0], "1.Element 0");
+            Bridge.Test.Assert.areEqual$1(1, a1[1], "1.Element 1");
+            Bridge.Test.Assert.areEqual$1(2, a1[2], "1.Element 2");
+
+            var a2 = System.Array.init(5, 0);
+            System.Array.copyTo(l, a2, 1, System.UInt32);
+
+            Bridge.Test.Assert.areEqual$1(0, a2[0], "2.Element 0");
+            Bridge.Test.Assert.areEqual$1(0, a2[1], "2.Element 1");
+            Bridge.Test.Assert.areEqual$1(1, a2[2], "2.Element 2");
+            Bridge.Test.Assert.areEqual$1(2, a2[3], "2.Element 3");
+            Bridge.Test.Assert.areEqual$1(0, a2[4], "2.Element 4");
+
+            Bridge.Test.Assert.throws$7(System.ArgumentNullException, function () {
+                System.Array.copyTo(l, null, 0, System.UInt32);
+            }, "3.null");
+
+            var a3 = System.Array.init(2, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a3, 0, System.UInt32);
+            }, "3.Short array");
+
+            var a4 = System.Array.init(3, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 1, System.UInt32);
+            }, "3.Start index 1");
+            Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, function () {
+                System.Array.copyTo(l, a4, -1, System.UInt32);
+            }, "3.Negative start index");
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 3, System.UInt32);
+            }, "3.Start index 3");
         }
     });
 
@@ -9050,6 +9323,45 @@
         iCollectionIsReadOnlyWorks: function () {
             var list = Bridge.cast(new Uint8Array(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
             Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionCopyTo: function () {
+            var l = new Uint8Array([0, 1, 2]);
+
+            var a1 = System.Array.init(3, 0);
+            System.Array.copyTo(l, a1, 0, System.Byte);
+
+            Bridge.Test.Assert.areEqual$1(0, a1[0], "1.Element 0");
+            Bridge.Test.Assert.areEqual$1(1, a1[1], "1.Element 1");
+            Bridge.Test.Assert.areEqual$1(2, a1[2], "1.Element 2");
+
+            var a2 = System.Array.init(5, 0);
+            System.Array.copyTo(l, a2, 1, System.Byte);
+
+            Bridge.Test.Assert.areEqual$1(0, a2[0], "2.Element 0");
+            Bridge.Test.Assert.areEqual$1(0, a2[1], "2.Element 1");
+            Bridge.Test.Assert.areEqual$1(1, a2[2], "2.Element 2");
+            Bridge.Test.Assert.areEqual$1(2, a2[3], "2.Element 3");
+            Bridge.Test.Assert.areEqual$1(0, a2[4], "2.Element 4");
+
+            Bridge.Test.Assert.throws$7(System.ArgumentNullException, function () {
+                System.Array.copyTo(l, null, 0, System.Byte);
+            }, "3.null");
+
+            var a3 = System.Array.init(2, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a3, 0, System.Byte);
+            }, "3.Short array");
+
+            var a4 = System.Array.init(3, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 1, System.Byte);
+            }, "3.Start index 1");
+            Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, function () {
+                System.Array.copyTo(l, a4, -1, System.Byte);
+            }, "3.Negative start index");
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 3, System.Byte);
+            }, "3.Start index 3");
         }
     });
 
@@ -9242,6 +9554,45 @@
         iCollectionIsReadOnlyWorks: function () {
             var list = Bridge.cast(new Uint8ClampedArray(System.Array.init(0, 0)), System.Collections.Generic.ICollection$1(System.Single));
             Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Single));
+        },
+        iCollectionCopyTo: function () {
+            var l = new Uint8ClampedArray([0, 1, 2]);
+
+            var a1 = System.Array.init(3, 0);
+            System.Array.copyTo(l, a1, 0, System.Byte);
+
+            Bridge.Test.Assert.areEqual$1(0, a1[0], "1.Element 0");
+            Bridge.Test.Assert.areEqual$1(1, a1[1], "1.Element 1");
+            Bridge.Test.Assert.areEqual$1(2, a1[2], "1.Element 2");
+
+            var a2 = System.Array.init(5, 0);
+            System.Array.copyTo(l, a2, 1, System.Byte);
+
+            Bridge.Test.Assert.areEqual$1(0, a2[0], "2.Element 0");
+            Bridge.Test.Assert.areEqual$1(0, a2[1], "2.Element 1");
+            Bridge.Test.Assert.areEqual$1(1, a2[2], "2.Element 2");
+            Bridge.Test.Assert.areEqual$1(2, a2[3], "2.Element 3");
+            Bridge.Test.Assert.areEqual$1(0, a2[4], "2.Element 4");
+
+            Bridge.Test.Assert.throws$7(System.ArgumentNullException, function () {
+                System.Array.copyTo(l, null, 0, System.Byte);
+            }, "3.null");
+
+            var a3 = System.Array.init(2, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a3, 0, System.Byte);
+            }, "3.Short array");
+
+            var a4 = System.Array.init(3, 0);
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 1, System.Byte);
+            }, "3.Start index 1");
+            Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, function () {
+                System.Array.copyTo(l, a4, -1, System.Byte);
+            }, "3.Negative start index");
+            Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
+                System.Array.copyTo(l, a4, 3, System.Byte);
+            }, "3.Start index 3");
         }
     });
 

--- a/Tests/Runner/Batch1/test.js
+++ b/Tests/Runner/Batch1/test.js
@@ -2349,6 +2349,7 @@
             QUnit.test("Float32ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests.iListMethodsWork_SPI_1559);
             QUnit.test("Float32ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests.iListIsReadOnlyWorks);
             QUnit.test("Float32ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests.iCollectionIsReadOnlyWorks);
+            QUnit.test("Float32ArrayTests - ICollectionCopyTo", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests.iCollectionCopyTo);
             QUnit.test("Float64ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.lengthConstructorWorks);
             QUnit.test("Float64ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.constructorFromIntWorks);
             QUnit.test("Float64ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.copyConstructorWorks);
@@ -2376,6 +2377,7 @@
             QUnit.test("Float64ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.iListMethodsWork_SPI_1559);
             QUnit.test("Float64ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.iListIsReadOnlyWorks);
             QUnit.test("Float64ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.iCollectionIsReadOnlyWorks);
+            QUnit.test("Float64ArrayTests - ICollectionCopyTo", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.iCollectionCopyTo);
             QUnit.test("Int16ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.lengthConstructorWorks);
             QUnit.test("Int16ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.constructorFromIntWorks);
             QUnit.test("Int16ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.copyConstructorWorks);
@@ -2403,6 +2405,7 @@
             QUnit.test("Int16ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.iListMethodsWork_SPI_1559);
             QUnit.test("Int16ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.iListIsReadOnlyWorks);
             QUnit.test("Int16ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.iCollectionIsReadOnlyWorks);
+            QUnit.test("Int16ArrayTests - ICollectionCopyTo", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.iCollectionCopyTo);
             QUnit.test("Int32ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.lengthConstructorWorks);
             QUnit.test("Int32ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.constructorFromIntWorks);
             QUnit.test("Int32ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.copyConstructorWorks);
@@ -2430,6 +2433,7 @@
             QUnit.test("Int32ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.iListMethodsWork_SPI_1559);
             QUnit.test("Int32ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.iListIsReadOnlyWorks);
             QUnit.test("Int32ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.iCollectionIsReadOnlyWorks);
+            QUnit.test("Int32ArrayTests - ICollectionCopyTo", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.iCollectionCopyTo);
             QUnit.test("Int8ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.lengthConstructorWorks);
             QUnit.test("Int8ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.constructorFromIntWorks);
             QUnit.test("Int8ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.copyConstructorWorks);
@@ -2457,6 +2461,7 @@
             QUnit.test("Int8ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.iListMethodsWork_SPI_1559);
             QUnit.test("Int8ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.iListIsReadOnlyWorks);
             QUnit.test("Int8ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.iCollectionIsReadOnlyWorks);
+            QUnit.test("Int8ArrayTests - ICollectionCopyTo", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.iCollectionCopyTo);
             QUnit.test("Uint16ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.lengthConstructorWorks);
             QUnit.test("Uint16ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.constructorFromIntWorks);
             QUnit.test("Uint16ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.copyConstructorWorks);
@@ -2484,6 +2489,7 @@
             QUnit.test("Uint16ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.iListMethodsWork_SPI_1559);
             QUnit.test("Uint16ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.iListIsReadOnlyWorks);
             QUnit.test("Uint16ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.iCollectionIsReadOnlyWorks);
+            QUnit.test("Uint16ArrayTests - ICollectionCopyTo", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.iCollectionCopyTo);
             QUnit.test("Uint32ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.lengthConstructorWorks);
             QUnit.test("Uint32ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.constructorFromIntWorks);
             QUnit.test("Uint32ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.copyConstructorWorks);
@@ -2511,6 +2517,7 @@
             QUnit.test("Uint32ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.iListMethodsWork_SPI_1559);
             QUnit.test("Uint32ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.iListIsReadOnlyWorks);
             QUnit.test("Uint32ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.iCollectionIsReadOnlyWorks);
+            QUnit.test("Uint32ArrayTests - ICollectionCopyTo", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.iCollectionCopyTo);
             QUnit.test("Uint8ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.lengthConstructorWorks);
             QUnit.test("Uint8ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.constructorFromIntWorks);
             QUnit.test("Uint8ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.copyConstructorWorks);
@@ -2538,6 +2545,7 @@
             QUnit.test("Uint8ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.iListMethodsWork_SPI_1559);
             QUnit.test("Uint8ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.iListIsReadOnlyWorks);
             QUnit.test("Uint8ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.iCollectionIsReadOnlyWorks);
+            QUnit.test("Uint8ArrayTests - ICollectionCopyTo", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.iCollectionCopyTo);
             QUnit.test("Uint8ClampedArrayTests - TypePropertiesAreCorrect_SPI_1560", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.typePropertiesAreCorrect_SPI_1560);
             QUnit.test("Uint8ClampedArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.lengthConstructorWorks);
             QUnit.test("Uint8ClampedArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.constructorFromIntWorks);
@@ -2566,6 +2574,7 @@
             QUnit.test("Uint8ClampedArrayTests - IListMethodsWork_SPI_1559_1560", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.iListMethodsWork_SPI_1559_1560);
             QUnit.test("Uint8ClampedArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.iListIsReadOnlyWorks);
             QUnit.test("Uint8ClampedArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.iCollectionIsReadOnlyWorks);
+            QUnit.test("Uint8ClampedArrayTests - ICollectionCopyTo", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.iCollectionCopyTo);
             QUnit.module("Utilities");
             QUnit.test("Environment - NewLineIsAStringContainingOnlyTheNewLineChar", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_EnvironmentTests.newLineIsAStringContainingOnlyTheNewLineChar);
             QUnit.module("СultureInfo");
@@ -4327,6 +4336,10 @@
             iCollectionIsReadOnlyWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests);
                 t.getFixture().iCollectionIsReadOnlyWorks();
+            },
+            iCollectionCopyTo: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests);
+                t.getFixture().iCollectionCopyTo();
             }
         }
     });
@@ -4441,6 +4454,10 @@
             iCollectionIsReadOnlyWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float64ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests);
                 t.getFixture().iCollectionIsReadOnlyWorks();
+            },
+            iCollectionCopyTo: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float64ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests);
+                t.getFixture().iCollectionCopyTo();
             }
         }
     });
@@ -4555,6 +4572,10 @@
             iCollectionIsReadOnlyWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests);
                 t.getFixture().iCollectionIsReadOnlyWorks();
+            },
+            iCollectionCopyTo: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests);
+                t.getFixture().iCollectionCopyTo();
             }
         }
     });
@@ -4669,6 +4690,10 @@
             iCollectionIsReadOnlyWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests);
                 t.getFixture().iCollectionIsReadOnlyWorks();
+            },
+            iCollectionCopyTo: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests);
+                t.getFixture().iCollectionCopyTo();
             }
         }
     });
@@ -4783,6 +4808,10 @@
             iCollectionIsReadOnlyWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests);
                 t.getFixture().iCollectionIsReadOnlyWorks();
+            },
+            iCollectionCopyTo: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests);
+                t.getFixture().iCollectionCopyTo();
             }
         }
     });
@@ -4897,6 +4926,10 @@
             iCollectionIsReadOnlyWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests);
                 t.getFixture().iCollectionIsReadOnlyWorks();
+            },
+            iCollectionCopyTo: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests);
+                t.getFixture().iCollectionCopyTo();
             }
         }
     });
@@ -5011,6 +5044,10 @@
             iCollectionIsReadOnlyWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests);
                 t.getFixture().iCollectionIsReadOnlyWorks();
+            },
+            iCollectionCopyTo: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests);
+                t.getFixture().iCollectionCopyTo();
             }
         }
     });
@@ -5125,6 +5162,10 @@
             iCollectionIsReadOnlyWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests);
                 t.getFixture().iCollectionIsReadOnlyWorks();
+            },
+            iCollectionCopyTo: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests);
+                t.getFixture().iCollectionCopyTo();
             }
         }
     });
@@ -5243,6 +5284,10 @@
             iCollectionIsReadOnlyWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ClampedArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests);
                 t.getFixture().iCollectionIsReadOnlyWorks();
+            },
+            iCollectionCopyTo: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ClampedArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests);
+                t.getFixture().iCollectionCopyTo();
             }
         }
     });

--- a/Tests/Runner/Batch1/test.js
+++ b/Tests/Runner/Batch1/test.js
@@ -124,6 +124,7 @@
             QUnit.test("Array - Set1 SortExceptionsWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.sortExceptionsWorks);
             QUnit.test("Array - Set1 ForeachWhenCastToIListWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.foreachWhenCastToIListWorks);
             QUnit.test("Array - Set1 ICollectionCountWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iCollectionCountWorks);
+            QUnit.test("Array - Set1 ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iCollectionIsReadOnlyWorks);
             QUnit.test("Array - Set1 ICollectionAddWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iCollectionAddWorks);
             QUnit.test("Array - Set1 ICollectionClearWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iCollectionClearWorks);
             QUnit.test("Array - Set1 ICollectionContainsWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iCollectionContainsWorks);
@@ -132,6 +133,7 @@
             QUnit.test("Array - Set1 ICollectionCopyToOffsetBoundWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iCollectionCopyToOffsetBoundWorks);
             QUnit.test("Array - Set1 ICollectionCopyToIllegalBoundWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iCollectionCopyToIllegalBoundWorks);
             QUnit.test("Array - Set1 ICollectionRemoveWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iCollectionRemoveWorks);
+            QUnit.test("Array - Set1 IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iListIsReadOnlyWorks);
             QUnit.test("Array - Set1 IListIndexingWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iListIndexingWorks);
             QUnit.test("Array - Set1 IListIndexOfWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iListIndexOfWorks);
             QUnit.test("Array - Set1 IListIndexOfUsesEqualsMethod", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1.iListIndexOfUsesEqualsMethod);
@@ -183,6 +185,9 @@
             QUnit.test("ICollection - ArrayCastToICollectionCountWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests.arrayCastToICollectionCountWorks);
             QUnit.test("ICollection - ClassImplementingICollectionCountWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests.classImplementingICollectionCountWorks);
             QUnit.test("ICollection - ClassImplementingICollectionCastToICollectionCountWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests.classImplementingICollectionCastToICollectionCountWorks);
+            QUnit.test("ICollection - ArrayCastToICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests.arrayCastToICollectionIsReadOnlyWorks);
+            QUnit.test("ICollection - ClassImplementingICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests.classImplementingICollectionIsReadOnlyWorks);
+            QUnit.test("ICollection - ClassImplementingICollectionCastToICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests.classImplementingICollectionCastToICollectionIsReadOnlyWorks);
             QUnit.test("ICollection - ClassImplementingICollectionAddWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests.classImplementingICollectionAddWorks);
             QUnit.test("ICollection - ClassImplementingICollectionCastToICollectionAddWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests.classImplementingICollectionCastToICollectionAddWorks);
             QUnit.test("ICollection - ClassImplementingICollectionClearWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests.classImplementingICollectionClearWorks);
@@ -221,6 +226,9 @@
             QUnit.test("IList - ArrayCastToIListSetItemWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests.arrayCastToIListSetItemWorks);
             QUnit.test("IList - ClassImplementingIListSetItemWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests.classImplementingIListSetItemWorks);
             QUnit.test("IList - ClassImplementingIListCastToIListSetItemWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests.classImplementingIListCastToIListSetItemWorks);
+            QUnit.test("IList - ArrayCastToIListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests.arrayCastToIListIsReadOnlyWorks);
+            QUnit.test("IList - ClassImplementingIListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests.classImplementingIListIsReadOnlyWorks);
+            QUnit.test("IList - ClassImplementingIListCastToIListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests.classImplementingIListCastToIListIsReadOnlyWorks);
             QUnit.test("IList - ArrayCastToIListIndexOfWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests.arrayCastToIListIndexOfWorks);
             QUnit.test("IList - ClassImplementingIListIndexOfWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests.classImplementingIListIndexOfWorks);
             QUnit.test("IList - ClassImplementingIListCastToIListIndexOfWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests.classImplementingIListCastToIListIndexOfWorks);
@@ -321,11 +329,13 @@
             QUnit.test("ReadOnlyCollection - ForeachWhenCastToIEnumerableWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.foreachWhenCastToIEnumerableWorks);
             QUnit.test("ReadOnlyCollection - IEnumerableGetEnumeratorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.iEnumerableGetEnumeratorWorks);
             QUnit.test("ReadOnlyCollection - ICollectionCountWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.iCollectionCountWorks);
+            QUnit.test("ReadOnlyCollection - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.iCollectionIsReadOnlyWorks);
             QUnit.test("ReadOnlyCollection - ICollectionContainsWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.iCollectionContainsWorks);
             QUnit.test("ReadOnlyCollection - ICollectionContainsUsesEqualsMethod", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.iCollectionContainsUsesEqualsMethod);
             QUnit.test("ReadOnlyCollection - IListIndexingWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.iListIndexingWorks);
             QUnit.test("ReadOnlyCollection - IListIndexOfWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.iListIndexOfWorks);
             QUnit.test("ReadOnlyCollection - IListIndexOfUsesEqualsMethod", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.iListIndexOfUsesEqualsMethod);
+            QUnit.test("ReadOnlyCollection - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests.iListIsReadOnlyWorks);
             QUnit.test("WeakMap - GettingSettingAndDeletingWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_WeakMapTests.gettingSettingAndDeletingWorks);
             QUnit.test("MultidimArray - TypePropertiesAreCorrect", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_MultidimArrayTests.typePropertiesAreCorrect);
             QUnit.test("MultidimArray - LengthWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_MultidimArrayTests.lengthWorks);
@@ -2337,6 +2347,8 @@
             QUnit.test("Float32ArrayTests - IEnumerableGetEnumeratorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests.iEnumerableGetEnumeratorWorks);
             QUnit.test("Float32ArrayTests - ICollectionMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests.iCollectionMethodsWork_SPI_1559);
             QUnit.test("Float32ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests.iListMethodsWork_SPI_1559);
+            QUnit.test("Float32ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests.iListIsReadOnlyWorks);
+            QUnit.test("Float32ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests.iCollectionIsReadOnlyWorks);
             QUnit.test("Float64ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.lengthConstructorWorks);
             QUnit.test("Float64ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.constructorFromIntWorks);
             QUnit.test("Float64ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.copyConstructorWorks);
@@ -2362,6 +2374,8 @@
             QUnit.test("Float64ArrayTests - IEnumerableGetEnumeratorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.iEnumerableGetEnumeratorWorks);
             QUnit.test("Float64ArrayTests - ICollectionMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.iCollectionMethodsWork_SPI_1559);
             QUnit.test("Float64ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.iListMethodsWork_SPI_1559);
+            QUnit.test("Float64ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.iListIsReadOnlyWorks);
+            QUnit.test("Float64ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests.iCollectionIsReadOnlyWorks);
             QUnit.test("Int16ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.lengthConstructorWorks);
             QUnit.test("Int16ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.constructorFromIntWorks);
             QUnit.test("Int16ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.copyConstructorWorks);
@@ -2387,6 +2401,8 @@
             QUnit.test("Int16ArrayTests - IEnumerableGetEnumeratorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.iEnumerableGetEnumeratorWorks);
             QUnit.test("Int16ArrayTests - ICollectionMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.iCollectionMethodsWork_SPI_1559);
             QUnit.test("Int16ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.iListMethodsWork_SPI_1559);
+            QUnit.test("Int16ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.iListIsReadOnlyWorks);
+            QUnit.test("Int16ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests.iCollectionIsReadOnlyWorks);
             QUnit.test("Int32ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.lengthConstructorWorks);
             QUnit.test("Int32ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.constructorFromIntWorks);
             QUnit.test("Int32ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.copyConstructorWorks);
@@ -2412,6 +2428,8 @@
             QUnit.test("Int32ArrayTests - IEnumerableGetEnumeratorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.iEnumerableGetEnumeratorWorks);
             QUnit.test("Int32ArrayTests - ICollectionMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.iCollectionMethodsWork_SPI_1559);
             QUnit.test("Int32ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.iListMethodsWork_SPI_1559);
+            QUnit.test("Int32ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.iListIsReadOnlyWorks);
+            QUnit.test("Int32ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests.iCollectionIsReadOnlyWorks);
             QUnit.test("Int8ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.lengthConstructorWorks);
             QUnit.test("Int8ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.constructorFromIntWorks);
             QUnit.test("Int8ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.copyConstructorWorks);
@@ -2437,6 +2455,8 @@
             QUnit.test("Int8ArrayTests - IEnumerableGetEnumeratorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.iEnumerableGetEnumeratorWorks);
             QUnit.test("Int8ArrayTests - ICollectionMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.iCollectionMethodsWork_SPI_1559);
             QUnit.test("Int8ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.iListMethodsWork_SPI_1559);
+            QUnit.test("Int8ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.iListIsReadOnlyWorks);
+            QUnit.test("Int8ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests.iCollectionIsReadOnlyWorks);
             QUnit.test("Uint16ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.lengthConstructorWorks);
             QUnit.test("Uint16ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.constructorFromIntWorks);
             QUnit.test("Uint16ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.copyConstructorWorks);
@@ -2462,6 +2482,8 @@
             QUnit.test("Uint16ArrayTests - IEnumerableGetEnumeratorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.iEnumerableGetEnumeratorWorks);
             QUnit.test("Uint16ArrayTests - ICollectionMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.iCollectionMethodsWork_SPI_1559);
             QUnit.test("Uint16ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.iListMethodsWork_SPI_1559);
+            QUnit.test("Uint16ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.iListIsReadOnlyWorks);
+            QUnit.test("Uint16ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests.iCollectionIsReadOnlyWorks);
             QUnit.test("Uint32ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.lengthConstructorWorks);
             QUnit.test("Uint32ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.constructorFromIntWorks);
             QUnit.test("Uint32ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.copyConstructorWorks);
@@ -2487,6 +2509,8 @@
             QUnit.test("Uint32ArrayTests - IEnumerableGetEnumeratorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.iEnumerableGetEnumeratorWorks);
             QUnit.test("Uint32ArrayTests - ICollectionMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.iCollectionMethodsWork_SPI_1559);
             QUnit.test("Uint32ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.iListMethodsWork_SPI_1559);
+            QUnit.test("Uint32ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.iListIsReadOnlyWorks);
+            QUnit.test("Uint32ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests.iCollectionIsReadOnlyWorks);
             QUnit.test("Uint8ArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.lengthConstructorWorks);
             QUnit.test("Uint8ArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.constructorFromIntWorks);
             QUnit.test("Uint8ArrayTests - CopyConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.copyConstructorWorks);
@@ -2512,6 +2536,8 @@
             QUnit.test("Uint8ArrayTests - IEnumerableGetEnumeratorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.iEnumerableGetEnumeratorWorks);
             QUnit.test("Uint8ArrayTests - ICollectionMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.iCollectionMethodsWork_SPI_1559);
             QUnit.test("Uint8ArrayTests - IListMethodsWork_SPI_1559", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.iListMethodsWork_SPI_1559);
+            QUnit.test("Uint8ArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.iListIsReadOnlyWorks);
+            QUnit.test("Uint8ArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests.iCollectionIsReadOnlyWorks);
             QUnit.test("Uint8ClampedArrayTests - TypePropertiesAreCorrect_SPI_1560", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.typePropertiesAreCorrect_SPI_1560);
             QUnit.test("Uint8ClampedArrayTests - LengthConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.lengthConstructorWorks);
             QUnit.test("Uint8ClampedArrayTests - ConstructorFromIntWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.constructorFromIntWorks);
@@ -2538,6 +2564,8 @@
             QUnit.test("Uint8ClampedArrayTests - GetEnumeratorWorks_SPI_1401", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.getEnumeratorWorks_SPI_1401);
             QUnit.test("Uint8ClampedArrayTests - ICollectionMethodsWork_SPI_1559_1560", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.iCollectionMethodsWork_SPI_1559_1560);
             QUnit.test("Uint8ClampedArrayTests - IListMethodsWork_SPI_1559_1560", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.iListMethodsWork_SPI_1559_1560);
+            QUnit.test("Uint8ClampedArrayTests - IListIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.iListIsReadOnlyWorks);
+            QUnit.test("Uint8ClampedArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests.iCollectionIsReadOnlyWorks);
             QUnit.module("Utilities");
             QUnit.test("Environment - NewLineIsAStringContainingOnlyTheNewLineChar", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_EnvironmentTests.newLineIsAStringContainingOnlyTheNewLineChar);
             QUnit.module("СultureInfo");
@@ -2736,6 +2764,10 @@
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.ArrayTests.ArrayTestsSet1).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1);
                 t.getFixture().iCollectionCountWorks();
             },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.ArrayTests.ArrayTestsSet1).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1);
+                t.getFixture().iCollectionIsReadOnlyWorks();
+            },
             iCollectionAddWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.ArrayTests.ArrayTestsSet1).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1);
                 t.getFixture().iCollectionAddWorks();
@@ -2767,6 +2799,10 @@
             iCollectionRemoveWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.ArrayTests.ArrayTestsSet1).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1);
                 t.getFixture().iCollectionRemoveWorks();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.ArrayTests.ArrayTestsSet1).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1);
+                t.getFixture().iListIsReadOnlyWorks();
             },
             iListIndexingWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.ArrayTests.ArrayTestsSet1).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_ArrayTestsSet1);
@@ -3424,6 +3460,18 @@
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ICollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests);
                 t.getFixture().classImplementingICollectionCastToICollectionCountWorks();
             },
+            arrayCastToICollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ICollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests);
+                t.getFixture().arrayCastToICollectionIsReadOnlyWorks();
+            },
+            classImplementingICollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ICollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests);
+                t.getFixture().classImplementingICollectionIsReadOnlyWorks();
+            },
+            classImplementingICollectionCastToICollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ICollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests);
+                t.getFixture().classImplementingICollectionCastToICollectionIsReadOnlyWorks();
+            },
             classImplementingICollectionAddWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ICollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ICollectionTests);
                 t.getFixture().classImplementingICollectionAddWorks();
@@ -3593,6 +3641,18 @@
             classImplementingIListCastToIListSetItemWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.IListTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests);
                 t.getFixture().classImplementingIListCastToIListSetItemWorks();
+            },
+            arrayCastToIListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.IListTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests);
+                t.getFixture().arrayCastToIListIsReadOnlyWorks();
+            },
+            classImplementingIListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.IListTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests);
+                t.getFixture().classImplementingIListIsReadOnlyWorks();
+            },
+            classImplementingIListCastToIListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.IListTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests);
+                t.getFixture().classImplementingIListCastToIListIsReadOnlyWorks();
             },
             arrayCastToIListIndexOfWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.IListTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_IListTests);
@@ -4012,6 +4072,10 @@
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests);
                 t.getFixture().iCollectionCountWorks();
             },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
+            },
             iCollectionContainsWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests);
                 t.getFixture().iCollectionContainsWorks();
@@ -4031,6 +4095,10 @@
             iListIndexOfUsesEqualsMethod: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests);
                 t.getFixture().iListIndexOfUsesEqualsMethod();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Generic_ReadOnlyCollectionTests);
+                t.getFixture().iListIsReadOnlyWorks();
             }
         }
     });
@@ -4251,6 +4319,14 @@
             iListMethodsWork_SPI_1559: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests);
                 t.getFixture().iListMethodsWork_SPI_1559();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests);
+                t.getFixture().iListIsReadOnlyWorks();
+            },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float32ArrayTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
             }
         }
     });
@@ -4357,6 +4433,14 @@
             iListMethodsWork_SPI_1559: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float64ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests);
                 t.getFixture().iListMethodsWork_SPI_1559();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float64ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests);
+                t.getFixture().iListIsReadOnlyWorks();
+            },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Float64ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Float64ArrayTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
             }
         }
     });
@@ -4463,6 +4547,14 @@
             iListMethodsWork_SPI_1559: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests);
                 t.getFixture().iListMethodsWork_SPI_1559();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests);
+                t.getFixture().iListIsReadOnlyWorks();
+            },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int16ArrayTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
             }
         }
     });
@@ -4569,6 +4661,14 @@
             iListMethodsWork_SPI_1559: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests);
                 t.getFixture().iListMethodsWork_SPI_1559();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests);
+                t.getFixture().iListIsReadOnlyWorks();
+            },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int32ArrayTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
             }
         }
     });
@@ -4675,6 +4775,14 @@
             iListMethodsWork_SPI_1559: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests);
                 t.getFixture().iListMethodsWork_SPI_1559();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests);
+                t.getFixture().iListIsReadOnlyWorks();
+            },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Int8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Int8ArrayTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
             }
         }
     });
@@ -4781,6 +4889,14 @@
             iListMethodsWork_SPI_1559: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests);
                 t.getFixture().iListMethodsWork_SPI_1559();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests);
+                t.getFixture().iListIsReadOnlyWorks();
+            },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint16ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint16ArrayTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
             }
         }
     });
@@ -4887,6 +5003,14 @@
             iListMethodsWork_SPI_1559: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests);
                 t.getFixture().iListMethodsWork_SPI_1559();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests);
+                t.getFixture().iListIsReadOnlyWorks();
+            },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint32ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint32ArrayTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
             }
         }
     });
@@ -4993,6 +5117,14 @@
             iListMethodsWork_SPI_1559: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests);
                 t.getFixture().iListMethodsWork_SPI_1559();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests);
+                t.getFixture().iListIsReadOnlyWorks();
+            },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ArrayTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
             }
         }
     });
@@ -5103,6 +5235,14 @@
             iListMethodsWork_SPI_1559_1560: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ClampedArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests);
                 t.getFixture().iListMethodsWork_SPI_1559_1560();
+            },
+            iListIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ClampedArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests);
+                t.getFixture().iListIsReadOnlyWorks();
+            },
+            iCollectionIsReadOnlyWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Collections.Native.Uint8ClampedArrayTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Collections_Native_Uint8ClampedArrayTests);
+                t.getFixture().iCollectionIsReadOnlyWorks();
             }
         }
     });

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -8879,6 +8879,83 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1810", {
+        testInterfaceIndexersAndCopyToAndIsReadOnly: function () {
+            var l = new (Bridge.ClientTest.Batch3.BridgeIssues.Bridge1810.C$1(System.Int32))();
+            Bridge.Test.Assert.notNull$1(l, "IList created");
+
+            var c = Bridge.as(l, System.Collections.Generic.ICollection$1(System.Int32));
+            Bridge.Test.Assert.true$1(System.Array.getIsReadOnly(c, System.Int32), "IsReadOnly");
+
+            var a = [1, 2];
+            System.Array.copyTo(c, a, 0, System.Int32);
+            Bridge.Test.Assert.areEqual$1(0, a[0], "CopyTo()");
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1810.C$1", function (T) { return {
+        inherits: [System.Collections.Generic.IList$1(T)],
+        config: {
+            alias: [
+            "System$Collections$Generic$IList$1$T$getItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$getItem",
+            "System$Collections$Generic$IList$1$T$setItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$setItem",
+            "System$Collections$Generic$ICollection$1$T$getCount", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getCount",
+            "System$Collections$Generic$ICollection$1$T$getIsReadOnly", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly",
+            "System$Collections$Generic$ICollection$1$T$add", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$add",
+            "System$Collections$Generic$ICollection$1$T$clear", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$clear",
+            "System$Collections$Generic$ICollection$1$T$contains", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$contains",
+            "System$Collections$Generic$ICollection$1$T$copyTo", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$copyTo",
+            "System$Collections$Generic$IEnumerable$1$T$getEnumerator", "System$Collections$Generic$IEnumerable$1$" + Bridge.getTypeAlias(T) + "$getEnumerator",
+            "System$Collections$Generic$IList$1$T$indexOf", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$indexOf",
+            "System$Collections$Generic$IList$1$T$insert", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$insert",
+            "System$Collections$Generic$ICollection$1$T$remove", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$remove",
+            "System$Collections$Generic$IList$1$T$removeAt", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$removeAt"
+            ]
+        },
+        System$Collections$Generic$IList$1$T$getItem: function (index) {
+            return Bridge.getDefaultValue(T);
+        },
+        System$Collections$Generic$IList$1$T$setItem: function (index, value) {
+
+        },
+        System$Collections$Generic$ICollection$1$T$getCount: function () {
+            throw new System.NotImplementedException();
+        },
+        System$Collections$Generic$ICollection$1$T$getIsReadOnly: function () {
+            return true;
+        },
+        System$Collections$Generic$ICollection$1$T$add: function (item) {
+            throw new System.NotImplementedException();
+        },
+        System$Collections$Generic$ICollection$1$T$clear: function () {
+            throw new System.NotImplementedException();
+        },
+        System$Collections$Generic$ICollection$1$T$contains: function (item) {
+            throw new System.NotImplementedException();
+        },
+        System$Collections$Generic$ICollection$1$T$copyTo: function (array, arrayIndex) {
+            array[0] = Bridge.getDefaultValue(T);
+        },
+        System$Collections$IEnumerable$getEnumerator: function () {
+            throw new System.NotImplementedException();
+        },
+        System$Collections$Generic$IEnumerable$1$T$getEnumerator: function () {
+            throw new System.NotImplementedException();
+        },
+        System$Collections$Generic$IList$1$T$indexOf: function (item) {
+            throw new System.NotImplementedException();
+        },
+        System$Collections$Generic$IList$1$T$insert: function (index, item) {
+            throw new System.NotImplementedException();
+        },
+        System$Collections$Generic$ICollection$1$T$remove: function (item) {
+            throw new System.NotImplementedException();
+        },
+        System$Collections$Generic$IList$1$T$removeAt: function (index) {
+            throw new System.NotImplementedException();
+        }
+    }; });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1812", {
         testDoubleConversion: function () {
             var a = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1812._Object.op_Implicit(1);

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -7994,6 +7994,7 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
             Bridge.Test.Assert.areEqual(0, System.Array.getItem(list, 0, System.Int32));
             Bridge.Test.Assert.true(System.Array.contains(list, 0, System.Int32));
             Bridge.Test.Assert.areEqual(100, System.Array.getCount(list, System.Int32));
+            Bridge.Test.Assert.true(System.Array.getIsReadOnly(list, System.Int32));
             Bridge.Test.Assert.null(Bridge.getEnumerator(list, "$1", System.Int32));
             Bridge.Test.Assert.areEqual(200, System.Array.indexOf(list, 0, 0, null, System.Int32));
             Bridge.Test.Assert.true(System.Array.remove(list, 0, System.Int32));
@@ -8007,6 +8008,7 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
             Bridge.Test.Assert.areEqual(0, list.getItem(0));
             Bridge.Test.Assert.true(list.contains(0));
             Bridge.Test.Assert.areEqual(1000, list.getCount());
+            Bridge.Test.Assert.false(list.getIsReadOnly());
             Bridge.Test.Assert.null(list.getEnumerator());
             Bridge.Test.Assert.areEqual(2000, list.indexOf(0));
             Bridge.Test.Assert.true(list.remove(0));
@@ -8018,6 +8020,7 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
             Bridge.Test.Assert.areEqual(0, System.Array.getItem(list2, 0, System.Int32));
             Bridge.Test.Assert.true(System.Array.contains(list2, 0, System.Int32));
             Bridge.Test.Assert.areEqual(1000, System.Array.getCount(list2, System.Int32));
+            Bridge.Test.Assert.false(list.getIsReadOnly());
             Bridge.Test.Assert.null(Bridge.getEnumerator(list2, "$1", System.Int32));
             Bridge.Test.Assert.areEqual(2000, System.Array.indexOf(list2, 0, 0, null, System.Int32));
             Bridge.Test.Assert.true(System.Array.remove(list2, 0, System.Int32));
@@ -8038,6 +8041,7 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
             "System$Collections$Generic$IList$1$T$getItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$getItem",
             "System$Collections$Generic$IList$1$T$setItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$setItem",
             "System$Collections$Generic$ICollection$1$T$getCount", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getCount",
+            "getIsReadOnly", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly",
             "System$Collections$Generic$ICollection$1$T$add", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$add",
             "System$Collections$Generic$ICollection$1$T$clear", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$clear",
             "System$Collections$Generic$ICollection$1$T$contains", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$contains",
@@ -8057,6 +8061,9 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
         },
         System$Collections$Generic$ICollection$1$T$getCount: function () {
             return 100;
+        },
+        getIsReadOnly: function () {
+            return true;
         },
         System$Collections$Generic$ICollection$1$T$add: function (item) {
         },
@@ -8093,6 +8100,7 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
             "getItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$getItem",
             "setItem", "System$Collections$Generic$IList$1$" + Bridge.getTypeAlias(T) + "$setItem",
             "getCount", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getCount",
+            "getIsReadOnly", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$getIsReadOnly",
             "add", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$add",
             "clear", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$clear",
             "contains", "System$Collections$Generic$ICollection$1$" + Bridge.getTypeAlias(T) + "$contains",
@@ -8112,6 +8120,9 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
         },
         getCount: function () {
             return 1000;
+        },
+        getIsReadOnly: function () {
+            return false;
         },
         add: function (item) {
         },

--- a/Tests/Runner/Batch3/test.js
+++ b/Tests/Runner/Batch3/test.js
@@ -278,6 +278,7 @@
             QUnit.test("#1802 - TestReservedWordsAsMethodName", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1802.testReservedWordsAsMethodName);
             QUnit.test("#1803 - TestCollectionInitializerWithStaticMember", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1803.testCollectionInitializerWithStaticMember);
             QUnit.test("#1804 - TestStructClone", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1804.testStructClone);
+            QUnit.test("#1810 - TestInterfaceIndexersAndCopyToAndIsReadOnly", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1810.testInterfaceIndexersAndCopyToAndIsReadOnly);
             QUnit.test("#1812 - TestDoubleConversion", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1812.testDoubleConversion);
             QUnit.test("#1813 - TestAddStaticMethod", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1813.testAddStaticMethod);
             QUnit.test("#1814 - TestNamespaceConflictResolution", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1814.testNamespaceConflictResolution);
@@ -2615,6 +2616,16 @@
             testStructClone: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1804).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1804);
                 t.getFixture().testStructClone();
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1810", {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1810)],
+        statics: {
+            testInterfaceIndexersAndCopyToAndIsReadOnly: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1810).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1810);
+                t.getFixture().testInterfaceIndexersAndCopyToAndIsReadOnly();
             }
         }
     });

--- a/Tests/Runner/Batch4/code.js
+++ b/Tests/Runner/Batch4/code.js
@@ -1099,6 +1099,7 @@
             alias: [
             "getEnumerator", "System$Collections$Generic$IEnumerable$1$String$getEnumerator",
             "getCount", "System$Collections$Generic$ICollection$1$String$getCount",
+            "getIsReadOnly", "System$Collections$Generic$ICollection$1$String$getIsReadOnly",
             "add", "System$Collections$Generic$ICollection$1$String$add",
             "clear", "System$Collections$Generic$ICollection$1$String$clear",
             "contains", "System$Collections$Generic$ICollection$1$String$contains",
@@ -1112,6 +1113,9 @@
         },
         getCount: function () {
             return this.getItems().getCount();
+        },
+        getIsReadOnly: function () {
+            return true;
         },
         System$Collections$IEnumerable$getEnumerator: function () {
             return this.getEnumerator();
@@ -1616,6 +1620,7 @@
             alias: [
             "getEnumerator", "System$Collections$Generic$IEnumerable$1$String$getEnumerator",
             "getCount", "System$Collections$Generic$ICollection$1$String$getCount",
+            "getIsReadOnly", "System$Collections$Generic$ICollection$1$String$getIsReadOnly",
             "add", "System$Collections$Generic$ICollection$1$String$add",
             "clear", "System$Collections$Generic$ICollection$1$String$clear",
             "contains", "System$Collections$Generic$ICollection$1$String$contains",
@@ -1634,6 +1639,9 @@
         },
         getCount: function () {
             return this.getItems().getCount();
+        },
+        getIsReadOnly: function () {
+            return true;
         },
         getItem: function (index) {
             return this.getItems().getItem(index);


### PR DESCRIPTION
Changes proposed in this pull request:
- #1810 Implemented `IsReadOnly` for `ICollection<T>` (`Array`, `IList<T>`, `List<T>`, `ReadOnlyCollection<T>`, `TypedArrays`); Added client tests
- #1811 Added Client tests for TypedArray's `CopyTo`
- #1811 Corrected `System.Array.copyTo` function to remove `return` statement
- #1025 Added test case for https://github.com/bridgedotnet/Bridge/issues/1025#issuecomment-245424630