### PR TITLE
[1816] Event's `CurrentTarget` and `Target` to be of less specific type

### DIFF
--- a/Html5/Events/Event.cs
+++ b/Html5/Events/Event.cs
@@ -39,7 +39,7 @@ namespace Bridge.Html5
         /// Identifies the current target for the event, as the event traverses the DOM. It always refers to the element the event handler has been attached to as opposed to event.target which identifies the element on which the event occurred.
         /// On Internet Explorer 6 through 8, the event model is different. Event listeners are attached with the non-standard element.attachEvent method. In this model, there is no equivalent to event.currentTarget and this is the global object.
         /// </summary>
-        public readonly HTMLElement CurrentTarget;
+        public readonly EventTarget CurrentTarget;
 
         /// <summary>
         /// Returns a boolean indicating whether or not event.preventDefault() was called on the event.
@@ -60,7 +60,7 @@ namespace Bridge.Html5
         /// This property of event objects is the object the event was dispatched on. It is different than event.currentTarget when the event handler is called in bubbling or capturing phase of the event.
         /// On IE6-8, the event model is different. Event listeners are attached with the non-standard element.attachEvent method. In this model, the event object is not passed as an argument to the event handler function but is the window.event object. This object has an srcElement property which has the same semantics than event.target.
         /// </summary>
-        public readonly HTMLElement Target;
+        public readonly EventTarget Target;
 
         /// <summary>
         /// Returns the time (in milliseconds since the epoch) at which the event was created.

--- a/Html5/Events/ProgressEvent.cs
+++ b/Html5/Events/ProgressEvent.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     [Name("ProgressEvent")]
     public class ProgressEvent : Event
     {
-        private ProgressEvent()
+        internal ProgressEvent()
         {
         }
 
@@ -33,5 +33,18 @@ namespace Bridge.Html5
     /// <typeparam name="TCurrentTarget">The CurrentTarget type</typeparam>
     [External]
     [Name("ProgressEvent")]
-    public class ProgressEvent<TCurrentTarget> : Event<TCurrentTarget> where TCurrentTarget : HTMLElement { }
+    public class ProgressEvent<TCurrentTarget> : ProgressEvent where TCurrentTarget : EventTarget
+    {
+        /// <summary>
+        /// Identifies the current target for the event, as the event traverses the DOM. It always refers to the element the event handler has been attached to as opposed to event.target which identifies the element on which the event occurred.
+        /// On Internet Explorer 6 through 8, the event model is different. Event listeners are attached with the non-standard element.attachEvent method. In this model, there is no equivalent to event.currentTarget and this is the global object.
+        /// </summary>
+        public new readonly TCurrentTarget CurrentTarget;
+
+        /// <summary>
+        /// This property of event objects is the object the event was dispatched on. It is different than event.currentTarget when the event handler is called in bubbling or capturing phase of the event.
+        /// On IE6-8, the event model is different. Event listeners are attached with the non-standard element.attachEvent method. In this model, the event object is not passed as an argument to the event handler function but is the window.event object. This object has an srcElement property which has the same semantics than event.target.
+        /// </summary>
+        public new readonly TCurrentTarget Target;
+    }
 }


### PR DESCRIPTION
Fixes #1816

Changes proposed in this pull request:

- Option1 from https://github.com/bridgedotnet/Bridge/issues/1816#issuecomment-251075624
- Event's `CurrentTarget` and `Target` to be of less specific type `EventTarget` (instead of `HtmlElement`);
- `ProgressEvent<T>` to inherit properties of `ProgressEvent` and override Event's `CurrentTarget` and `Target`.