### PR TITLE
[2003] lambda expressions referencing 'this' are not compiled correctly

### DIFF
--- a/Compiler/Translator/Emitter/Blocks/IdentifierBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/IdentifierBlock.cs
@@ -134,6 +134,7 @@ namespace Bridge.Translator
 
             if (hasThis)
             {
+                Emitter.ThisRefCounter++;
                 this.Write("");
                 var oldBuilder = this.Emitter.Output;
                 this.Emitter.Output = new StringBuilder();

--- a/Compiler/Translator/Emitter/Blocks/InvocationBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/InvocationBlock.cs
@@ -203,6 +203,11 @@ namespace Bridge.Translator
                             inlineScript = inlineScript.Substring(6);
                         }
 
+                        if (!noThis)
+                        {
+                            Emitter.ThisRefCounter++;
+                        }
+
                         if (!isStaticMethod && noThis)
                         {
                             this.WriteThis();

--- a/Tests/Batch2/Batch2.csproj
+++ b/Tests/Batch2/Batch2.csproj
@@ -49,6 +49,7 @@
     <Compile Include="BridgeIssues\N1204.cs" />
     <Compile Include="BridgeIssues\N1122.cs" />
     <Compile Include="BridgeIssues\N1499.cs" />
+    <Compile Include="BridgeIssues\N2003.cs" />
     <Compile Include="BridgeIssues\N772.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Batch2/BridgeIssues/N2003.cs
+++ b/Tests/Batch2/BridgeIssues/N2003.cs
@@ -1,0 +1,33 @@
+﻿using Bridge.Testing;
+using System;
+
+namespace Bridge.ClientTest.Batch2.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#2003 - " + Constants.BATCH_NAME + " {0}")]
+    public class N2003
+    {
+        class Issue2003Helper
+        {
+            [Template("{this}.setSomeProp({this}.getSomeProp() + 1)")]
+            public extern object SomeInline();
+        
+            public int SomeProp {get; set; }
+            
+            public void CreateAndCallLambda()
+            {
+                Func<object> cb = () => { return SomeInline();};
+                cb();
+            }
+        }
+
+        [Test(ExpectedCount = 1)]
+        public static void TestThisIsBindInTemplatedMemberMethods()
+        {
+            var sut = new Issue2003Helper();
+            sut.SomeProp = 5;
+            sut.CreateAndCallLambda();
+            Assert.AreEqual(6, sut.SomeProp);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2003

Changes proposed in this pull request:
-Make lambda expressions increase Emitter's ThisRefCounter if 'this' is detected in generated template script
-Test added to avoid regression in future (but not sure if it works as Bridge.Testing is not available)