### PR TITLE
[2005] Implements DOM MutationObserver API

### DIFF
--- a/Html5/Bridge.Html5.csproj
+++ b/Html5/Bridge.Html5.csproj
@@ -73,6 +73,7 @@
     <Compile Include="GamepadMappingType.cs" />
     <Compile Include="Interfaces\Touch.cs" />
     <Compile Include="Interfaces\TouchList.cs" />
+    <Compile Include="MutationObserver.cs" />
     <Compile Include="String.cs" />
     <Compile Include="TypedArray\Float32Array.cs" />
     <Compile Include="TypedArray\Float64Array.cs" />
@@ -352,6 +353,9 @@
     <NuGetPackageSourcePath Include="$(SolutionDir).build\specs\Bridge.Html5.nuspec">
       <Path>$(SolutionDir).build\specs\Bridge.Html5.nuspec</Path>
     </NuGetPackageSourcePath>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
   </ItemGroup>
   <Import Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" Project="$(SolutionDir).build\common\NuGet.Build.Package.targets" />
   <Target Name="CleanProjectNuGetOutput" BeforeTargets="Clean">

--- a/Html5/MutationObserver.cs
+++ b/Html5/MutationObserver.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Bridge.Html5
+{
+/// <summary>
+    /// see <a href="https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord">MDN</a>
+    /// </summary>
+    [External]
+    [Name("MutationRecord")]
+    public class MutationRecord
+    {
+        public readonly string Type;
+        public readonly Node Target;
+        public readonly NodeList AddedNodes;
+        public readonly NodeList RemovedNodes;
+        public readonly Node PreviousSibling;
+        public readonly Node NextSibling;
+        public readonly string AttributeName;
+        public readonly string AttributeNamespace;
+        public readonly string OldValue;
+    }
+
+    /// <summary>
+    /// see <a href="https://developer.mozilla.org/en/docs/Web/API/MutationObserver#MutationObserverInit">MDN</a>
+    /// </summary>
+    [External]
+    [Name("Object")]
+    public class MutationObserverInit
+    {
+        public bool ChildList;
+        public bool Attributes;
+        public bool CharacterData;
+        public bool Subtree;
+        public bool AttributeOldValue;
+        public bool CharacterDataOldValue;
+        public bool AttributeFilter;
+    }
+
+    /// <summary>
+    /// see <a href="https://developer.mozilla.org/en/docs/Web/API/MutationObserver">MDN</a>
+    /// </summary>
+    [External]
+    [Name("MutationObserver")]
+    public class MutationObserver
+    {
+        public extern MutationObserver(Action<MutationRecord[],MutationObserver> callback);
+        public extern void Observe(Node target, MutationObserverInit options);
+        public extern void Disconnect();
+        public extern MutationRecord[] TakeRecords();
+    }
+}

--- a/Tests/Batch4/Batch4.csproj
+++ b/Tests/Batch4/Batch4.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="ActivatorTests.cs" />
     <Compile Include="Collections\JsDictionaryTests.cs" />
+    <Compile Include="MutationObserverTests.cs" />
     <Compile Include="TestHelper.cs" />
     <Compile Include="RefParameterTests.cs" />
     <Compile Include="ArgumentsTests.cs" />

--- a/Tests/Batch4/MutationObserverTests.cs
+++ b/Tests/Batch4/MutationObserverTests.cs
@@ -1,0 +1,48 @@
+﻿using Bridge.Test;
+using System;
+using System.Threading.Tasks;
+using Bridge.Html5;
+
+namespace Bridge.ClientTest.Batch4
+{
+    [TestFixture(TestNameFormat = "MutationObserverTests - {0}")]
+    public class MutationObserverTests
+    {
+        private int ChangesCount {get; set; }
+
+        [Test]
+        public void MutationObserverIsActuallyCalledForNewlyAttachedElements()
+        {
+            var done = Assert.Async();
+
+            //setup observer
+            var observer = new MutationObserver((changes, _) => {
+                ChangesCount += changes.Length;
+            });
+
+            observer.Observe(Document.Body, new MutationObserverInit {
+                Subtree = true,
+                ChildList = true
+            });
+
+            //mutate DOM
+            Document.Body.AppendChild(new HTMLSpanElement());
+
+            //observer will be invoked asynchronously
+
+            Task task = new Task(null);
+
+            Window.SetTimeout(async delegate
+            {
+                await Task.Delay(1);
+                task.Complete();
+            });
+
+            await task;
+
+            Assert.AreEqual(1, ChangesCount);
+
+            done();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2005 .

Changes proposed in this pull request:
- wrapper code / implementation
- simple dom-element-attached test BUT don't know if it works without Bridge.Testing
 