### PR TITLE
[1961]  Project post build event task is called before Bridge GenerateScript task

### DIFF
--- a/.build/files/Bridge.Min.targets
+++ b/.build/files/Bridge.Min.targets
@@ -8,7 +8,13 @@
     <AdditionalExplicitAssemblyReferences />
   </PropertyGroup>
 
-  <Target Name="AfterBuild">
+  <PropertyGroup>
+    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);BridgeGenerateScript</PrepareForRunDependsOn>
+  </PropertyGroup>
+
+  <Target Name="BridgeGenerateScript">
+    <Message Text="------ BridgeGenerateScript task started: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) ------" Importance="high" />
+
     <GenerateScript
       DefineConstants="$(DefineConstants)"
       OutputPath="$(OutputPath)"
@@ -16,5 +22,7 @@
       Assembly="@(IntermediateAssembly)"
       AssembliesPath="$(OutputPath)"
       ProjectPath="$(MSBuildProjectFullPath)" />
+
+    <Message Text="------ BridgeGenerateScript task done: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) ------" Importance="high" />
   </Target>
 </Project>


### PR DESCRIPTION
Fixes #1961

Changes proposed in this pull request:

- Bridge script task (Bridge.Min.targets) to run on `PrepareForRun` instead of `AfterBuild`
- Added info messages that are shown in Build output window on the script task starts and finishes
  
```
------ BridgeGenerateScript task done: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform)
```
