### PR TITLE
[1990] Fix path conversion

### DIFF
--- a/Compiler/Contract/Config/ConfigHelper.cs
+++ b/Compiler/Contract/Config/ConfigHelper.cs
@@ -2,11 +2,58 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace Bridge.Contract
 {
     public class ConfigHelper
     {
+        class PathChanger
+        {
+            //private Regex PathSchemaRegex = new Regex(@"(?<=(^\w+:)|^)[\\/]{2,}");
+            //private Regex PathNonSchemaRegex = new Regex(@"(?<!((^\w+:)|^)[\\/]*)[\\/]+");
+            private Regex PathRegex = new Regex(@"(?<schema>(?<=(^\w+:)|^)[\\/]{2,})|[\\/]+");
+
+            public string Separator
+            {
+                get; private set;
+            }
+
+            public string DoubleSeparator
+            {
+                get; private set;
+            }
+
+            public string Path
+            {
+                get; private set;
+            }
+
+            public PathChanger(string path, char separator)
+            {
+                Path = path;
+                Separator = separator.ToString();
+                DoubleSeparator = new string(separator, 2);
+            }
+
+            private string ReplaceSlashEvaluator(Match m)
+            {
+                if (m.Groups["schema"].Success)
+                {
+                    return DoubleSeparator;
+                }
+                return Separator;
+            }
+
+            public string ConvertPath()
+            {
+                //path = PathSchemaRegex.Replace(path, directorySeparator.ToString());
+                //path = PathNonSchemaRegex.Replace(path, directorySeparator.ToString());
+
+                return PathRegex.Replace(Path, ReplaceSlashEvaluator);
+            }
+        }
+
         public string ConvertPath(string path, char directorySeparator = char.MinValue)
         {
             if (path == null)
@@ -19,10 +66,7 @@ namespace Bridge.Contract
                 directorySeparator = Path.DirectorySeparatorChar;
             }
 
-            path = path.Replace("//", directorySeparator.ToString());
-            path = path.Replace('/', directorySeparator);
-            path = path.Replace("\\\\", directorySeparator.ToString());
-            path = path.Replace('\\', directorySeparator);
+            path = new PathChanger(path, directorySeparator).ConvertPath();
 
             return path;
         }

--- a/Compiler/TranslatorTests/Bridge.Translator.Tests.csproj
+++ b/Compiler/TranslatorTests/Bridge.Translator.Tests.csproj
@@ -66,6 +66,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="OutputTest.cs" />
+    <Compile Include="ContractTests\ConfigHelperTests.cs" />
     <Compile Include="TranslatorRunner.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -84,7 +85,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Build\" />
-    <Folder Include="TestProjects\Helpers\" />
+    <Folder Include="TestProjects\" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/Compiler/TranslatorTests/ContractTests/ConfigHelperTests.cs
+++ b/Compiler/TranslatorTests/ContractTests/ConfigHelperTests.cs
@@ -1,0 +1,93 @@
+﻿
+using Bridge.Contract;
+using NUnit.Framework;
+
+namespace Bridge.Translator.Tests
+{
+    [TestFixture]
+    internal class ConfigHelperTests
+    {
+        public class ConvertPathTests
+        {
+            public ConfigHelper Helper
+            {
+                get; set;
+            }
+
+            [OneTimeSetUp]
+            public void TestFixtureSetUp()
+            {
+                this.Helper = new ConfigHelper();
+            }
+
+            class A
+            {
+                public string Input
+                {
+                    get; set;
+                }
+
+                public string Expected
+                {
+                    get; set;
+                }
+
+                public char Separator
+                {
+                    get; set;
+                }
+
+                public A(string input, string expected, char separator)
+                {
+                    Input = input;
+                    Expected = expected;
+                    Separator = separator;
+                }
+            }
+
+            [TestCase]
+            public void ConvertPath()
+            {
+                var data = new A[]
+                {
+                    new A(@"\\root\folder1\\folder2\\\folder3\", @"//root/folder1/folder2/folder3/", '/'),
+                    new A(@"http:\\root\folder1\\folder2\\\folder3\", @"http://root/folder1/folder2/folder3/", '/'),
+                    new A(@"https:\\root\folder1\\folder2\\\folder3\", @"https://root/folder1/folder2/folder3/", '/'),
+                    new A(@"ftp:\\root\folder1\\folder2\\\folder3", @"ftp://root/folder1/folder2/folder3", '/'),
+                    new A(@"\root\folder1/\\folder2\\\folder3\", @"/root/folder1/folder2/folder3/", '/'),
+                    new A(@"\root\folder1\\folder2//\\\folder3\folder4/folder5//folder6/", @"/root/folder1/folder2/folder3/folder4/folder5/folder6/", '/'),
+                    new A(@"\\root\folder1\\folder2\\\folder3\", @"//root/folder1/folder2/folder3/", '/'),
+                    new A(null, null, '/'),
+                    new A("", "", '/'),
+
+                    new A(@"http:\\root\folder1\\folder2\\\folder3\", @"http:\\root\folder1\folder2\folder3\", '\\'),
+                    new A(@"https:\\root\folder1\\folder2\\\folder3\", @"https:\\root\folder1\folder2\folder3\", '\\'),
+                    new A(@"ftp:\\root\folder1\\folder2\\\folder3", @"ftp:\\root\folder1\folder2\folder3", '\\'),
+                    new A(@"\\root\folder1\\folder2\\\folder3\", @"\\root\folder1\folder2\folder3\", '\\'),
+                    new A(@"\root\folder1/\\folder2\\\folder3\", @"\root\folder1\folder2\folder3\", '\\'),
+                    new A(@"\root\folder1\\folder2//\\\folder3\folder4/folder5//folder6/", @"\root\folder1\folder2\folder3\folder4\folder5\folder6\", '\\'),
+                    new A(@"\\root\folder1\\folder2\\\folder3\", @"\\root\folder1\folder2\folder3\", '\\'),
+                    new A(@"//root\folder1\\folder2\\\folder3\", @"\\root\folder1\folder2\folder3\", '\\'),
+                    new A(@"/root\folder1/\\folder2\\\folder3\", @"\root\folder1\folder2\folder3\", '\\'),
+                    new A(@"/root\folder1\\folder2//\\\folder3\folder4/folder5//folder6/", @"\root\folder1\folder2\folder3\folder4\folder5\folder6\", '\\'),
+                    new A(@"//root\folder1\\folder2\\\folder3\", @"\\root\folder1\folder2\folder3\", '\\'),
+                    new A(null, null, '\\'),
+                    new A("", "", '\\')
+                };
+
+                string actual;
+
+                var number = 1;
+
+                foreach (var d in data)
+                {
+                    actual = Helper.ConvertPath(d.Input, d.Separator);
+
+                    Assert.AreEqual(d.Expected, actual, "Test number " + number);
+
+                    number++;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
See #1960

Changes proposed in this pull request:

- Do not replace trailing double '\\' or '//' in paths in case for server apps like
For, example,  **\\root\folder\**

Convertion result for  **\\root/folder/**
- before fix  **\root\folder\**
- after fix  **\\root\folder\**

Fixes PR #1990