### PR TITLE
[2074] "fileName" option in bridge.json requires outputBy Project

### DIFF
--- a/Compiler/Translator/Utils/AssemblyInfo.cs
+++ b/Compiler/Translator/Utils/AssemblyInfo.cs
@@ -55,10 +55,11 @@ namespace Bridge.Translator
         {
             get
             {
-                if (this.CombineScripts)
+                if (this.CombineScripts || !string.IsNullOrEmpty(this.FileName))
                 {
                     return OutputBy.Project;
                 }
+
                 return this.outputBy;
             }
             set

--- a/Compiler/TranslatorTests/TestProjects/15/Bridge/bridge.json
+++ b/Compiler/TranslatorTests/TestProjects/15/Bridge/bridge.json
@@ -2,6 +2,5 @@
   "output": "Bridge\\output",
   "cleanOutputFolderBeforeBuildPattern": "*.*",
   "fileName": "code.js",
-  "outputBy": "project",
   "preserveMemberCase": "true"
 }


### PR DESCRIPTION
Fixes #2074

Changes proposed in this pull request:

-  Set `outputBy: "Project"` if fileName being used
