### PR TITLE
[2077] Support boxing/unboxing operations

### DIFF
--- a/Bridge/Attributes/UnboxAttribute.cs
+++ b/Bridge/Attributes/UnboxAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Bridge
+{
+    [External]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    [NonScriptable]
+    public class UnboxAttribute : Attribute
+    {
+        public extern UnboxAttribute(bool allow);
+    }
+}

--- a/Bridge/Bridge.csproj
+++ b/Bridge/Bridge.csproj
@@ -57,6 +57,7 @@
     <AdditionalExplicitAssemblyReferences />
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Attributes\UnboxAttribute.cs" />
     <Compile Include="Attributes\GlobalMethodsAttribute.cs" />
     <Compile Include="Attributes\MixinAttribute.cs" />
     <Compile Include="Attributes\ImmutableAttribute.cs" />

--- a/Bridge/Resources/.generated/bridge/utils/console.js
+++ b/Bridge/Resources/.generated/bridge/utils/console.js
@@ -220,8 +220,8 @@
                 this.closeBtn.addEventListener("mouseout", Bridge.fn.bind(this, this.hideTooltip));
 
                 this.consoleDefined = Bridge.isDefined(Bridge.global) && Bridge.isDefined(Bridge.global.console);
-                this.consoleDebugDefined = this.consoleDefined && Bridge.isDefined(Bridge.global.console.debug);
-                this.operaPostErrorDefined = Bridge.isDefined(Bridge.global.opera) && Bridge.isDefined(Bridge.global.opera.postError);
+                this.consoleDebugDefined = this.consoleDefined && Bridge.isDefined(Bridge.unbox(Bridge.global.console.debug));
+                this.operaPostErrorDefined = Bridge.isDefined(Bridge.global.opera) && Bridge.isDefined(Bridge.unbox(Bridge.global.opera.postError));
             }
         },
         showTooltip: function () {

--- a/Bridge/Resources/.generated/system/formattableStringImpl.js
+++ b/Bridge/Resources/.generated/system/formattableStringImpl.js
@@ -26,3 +26,11 @@
             return System.String.formatProvider.apply(System.String, [formatProvider, this.format].concat(this.args));
         }
     });
+
+    var $box_ = {};
+
+    Bridge.ns("System.Char", $box_);
+
+    Bridge.apply($box_.System.Char, {
+        toString: function(obj) {return String.fromCharCode(obj);}
+    });

--- a/Bridge/Resources/.generated/system/guid.js
+++ b/Bridge/Resources/.generated/system/guid.js
@@ -89,7 +89,7 @@
             }
 
             if (b.length !== 16) {
-                throw new System.ArgumentException(System.String.format(System.Guid.error1, 16));
+                throw new System.ArgumentException(System.String.format(System.Guid.error1, Bridge.box(16, System.Int32)));
             }
 
             this._a = (b[3] << 24) | (b[2] << 16) | (b[1] << 8) | b[0];
@@ -125,7 +125,7 @@
             }
 
             if (d.length !== 8) {
-                throw new System.ArgumentException(System.String.format(System.Guid.error1, 8));
+                throw new System.ArgumentException(System.String.format(System.Guid.error1, Bridge.box(8, System.Int32)));
             }
 
             this._a = a;
@@ -262,10 +262,10 @@
                     return s.replace(System.Guid.replace, "");
                 case "b": 
                 case "B": 
-                    return System.String.concat(String.fromCharCode(123), s, String.fromCharCode(125));
+                    return System.String.concat(String.fromCharCode(Bridge.box(123, System.Char, $box_.System.Char.toString)), s, String.fromCharCode(Bridge.box(125, System.Char, $box_.System.Char.toString)));
                 case "p": 
                 case "P": 
-                    return System.String.concat(String.fromCharCode(40), s, String.fromCharCode(41));
+                    return System.String.concat(String.fromCharCode(Bridge.box(40, System.Char, $box_.System.Char.toString)), s, String.fromCharCode(Bridge.box(41, System.Char, $box_.System.Char.toString)));
                 default: 
                     return s;
             }

--- a/Bridge/Resources/.typescript/bridge.d.ts
+++ b/Bridge/Resources/.typescript/bridge.d.ts
@@ -1,6 +1,8 @@
 declare module Bridge {
     export function global<T>(): T;
     export function emptyFn(): Function;
+    export function box<T>(v: T, type: { prototype: T }): { v: T, type: { prototype: T } };
+    export function unbox(obj:any): any;
     export function property(scope: any, name: string, defaultValue: any): void;
     export function event(scope: any, name: string, defaultValue: any): void;
     export function copy<T>(to: T, from: T, keys: string[], toIf?: boolean): T;

--- a/Bridge/Resources/Class.js
+++ b/Bridge/Resources/Class.js
@@ -381,10 +381,13 @@
             }
 
             if (Class.$kind === "enum") {
+                if (!Class.prototype.$utype) {
+                    Class.prototype.$utype = System.Int32;
+                }
                 Class.$is = function (instance) {
                     var utype = Class.prototype.$utype;
 
-                    if (utype === System.String) {
+                    if (utype === String) {
                         return typeof (instance) == "string";
                     }
 
@@ -398,7 +401,7 @@
                 Class.getDefaultValue = function () {
                     var utype = Class.prototype.$utype;
 
-                    if (utype === System.String) {
+                    if (utype === String) {
                         return null;
                     }
 

--- a/Bridge/Resources/Core.js
+++ b/Bridge/Resources/Core.js
@@ -15,6 +15,51 @@
             return name2;
         },
 
+        box: function (v, T, toStr, hashCode) {
+            if (v && v.$boxed) {
+                return v;
+            }
+
+            if (v == null) {
+                return v;
+            }
+
+            return {
+                $boxed: true,
+                fn: {
+                    toString: toStr,
+                    getHashCode: hashCode
+                },
+                v: v,
+                type: T,
+                constructor: T,
+                getHashCode: function() {
+                    return this.fn.getHashCode ? this.fn.getHashCode(this.v) : Bridge.getHashCode(this.v);
+                },
+                equals: function (o) {
+                    var eq = this.equals;
+                    this.equals = null;
+                    var r = Bridge.equals(this.v, o);
+                    this.equals = eq;
+                    return r;
+                },
+                valueOf: function() {
+                    return this.v;
+                },
+                toString: function () {
+                    return this.fn.toString ? this.fn.toString(this.v) : this.v.toString();
+                }
+            };
+        },
+
+        unbox: function(o) {
+            if (o && o.$boxed) {
+                return o.v;
+            }
+
+            return o;
+        },
+
         isPlainObject: function (obj) {
             if (typeof obj == 'object' && obj !== null) {
                 if (typeof Object.getPrototypeOf == 'function') {
@@ -343,6 +388,8 @@
             //     for value types it returns deterministic values (f.e. for int 3 it returns 3)
             //     for reference types it returns random value
 
+            value = Bridge.unbox(value);
+
             if (Bridge.isEmpty(value, true)) {
                 if (safe) {
                     return 0;
@@ -451,7 +498,7 @@
         },
 
         hasValue: function (obj) {
-            return obj != null;
+            return Bridge.unbox(obj) != null;
         },
 
         hasValue$1: function () {
@@ -473,6 +520,25 @@
         is: function (obj, type, ignoreFn, allowNull) {
             if (obj == null) {
                 return !!allowNull;
+            }
+
+            if (obj.$boxed) {
+                if (obj.type.$kind === "enum" && (obj.type.prototype.$utype === type || type === System.Enum)) {
+                    return true;
+                }
+                else if (type.$kind !== "interface" && !type.$nullable) {
+                    return obj.type === type || type === Object;
+                }
+
+                if (ignoreFn !== true && type.$is) {
+                    return type.$is(Bridge.unbox(obj));
+                }
+
+                if (Bridge.Reflection.isAssignableFrom(type, obj.type)) {
+                    return true;
+                }
+
+                obj = Bridge.unbox(obj);
             }
 
             var ctor = obj.constructor;
@@ -546,7 +612,10 @@
         },
 
         as: function (obj, type, allowNull) {
-            return Bridge.is(obj, type, false, allowNull) ? obj : null;
+            if (Bridge.is(obj, type, false, allowNull)) {
+                return obj.$boxed && type !== Object ? obj.v : obj;
+            }
+            return null;
         },
 
         cast: function (obj, type, allowNull) {
@@ -558,6 +627,10 @@
 
             if (result === null) {
                 throw new System.InvalidCastException("Unable to cast type " + (obj ? Bridge.getTypeName(obj) : "'null'") + " to type " + Bridge.getTypeName(type));
+            }
+
+            if (obj.$boxed && type !== Object) {
+                return obj.v;
             }
 
             return result;
@@ -1011,6 +1084,10 @@
         },
 
         getType: function (instance) {
+            if (instance && instance.$boxed) {
+                return instance.type;
+            }
+
             if (instance == null) {
                 throw new System.NullReferenceException("instance is null");
             }

--- a/Bridge/Resources/Enum.js
+++ b/Bridge/Resources/Enum.js
@@ -28,7 +28,7 @@
             var intValue = {};
 
             if (System.Int32.tryParse(s, intValue)) {
-                return intValue.v;
+                return Bridge.box(intValue.v, enumType, function (obj) { return System.Enum.toString(enumType, obj); });
             }
 
             var values = enumType;
@@ -36,7 +36,7 @@
             if (!enumType.prototype || !enumType.prototype.$flags) {
                 for (var f in values) {
                     if (enumMethods.nameEquals(f, s, ignoreCase)) {
-                        return values[f];
+                        return Bridge.box(values[f], enumType, function (obj) { return System.Enum.toString(enumType, obj); });
                     }
                 }
             } else {
@@ -65,7 +65,7 @@
                 }
 
                 if (parsed) {
-                    return value;
+                    return Bridge.box(value, enumType, function (obj) { return System.Enum.toString(enumType, obj); });
                 }
             }
 
@@ -77,6 +77,12 @@
         },
 
         toString: function (enumType, value, forceFlags) {
+            if (value && value.$boxed && enumType === System.Enum) {
+                enumType = value.type;
+            }
+
+            value = Bridge.unbox(value);
+
             if (enumType === Number) {
                 return value.toString();
             }
@@ -174,7 +180,6 @@
             System.Enum.checkEnumType(enumType);
 
             var values = enumType;
-
             for (var i in values) {
                 if (values[i] === value) {
                     return i.charAt(0).toUpperCase() + i.slice(1);
@@ -205,7 +210,7 @@
 
         tryParse: function (enumType, value, result, ignoreCase) {
             result.v = 0;
-            result.v = enumMethods.parse(enumType, value, ignoreCase, true);
+            result.v = Bridge.unbox(enumMethods.parse(enumType, value, ignoreCase, true));
 
             if (result.v == null) {
                 return false;

--- a/Bridge/Resources/Nullable.js
+++ b/Bridge/Resources/Nullable.js
@@ -2,6 +2,7 @@
         hasValue: Bridge.hasValue,
 
         getValue: function (obj) {
+            obj = Bridge.unbox(obj);
             if (!Bridge.hasValue(obj)) {
                 throw new System.InvalidOperationException("Nullable instance doesn't have a value.");
             }
@@ -181,6 +182,8 @@
             $kind: "struct",
 
             statics: {
+                $nullable: true,
+                $nullableType: T,
                 getDefaultValue: function () {
                     return null;
                 },

--- a/Bridge/Resources/String.js
+++ b/Bridge/Resources/String.js
@@ -117,10 +117,13 @@
                 value = "";
             }
 
-            if (formatStr && Bridge.is(value, System.IFormattable)) {
-                value = Bridge.format(value, formatStr, provider);
+            if (formatStr && value.$boxed && value.type.$kind === "enum") {
+                value = System.Enum.format(value.type, value.v, formatStr);
+            }
+            else if (formatStr && Bridge.is(value, System.IFormattable)) {
+                value = Bridge.format(Bridge.unbox(value), formatStr, provider);
             } else {
-                value = "" + value;
+                value = "" + value.toString();
             }
 
             if (alignment) {

--- a/Bridge/System/Console.cs
+++ b/Bridge/System/Console.cs
@@ -6,6 +6,7 @@ namespace System
     /// Represents the standard input, output, and error streams for console applications.
     /// </summary>
     [External]
+    [Unbox(false)]
     [Name("console")]
     public sealed partial class Console
     {

--- a/Bridge/System/String.cs
+++ b/Bridge/System/String.cs
@@ -697,6 +697,7 @@ namespace System
         ///     of the corresponding objects in args.
         ///
         [Template("System.String.format({format}, {args})")]
+        [Unbox(false)]
         public static extern string Format(string format, params object[] args);
 
         ///
@@ -715,6 +716,7 @@ namespace System
         ///     A copy of format in which any format items are replaced by the string representation
         ///     of arg0.
         [Template("System.String.format({format}, {arg0})")]
+        [Unbox(false)]
         public static extern String Format(String format, object arg0);
 
         ///
@@ -737,6 +739,7 @@ namespace System
         ///     A copy of format in which the format items have been replaced by the string representation
         ///     of the corresponding objects in args.
         [Template("System.String.formatProvider({provider}, {format}, {args})")]
+        [Unbox(false)]
         public static extern String Format(IFormatProvider provider, String format, params object[] args);
 
         ///
@@ -758,6 +761,7 @@ namespace System
         ///     A copy of format in which format items are replaced by the string representations
         ///     of arg0 and arg1.
         [Template("System.String.format({format}, {arg0}, {arg1})")]
+        [Unbox(false)]
         public static extern String Format(String format, object arg0, object arg1);
 
         ///
@@ -782,6 +786,7 @@ namespace System
         ///     A copy of format in which the format items have been replaced by the string representations
         ///     of arg0, arg1, and arg2.
         [Template("System.String.format({format}, {arg0}, {arg1}, {arg2})")]
+        [Unbox(false)]
         public static extern String Format(String format, object arg0, object arg1, object arg2);
 
         [Template("System.String.indexOfAny({this}, {anyOf})")]
@@ -830,12 +835,14 @@ namespace System
         public static extern string Join(string separator, params string[] args);
 
         [Template("{args:array}.join({separator})")]
+        [Unbox(false)]
         public static extern string Join(string separator, params object[] args);
 
         [Template("Bridge.toArray({args}).join({separator})")]
         public static extern string Join(string separator, IEnumerable<string> args);
 
         [Template("Bridge.toArray({args}).join({separator})")]
+        [Unbox(false)]
         public static extern string Join<T>(string separator, IEnumerable<T> args);
 
         [Template("{args}.slice({startIndex}, {startIndex} + {count}).join({separator})")]

--- a/Compiler/Contract/Constants/JS.cs
+++ b/Compiler/Contract/Constants/JS.cs
@@ -242,6 +242,7 @@
         {
             public const char D = '$';
             public const string D_ = "$_";
+            public const string DBOX_ = "$box_";
             public const string D_THIS = "$this";
 
             public const string T = "$t";

--- a/Compiler/Contract/IEmitter.cs
+++ b/Compiler/Contract/IEmitter.cs
@@ -419,6 +419,11 @@ namespace Bridge.Contract
             get; set;
         }
 
+        Dictionary<IType, Dictionary<string, string>> NamedBoxedFunctions
+        {
+            get; set;
+        }
+
         bool StaticBlock
         {
             get;
@@ -469,5 +474,7 @@ namespace Bridge.Contract
 
         void WriteIndented(string s, int? position = null);
         string GetReflectionName(IType type);
+
+        bool ForbidLifting { get; set; }
     }
 }

--- a/Compiler/Translator/Emitter/Blocks/BinaryOperatorBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/BinaryOperatorBlock.cs
@@ -924,10 +924,6 @@ namespace Bridge.Translator
                         argsInfo.ArgumentsNames = new string[] { "this" };
                         argsInfo.ThisArgument = result;
                         new InlineArgumentsBlock(this.Emitter, argsInfo, writer.InlineCode).Emit();
-
-                        //result = writer.InlineCode.Replace("{this}", result);
-                        //this.Write(result);
-
                         return;
                     }
                 }

--- a/Compiler/Translator/Emitter/Blocks/ClassBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/ClassBlock.cs
@@ -340,11 +340,15 @@ namespace Bridge.Translator
                 var etype = this.TypeInfo.Type.GetDefinition().EnumUnderlyingType;
                 var enumMode = this.Emitter.Validator.EnumEmitMode(this.TypeInfo.Type);
                 var isString = enumMode >= 3 && enumMode <= 6;
-                if (!etype.IsKnownType(KnownTypeCode.Int32) || isString)
+                if (isString)
+                {
+                    etype = this.Emitter.Resolver.Compilation.FindType(KnownTypeCode.String);
+                }
+                if (!etype.IsKnownType(KnownTypeCode.Int32))
                 {
                     this.EnsureComma();
                     this.Write(JS.Fields.UNDERLYINGTYPE + ": ");
-                    this.Write(isString ? "System.String" : BridgeTypes.ToJsName(etype, this.Emitter));
+                    this.Write(BridgeTypes.ToJsName(etype, this.Emitter));
 
                     this.Emitter.Comma = true;
                 }

--- a/Compiler/Translator/Emitter/Blocks/ConversionBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/ConversionBlock.cs
@@ -8,6 +8,8 @@ using ICSharpCode.NRefactory.TypeSystem.Implementation;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using ICSharpCode.NRefactory.CSharp.Resolver;
+using Object.Net.Utilities;
 
 namespace Bridge.Translator
 {
@@ -21,7 +23,7 @@ namespace Bridge.Translator
         protected sealed override void DoEmit()
         {
             this.AfterOutput = "";
-            this.AfterExpressionOutput = "";
+            this.AfterOutput2 = "";
             var expression = this.GetExpression();
 
             if (expressionInWork.Contains(expression))
@@ -88,6 +90,11 @@ namespace Bridge.Translator
             {
                 this.Write(this.AfterOutput);
             }
+
+            if (this.AfterOutput2.Length > 0)
+            {
+                this.Write(this.AfterOutput2);
+            }
         }
 
         protected virtual string AfterOutput
@@ -96,7 +103,7 @@ namespace Bridge.Translator
             set;
         }
 
-        protected virtual string AfterExpressionOutput
+        protected virtual string AfterOutput2
         {
             get;
             set;
@@ -159,8 +166,89 @@ namespace Bridge.Translator
             return 0;
         }
 
+        private static string GetBoxedType(IType itype, IEmitter emitter)
+        {
+            if (NullableType.IsNullable(itype))
+            {
+                itype = NullableType.GetUnderlyingType(itype);
+            }
+
+            return BridgeTypes.ToJsName(itype, emitter);
+        }
+
+        private static string GetInlineMethod(IEmitter emitter, string name, IType returnType, ResolveResult rr, Expression expression)
+        {
+            if (emitter.NamedBoxedFunctions.ContainsKey(rr.Type) && emitter.NamedBoxedFunctions[rr.Type].ContainsKey(name) && emitter.NamedBoxedFunctions[rr.Type][name] != null)
+            {
+                return JS.Vars.DBOX_ + "." + BridgeTypes.ToJsName(rr.Type, emitter, true) + "." + name.ToLowerCamelCase();
+            }
+
+            var methodDef = rr.Type.GetMembers().FirstOrDefault(m =>
+            {
+                if (m.Name == name && !m.IsStatic && m.ReturnType.Equals(returnType) && m.IsOverride)
+                {
+                    var method = m as IMethod;
+
+                    if (method != null && method.Parameters.Count == 0 && method.TypeParameters.Count == 0)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            });
+
+            if (methodDef != null)
+            {
+                var inline = emitter.GetInline(methodDef);
+
+                if (inline != null)
+                {
+                    var writer = new Writer
+                    {
+                        InlineCode = inline,
+                        Output = emitter.Output,
+                        IsNewLine = emitter.IsNewLine
+                    };
+                    emitter.IsNewLine = false;
+                    emitter.Output = new StringBuilder();
+
+                    var argsInfo = new ArgumentsInfo(emitter, expression, rr);
+                    argsInfo.ArgumentsExpressions = new Expression[] {expression};
+                    argsInfo.ArgumentsNames = new string[] {"this"};
+                    argsInfo.ThisArgument = "obj";
+                    new InlineArgumentsBlock(emitter, argsInfo, writer.InlineCode).Emit();
+
+                    var result = emitter.Output.ToString();
+                    emitter.Output = writer.Output;
+                    emitter.IsNewLine = writer.IsNewLine;
+
+                    Dictionary<string, string> fn = null;
+
+                    if (emitter.NamedBoxedFunctions.ContainsKey(rr.Type))
+                    {
+                        fn = emitter.NamedBoxedFunctions[rr.Type];
+                    }
+                    else
+                    {
+                        fn = new Dictionary<string, string>();
+                        emitter.NamedBoxedFunctions.Add(rr.Type, fn);
+                    }
+
+                    result = string.Format("function(obj) {{return {0};}}", result);
+
+                    fn.Add(name, result);
+
+                    return JS.Vars.DBOX_ + "." + BridgeTypes.ToJsName(rr.Type, emitter, true) + "." + name.ToLowerCamelCase();
+                }
+
+            }
+
+            return null;
+        }
+
         private static int DoConversion(ConversionBlock block, Expression expression, Conversion conversion, IType expectedType,
-            int level, ResolveResult rr, bool ignoreConversionResolveResult = false)
+            int level, ResolveResult rr, bool ignoreConversionResolveResult = false, bool ignoreBoxing = false)
         {
             if (ConversionBlock.expressionIgnoreUserDefine.Contains(expression) && conversion.IsUserDefined)
             {
@@ -170,6 +258,81 @@ namespace Bridge.Translator
             if (block.Emitter.IsAssignment)
             {
                 return level;
+            }
+
+            if (!ignoreBoxing && expectedType.Kind != TypeKind.Dynamic)
+            {
+                var inv = expression.Parent as InvocationExpression;
+                var isArgument = inv != null && inv.Arguments.Contains(expression);
+
+                if (isArgument)
+                {
+                    var inv_rr = block.Emitter.Resolver.ResolveNode(inv, block.Emitter);
+                    var parent_rr = inv_rr as InvocationResolveResult;
+                    if (parent_rr != null)
+                    {
+                        isArgument = block.Emitter.Validator.IsIgnoreType(parent_rr.Member.DeclaringTypeDefinition) || block.Emitter.Validator.IsIgnoreType(parent_rr.Member);
+
+                        var attr = parent_rr.Member.Attributes.FirstOrDefault(a => a.AttributeType.FullName == "Bridge.UnboxAttribute");
+
+                        if (attr != null)
+                        {
+                            isArgument = (bool)attr.PositionalArguments.First().ConstantValue;
+                        }
+                        else
+                        {
+                            attr = parent_rr.Member.DeclaringTypeDefinition.Attributes.FirstOrDefault(a => a.AttributeType.FullName == "Bridge.UnboxAttribute");
+
+                            if (attr != null)
+                            {
+                                isArgument = (bool)attr.PositionalArguments.First().ConstantValue;
+                            }
+                        }
+                    }
+                    else if (inv_rr is DynamicInvocationResolveResult)
+                    {
+                        isArgument = true;
+                    }
+                    
+                }
+
+                if (conversion.IsBoxingConversion && !isArgument)
+                {
+                    block.Write("Bridge.box(");
+                    block.AfterOutput2 += ", " + ConversionBlock.GetBoxedType(rr.Type, block.Emitter);
+
+                    var inlineMethod = ConversionBlock.GetInlineMethod(block.Emitter, "ToString",
+                        block.Emitter.Resolver.Compilation.FindType(KnownTypeCode.String), rr, expression);
+
+                    if (inlineMethod != null)
+                    {
+                        block.AfterOutput2 += ", " + inlineMethod ;
+                    }
+
+                    inlineMethod = ConversionBlock.GetInlineMethod(block.Emitter, "GetHashCode",
+                        block.Emitter.Resolver.Compilation.FindType(KnownTypeCode.String), rr, expression);
+
+                    if (inlineMethod != null)
+                    {
+                        block.AfterOutput2 += ", " + inlineMethod;
+                    }
+
+                    block.AfterOutput2 +=")";
+
+                    if (rr.Type.Kind == TypeKind.TypeParameter)
+                    {
+                        block.Emitter.ForbidLifting = true;
+                    }
+
+                    //return level;
+                }
+
+                if (conversion.IsUnboxingConversion || isArgument && expectedType.IsKnownType(KnownTypeCode.Object) && rr.Type.IsKnownType(KnownTypeCode.Object))
+                {
+                    block.Write("Bridge.unbox(");
+                    block.AfterOutput2 += ")";
+                    //return level;
+                }
             }
 
             if (expression is ParenthesizedExpression && ((ParenthesizedExpression) expression).Expression is CastExpression)
@@ -213,14 +376,14 @@ namespace Bridge.Translator
 
                         if (parentrr != null && parentrr.Type != expectedType || parentrr == null && expectedType != parentExpectedType)
                         {
-                            level = ConversionBlock.DoConversion(block, expression, conversion, expectedType, level, rr, true);
+                            level = ConversionBlock.DoConversion(block, expression, conversion, expectedType, level, rr, true, true);
                             afterUserDefined = block.AfterOutput;
                             block.AfterOutput = "";
                         }
                     }
                     else
                     {
-                        level = ConversionBlock.DoConversion(block, expression, conversion, expectedType, level, rr, true);
+                        level = ConversionBlock.DoConversion(block, expression, conversion, expectedType, level, rr, true, true);
                         afterUserDefined = block.AfterOutput;
                         block.AfterOutput = "";
                     }

--- a/Compiler/Translator/Emitter/Blocks/EmitBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/EmitBlock.cs
@@ -242,6 +242,7 @@ namespace Bridge.Translator
             var reflectedTypes = this.Emitter.ReflectableTypes;
             var tmpBuffer = new StringBuilder();
             StringBuilder currentOutput = null;
+            this.Emitter.NamedBoxedFunctions = new Dictionary<IType, Dictionary<string, string>>();
 
             foreach (var type in this.Emitter.Types)
             {
@@ -311,6 +312,8 @@ namespace Bridge.Translator
                 currentOutput.Append(tmpBuffer.ToString());
                 this.Emitter.Output = currentOutput;
             }
+
+            this.EmitNamedBoxedFunctions();
 
             this.Emitter.NamespacesCache = new Dictionary<string, int>();
             foreach (var type in this.Emitter.Types)
@@ -437,6 +440,51 @@ namespace Bridge.Translator
             //this.RemovePenultimateEmptyLines(true);
 
             this.Emitter.Translator.Plugins.AfterTypesEmit(this.Emitter, this.Emitter.Types);
+        }
+
+        protected virtual void EmitNamedBoxedFunctions()
+        {
+            if (this.Emitter.NamedBoxedFunctions.Count > 0)
+            {
+                this.Emitter.Comma = false;
+
+                this.WriteNewLine();
+                this.Write("var " + JS.Vars.DBOX_ + " = {};");
+
+                foreach (var boxedFunction in this.Emitter.NamedBoxedFunctions)
+                {
+                    var name = BridgeTypes.ToJsName(boxedFunction.Key, this.Emitter, true);
+
+                    this.WriteNewLine();
+                    this.WriteNewLine();
+                    this.Write(JS.Funcs.BRIDGE_NS);
+                    this.WriteOpenParentheses();
+                    this.WriteScript(name);
+                    this.Write(", " + JS.Vars.DBOX_ + ")");
+                    this.WriteSemiColon();
+
+                    this.WriteNewLine();
+                    this.WriteNewLine();
+                    this.Write(JS.Types.Bridge.APPLY + "(" + JS.Vars.DBOX_ + ".");
+                    this.Write(name);
+                    this.Write(", ");
+                    this.BeginBlock();
+
+                    this.Emitter.Comma = false;
+                    foreach (KeyValuePair<string, string> namedFunction in boxedFunction.Value)
+                    {
+                        this.EnsureComma();
+                        this.Write(namedFunction.Key.ToLowerCamelCase() + ": " + namedFunction.Value);
+                        this.Emitter.Comma = true;
+                    }
+
+                    this.WriteNewLine();
+                    this.EndBlock();
+                    this.WriteCloseParentheses();
+                    this.WriteSemiColon();
+                    this.WriteNewLine();
+                }
+            }
         }
 
         private IType[] GetReflectableTypes()

--- a/Compiler/Translator/Emitter/Blocks/InlineArgumentsBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/InlineArgumentsBlock.cs
@@ -502,7 +502,7 @@ namespace Bridge.Translator
                             var rr = this.Emitter.Resolver.ResolveNode(node, this.Emitter);
                             var type = rr.Type;
                             var mrr = rr as MemberResolveResult;
-                            if (mrr != null && mrr.Member.ReturnType.Kind != TypeKind.Enum)
+                            if (mrr != null && mrr.Member.ReturnType.Kind != TypeKind.Enum && mrr.TargetResult != null)
                             {
                                 type = mrr.TargetResult.Type;
                             }

--- a/Compiler/Translator/Emitter/Blocks/LambdaBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/LambdaBlock.cs
@@ -147,7 +147,8 @@ namespace Bridge.Translator
         protected virtual void EmitLambda(IEnumerable<ParameterDeclaration> parameters, AstNode body, AstNode context)
         {
             var rr = this.Emitter.Resolver.ResolveNode(context, this.Emitter);
-
+            var oldLifting = this.Emitter.ForbidLifting;
+            this.Emitter.ForbidLifting = false;
             var analyzer = new CaptureAnalyzer(this.Emitter);
             analyzer.Analyze(this.Body, this.Parameters.Select(p => p.Name));
 
@@ -236,23 +237,29 @@ namespace Bridge.Translator
 
             if (analyzer.UsedVariables.Count == 0)
             {
-                var name = "f" + (this.Emitter.NamedFunctions.Count + 1);
-                var code = this.Emitter.Output.ToString().Substring(savedPos);
-                var pair = this.Emitter.NamedFunctions.FirstOrDefault(p => p.Value == code);
-
-                if (pair.Key != null && pair.Value != null)
+                if (!this.Emitter.ForbidLifting)
                 {
-                    name = pair.Key;
-                }
-                else
-                {
-                    this.Emitter.NamedFunctions.Add(name, code);
-                }
+                    var name = "f" + (this.Emitter.NamedFunctions.Count + 1);
+                    var code = this.Emitter.Output.ToString().Substring(savedPos);
+                    var pair = this.Emitter.NamedFunctions.FirstOrDefault(p => p.Value == code);
 
-                this.Emitter.Output.Remove(savedPos, this.Emitter.Output.Length - savedPos);
-                this.Emitter.Output.Insert(savedPos, JS.Vars.D_ + "." + BridgeTypes.ToJsName(this.Emitter.TypeInfo.Type, this.Emitter, true) + "." + name);
+                    if (pair.Key != null && pair.Value != null)
+                    {
+                        name = pair.Key;
+                    }
+                    else
+                    {
+                        this.Emitter.NamedFunctions.Add(name, code);
+                    }
+
+                    this.Emitter.Output.Remove(savedPos, this.Emitter.Output.Length - savedPos);
+                    this.Emitter.Output.Insert(savedPos, JS.Vars.D_ + "." + BridgeTypes.ToJsName(this.Emitter.TypeInfo.Type, this.Emitter, true) + "." + name);
+                }
+                
                 this.Emitter.ResetLevel(oldLevel);
             }
+
+            this.Emitter.ForbidLifting = oldLifting;
 
             if (this.Emitter.ThisRefCounter > savedThisCount)
             {

--- a/Compiler/Translator/Emitter/Emitter.Properties.cs
+++ b/Compiler/Translator/Emitter/Emitter.Properties.cs
@@ -451,6 +451,12 @@ namespace Bridge.Translator
             set;
         }
 
+        public Dictionary<IType, Dictionary<string, string>> NamedBoxedFunctions
+        {
+            get;
+            set;
+        }
+
         public bool IsJavaScriptOverflowMode
         {
             get
@@ -498,6 +504,11 @@ namespace Bridge.Translator
         }
 
         private bool AssemblyJsDocWritten
+        {
+            get; set;
+        }
+
+        public bool ForbidLifting
         {
             get; set;
         }

--- a/Tests/Batch1/BridgeConsoleTests.cs
+++ b/Tests/Batch1/BridgeConsoleTests.cs
@@ -12,8 +12,8 @@ namespace Bridge.ClientTest
         public void TestLogMessageObject()
         {
             AssertLogMessageObject("#0 - ", "Test Bridge Console Log Message Object", "Test Bridge Console Log Message Object");
-            AssertLogMessageObject("#1 - ", true, "true");
-            AssertLogMessageObject("#2 - ", false, "false");
+            AssertLogMessageObject("#1 - ", true, "True");
+            AssertLogMessageObject("#2 - ", false, "False");
             AssertLogMessageObject("#3 - ", -1, "-1");
             AssertLogMessageObject("#4 - ", 1, "1");
             AssertLogMessageObject("#5 - ", -12345678, "-12345678");
@@ -30,8 +30,8 @@ namespace Bridge.ClientTest
             AssertLogMessageObject("#16 - ", 12345678d, "12345678");
             AssertLogMessageObject("#17 - ", -1.12345678, "-1.12345678");
             AssertLogMessageObject("#18 - ", 1.12345678, "1.12345678");
-            AssertLogMessageObject("#19 - ", -12345678.12345678, "-12345678.12345678");
-            AssertLogMessageObject("#20 - ", 12345678.12345678, "12345678.12345678");
+            AssertLogMessageObject("#19 - ", -12345678.12345678, "-12345678.1234568");
+            AssertLogMessageObject("#20 - ", 12345678.12345678, "12345678.1234568");
             AssertLogMessageObject("#21 - ", -1m, "-1");
             AssertLogMessageObject("#22 - ", 1m, "1");
             AssertLogMessageObject("#23 - ", -12345678m, "-12345678");

--- a/Tests/Batch1/Linq/TestLinqConversionOperators.cs
+++ b/Tests/Batch1/Linq/TestLinqConversionOperators.cs
@@ -132,7 +132,7 @@ namespace Bridge.ClientTest.Linq
 
             var doubleNumbers = numbers.OfType<double>().ToArray();
 
-            Assert.AreDeepEqual(new[] { 1.0, 3, 5, 7.0 }, doubleNumbers, "Issue #218. OfType<double> should get only double type items");
+            Assert.AreDeepEqual(new[] { 1.0, 7.0 }, doubleNumbers, "Issue #218. OfType<double> should get only double type items");
         }
     }
 }

--- a/Tests/Batch1/SimpleTypes/CharTests.cs
+++ b/Tests/Batch1/SimpleTypes/CharTests.cs
@@ -10,7 +10,7 @@ namespace Bridge.ClientTest.SimpleTypes
         [Test]
         public void TypePropertiesAreInt32()
         {
-            Assert.True((object)0 is char);
+            Assert.False((object)0 is char);
             Assert.False((object)0.5 is char);
             Assert.False((object)-1 is char);
             Assert.False((object)65536 is char);

--- a/Tests/Batch1/SimpleTypes/Int64Tests.cs
+++ b/Tests/Batch1/SimpleTypes/Int64Tests.cs
@@ -130,8 +130,8 @@ namespace Bridge.ClientTest.SimpleTypes
             long l = 100;
 
             AssertLong("111", dcml + l, null, "System.Decimal");
-            AssertLong("112", dbl + l, null, "System.Int32");
-            AssertLong("113", flt + l, null, "System.Int32");
+            AssertLong("112", dbl + l, null, "System.Double");
+            AssertLong("113", flt + l, null, "System.Single");
         }
 
         private T GetDefaultValue<T>()

--- a/Tests/Batch1/SimpleTypes/SByteTests.cs
+++ b/Tests/Batch1/SimpleTypes/SByteTests.cs
@@ -10,7 +10,7 @@ namespace Bridge.ClientTest.SimpleTypes
         [Test]
         public void TypePropertiesAreCorrect()
         {
-            Assert.True((object)(byte)0 is sbyte);
+            Assert.False((object)(byte)0 is sbyte);
             Assert.False((object)0.5 is sbyte);
             Assert.False((object)-129 is sbyte);
             Assert.False((object)128 is sbyte);

--- a/Tests/Batch1/SimpleTypes/StringTests.cs
+++ b/Tests/Batch1/SimpleTypes/StringTests.cs
@@ -884,9 +884,7 @@ namespace Bridge.ClientTest.SimpleTypes
             Assert.AreEqual("1, 5, 6", String.Join(", ", intValues));
             IEnumerable<string> stringValues = new MyEnumerable<string>(new[] { "a", "ab", "abc", "abcd" });
             Assert.AreEqual("a, ab, abc, abcd", String.Join(", ", stringValues));
-
-            // TODO: c# makes it False but js false
-            Assert.AreEqual("a, 1, abc, false", String.Join(", ", new Object[] { "a", 1, "abc", false }));// False");
+            Assert.AreEqual("a, 1, abc, False", String.Join(", ", new Object[] { "a", 1, "abc", false }));
         }
 
         [Test]

--- a/Tests/Batch1/SimpleTypes/UInt32Tests.cs
+++ b/Tests/Batch1/SimpleTypes/UInt32Tests.cs
@@ -10,7 +10,7 @@ namespace Bridge.ClientTest.SimpleTypes
         [Test]
         public void TypePropertiesAreCorrect()
         {
-            Assert.True((object)(int)0 is uint);
+            Assert.False((object)(int)0 is uint);
             Assert.False((object)0.5 is uint);
             Assert.False((object)-1 is uint);
             Assert.False((object)4294967296 is uint);

--- a/Tests/Batch1/SimpleTypes/UInt64Tests.cs
+++ b/Tests/Batch1/SimpleTypes/UInt64Tests.cs
@@ -125,8 +125,8 @@ namespace Bridge.ClientTest.SimpleTypes
             long l = 100;
 
             AssertULong("111", dcml + l, null, "System.Decimal");
-            AssertULong("112", dbl + l, null, "System.Int32");
-            AssertULong("113", flt + l, null, "System.Int32");
+            AssertULong("112", dbl + l, null, "System.Double");
+            AssertULong("113", flt + l, null, "System.Single");
         }
 
         private T GetDefaultValue<T>()

--- a/Tests/Batch1/Threading/Tasks/PromiseTests.cs
+++ b/Tests/Batch1/Threading/Tasks/PromiseTests.cs
@@ -126,7 +126,7 @@ namespace Bridge.ClientTest.Threading
             public string S { get; set; }
             public int J { get; set; }
 
-            public delegate TaskResult TaskResultHandler(int i, string s, int j);
+            public delegate TaskResult TaskResultHandler(object i, object s, object j);
         }
 
         [Test(ExpectedCount = 7)]
@@ -166,7 +166,7 @@ namespace Bridge.ClientTest.Threading
         {
             var completeAsync = Assert.Async();
 
-            TaskResult.TaskResultHandler trh = (int i, string s, int j) => { return new TaskResult() { I = i, S = s, J = j }; };
+            TaskResult.TaskResultHandler trh = (object i, object s, object j) => { return new TaskResult() { I = (int)i, S = (string)s, J = (int)j }; };
 
             var promise = CreatePromise();
             var task = Task.FromPromise<TaskResult>(promise, trh);

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -408,6 +408,7 @@
     <Compile Include="BridgeIssues\2000\N2024.cs" />
     <Compile Include="BridgeIssues\2000\N2027.cs" />
     <Compile Include="BridgeIssues\2000\N2033.cs" />
+    <Compile Include="BridgeIssues\2000\N2077.cs" />
     <Compile Include="BridgeIssues\2000\N2038.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />

--- a/Tests/Batch3/BridgeIssues/1100/N1184.cs
+++ b/Tests/Batch3/BridgeIssues/1100/N1184.cs
@@ -34,10 +34,10 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             Assert.AreEqual(typeof(float), f.GetType());
 
             object o = b;
-            Assert.AreEqual(typeof(int), o.GetType());
+            Assert.AreEqual(typeof(byte), o.GetType());
 
             o = f;
-            Assert.AreEqual(typeof(double), o.GetType());
+            Assert.AreEqual(typeof(float), o.GetType());
         }
     }
 }

--- a/Tests/Batch3/BridgeIssues/1300/N1379.cs
+++ b/Tests/Batch3/BridgeIssues/1300/N1379.cs
@@ -1,3 +1,4 @@
+using System;
 using Bridge.Test;
 
 namespace Bridge.ClientTest.Batch3.BridgeIssues
@@ -6,31 +7,36 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
     [TestFixture(TestNameFormat = "#1379 - {0}")]
     public class Bridge1379
     {
-        private static void AssertNaN(object value)
+        private static void AssertDoubleNaN(object value)
         {
             Assert.AreEqual("System.Double", value.GetType().FullName);
+        }
+
+        private static void AssertSingleNaN(object value)
+        {
+            Assert.AreEqual("System.Single", value.GetType().FullName);
         }
 
         [Test]
         public static void TestNanFiniteType()
         {
             object value1 = 0.0 / 0.0;
-            AssertNaN(value1);
+            AssertDoubleNaN(value1);
 
             object value2 = 1.0 / 0.0;
-            AssertNaN(value2);
+            AssertDoubleNaN(value2);
 
             object value3 = -1.0 / 0.0;
-            AssertNaN(value3);
+            AssertDoubleNaN(value3);
 
             object value4 = 0.0f / 0.0f;
-            AssertNaN(value4);
+            AssertSingleNaN(value4);
 
             object value5 = 1.0f / 0.0f;
-            AssertNaN(value5);
+            AssertSingleNaN(value5);
 
             object value6 = -1.0f / 0.0f;
-            AssertNaN(value6);
+            AssertSingleNaN(value6);
         }
     }
 }

--- a/Tests/Batch3/BridgeIssues/1600/N1653.cs
+++ b/Tests/Batch3/BridgeIssues/1600/N1653.cs
@@ -31,7 +31,7 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
                 var v1 = values.Select(value => value + " " + value.GetSomething());
                 var v2 = values.Select(value => value + " " + Bridge1653_Extensions.GetSomething(value));
                 var v3 = values.Select(value => value + " " + Bridge1653_Extensions.GetSomething1(value));
-                var v4 = values.Select(value => value + "_" + Bridge1653_Extensions.GetSomething1("v4"));
+                var v4 = values.Select(value => value.ToString() + "_" + Bridge1653_Extensions.GetSomething1("v4"));
             }
         }
 

--- a/Tests/Batch3/BridgeIssues/2000/N2077.cs
+++ b/Tests/Batch3/BridgeIssues/2000/N2077.cs
@@ -1,0 +1,91 @@
+using Bridge.Test;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#2065 - {0}")]
+    public class Bridge2065
+    {
+        public enum VehicleType
+        {
+            Car,
+            Plane,
+            Boat
+        }
+
+        [Test]
+        public static void TestBoxedEnum()
+        {
+            VehicleType vehicleType = VehicleType.Boat;
+            object box = vehicleType;
+
+            Assert.AreEqual(VehicleType.Boat, vehicleType);
+            Assert.AreEqual("Boat", box.ToString());
+            Assert.AreEqual("Boat", System.Enum.Parse(typeof(VehicleType), "Boat").ToString());
+        }
+    }
+
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#1357 - {0}")]
+    public class Bridge1357
+    {
+        [Test]
+        public static void TestBoxedValueType()
+        {
+            object a1 = 7;
+            object b1 = 7;
+            object c1 = a1;
+
+            var r1 = a1 == b1;
+            var r2 = a1 == c1;
+            Assert.False(r1);
+            Assert.True(r2);
+        }
+    }
+
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#1292 - {0}")]
+    public class Bridge1292
+    {
+        [Test]
+        public static void TestBoxedChar()
+        {
+            object v = 'a';
+            Assert.AreEqual("System.Char", v.GetType().FullName);
+        }
+    }
+
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#1290 - {0}")]
+    public class Bridge1290
+    {
+        [Test]
+        public static void TestBoxedChar()
+        {
+            object v = 'a';
+            Assert.AreEqual("a", v.ToString());
+        }
+    }
+
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#1301 - {0}")]
+    public class Bridge1301
+    {
+        [Test]
+        public static void TestBoxedNumbers()
+        {
+            object v = (byte)3;
+            Assert.AreEqual("System.Byte", v.GetType().FullName);
+            v = (uint)3;
+            Assert.AreEqual("System.UInt32", v.GetType().FullName);
+            v = (ushort)3;
+            Assert.AreEqual("System.UInt16", v.GetType().FullName);
+            v = (short)3;
+            Assert.AreEqual("System.Int16", v.GetType().FullName);
+            v = 1.0;
+            Assert.AreEqual("System.Double", v.GetType().FullName);
+            v = 1f;
+            Assert.AreEqual("System.Single", v.GetType().FullName);
+        }
+    }
+}

--- a/Tests/Batch3/BridgeIssues/TestBridgeIssues.cs
+++ b/Tests/Batch3/BridgeIssues/TestBridgeIssues.cs
@@ -982,8 +982,8 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             EnsureNumber(DecimalZero, "0", "DecimalZero");
             EnsureNumber(DecimalOne, "1", "DecimalOne");
             EnsureNumber(DecimalMinusOne, "-1", "DecimalMinusOne");
-            EnsureNumber(DecimalMaxValue, "7.9228162514264337593543950335e+28", "DecimalMaxValue");
-            EnsureNumber(DecimalMinValue, "-7.9228162514264337593543950335e+28", "DecimalMinValue");
+            EnsureNumber(DecimalMaxValue, "79228162514264337593543950335", "DecimalMaxValue");
+            EnsureNumber(DecimalMinValue, "-79228162514264337593543950335", "DecimalMinValue");
 
             // Decimal consts in expressions
             decimal dz = 0m;
@@ -1000,8 +1000,8 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             EnsureNumber(DecimalZero, "0", "DecimalZeroin expression");
             EnsureNumber(DecimalOne, "1", "DecimalOnein expression");
             EnsureNumber(DecimalMinusOne, "-1", "DecimalMinusOnein expression");
-            EnsureNumber(DecimalMaxValue, "7.9228162514264337593543950335e+28", "DecimalMaxValuein expression");
-            EnsureNumber(DecimalMinValue, "-7.9228162514264337593543950335e+28", "DecimalMinValuein expression");
+            EnsureNumber(DecimalMaxValue, "79228162514264337593543950335", "DecimalMaxValuein expression");
+            EnsureNumber(DecimalMinValue, "-79228162514264337593543950335", "DecimalMinValuein expression");
 
             var numberPositiveInfinity = Script.Get<object>("Number.POSITIVE_INFINITY");
             var numberNegativeInfinity = Script.Get<object>("Number.NEGATIVE_INFINITY");
@@ -1015,9 +1015,9 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             var DoublePositiveInfinity = double.PositiveInfinity;
             var DoubleNaN = double.NaN;
 
-            EnsureNumber(DoubleMaxValue, "1.7976931348623157e+308", "DoubleMaxValue");
-            EnsureNumber(DoubleMinValue, "-1.7976931348623157e+308", "DoubleMinValue");
-            EnsureNumber(DoubleEpsilon, "5e-324", "DoubleEpsilon");
+            EnsureNumber(DoubleMaxValue, "1.79769313486232E+308", "DoubleMaxValue");
+            EnsureNumber(DoubleMinValue, "-1.79769313486232E+308", "DoubleMinValue");
+            EnsureNumber(DoubleEpsilon, "4.94065645841247E-324", "DoubleEpsilon");
             Assert.AreEqual(numberNegativeInfinity, DoubleNegativeInfinity, "DoubleNegativeInfinity");
             Assert.AreEqual(numberPositiveInfinity, DoublePositiveInfinity, "DoublePositiveInfinity");
             Assert.AreEqual(numberNaN, DoubleNaN, "DoubleNaN");
@@ -1031,9 +1031,9 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             DoublePositiveInfinity = double.PositiveInfinity + dblz;
             DoubleNaN = double.NaN + dblz;
 
-            EnsureNumber(DoubleMaxValue, "1.7976931348623157e+308", "DoubleMaxValuein expression");
-            EnsureNumber(DoubleMinValue, "-1.7976931348623157e+308", "DoubleMinValuein expression");
-            EnsureNumber(DoubleEpsilon, "5e-324", "DoubleEpsilonin expression");
+            EnsureNumber(DoubleMaxValue, "1.79769313486232E+308", "DoubleMaxValuein expression");
+            EnsureNumber(DoubleMinValue, "-1.79769313486232E+308", "DoubleMinValuein expression");
+            EnsureNumber(DoubleEpsilon, "4.94065645841247E-324", "DoubleEpsilonin expression");
             Assert.AreEqual(numberNegativeInfinity, DoubleNegativeInfinity, "DoubleNegativeInfinityin expression");
             Assert.AreEqual(numberPositiveInfinity, DoublePositiveInfinity, "DoublePositiveInfinityin expression");
             Assert.AreEqual(numberNaN, DoubleNaN, "DoubleNaNin expression");
@@ -1048,15 +1048,15 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             var MathSQRT1_2 = Math.SQRT1_2;
             var MathSQRT2 = Math.SQRT2;
 
-            EnsureNumber(MathE, "2.718281828459045", "MathE");
-            EnsureNumber(MathLN10, "2.302585092994046", "MathLN10");
-            EnsureNumber(MathLN2, "0.6931471805599453", "MathLN2");
+            EnsureNumber(MathE, "2.71828182845905", "MathE");
+            EnsureNumber(MathLN10, "2.30258509299405", "MathLN10");
+            EnsureNumber(MathLN2, "0.69314718055995", "MathLN2");
             //IE has Math.LOG2E defined as 1.4426950408889633 instead of standard 1.4426950408889634
             AssertAlmostEqual(MathLOG2E, 1.4426950408889634, "MathLOG2E");
-            EnsureNumber(MathLOG10E, "0.4342944819032518", "MathLOG10E");
-            EnsureNumber(MathPI, "3.141592653589793", "MathPI");
-            EnsureNumber(MathSQRT1_2, "0.7071067811865476", "MathSQRT1_2");
-            EnsureNumber(MathSQRT2, "1.4142135623730951", "MathSQRT2");
+            EnsureNumber(MathLOG10E, "0.43429448190325", "MathLOG10E");
+            EnsureNumber(MathPI, "3.14159265358979", "MathPI");
+            EnsureNumber(MathSQRT1_2, "0.70710678118655", "MathSQRT1_2");
+            EnsureNumber(MathSQRT2, "1.4142135623731", "MathSQRT2");
 
             // Math consts in expression
             MathE = Math.E + 0;
@@ -1068,15 +1068,15 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             MathSQRT1_2 = Math.SQRT1_2 + 0;
             MathSQRT2 = Math.SQRT2 + 0;
 
-            EnsureNumber(MathE, "2.718281828459045", "MathEin expression");
-            EnsureNumber(MathLN10, "2.302585092994046", "MathLN10in expression");
-            EnsureNumber(MathLN2, "0.6931471805599453", "MathLN2in expression");
+            EnsureNumber(MathE, "2.71828182845905", "MathEin expression");
+            EnsureNumber(MathLN10, "2.30258509299405", "MathLN10in expression");
+            EnsureNumber(MathLN2, "0.69314718055995", "MathLN2in expression");
             //IE has Math.LOG2E defined as 1.4426950408889633 instead of standard 1.4426950408889634
             AssertAlmostEqual(MathLOG2E, 1.4426950408889634, "MathLOG2Ein expression");
-            EnsureNumber(MathLOG10E, "0.4342944819032518", "MathLOG10Ein expression");
-            EnsureNumber(MathPI, "3.141592653589793", "MathPIin expression");
-            EnsureNumber(MathSQRT1_2, "0.7071067811865476", "MathSQRT1_2in expression");
-            EnsureNumber(MathSQRT2, "1.4142135623730951", "MathSQRT2in expression");
+            EnsureNumber(MathLOG10E, "0.43429448190325", "MathLOG10Ein expression");
+            EnsureNumber(MathPI, "3.14159265358979", "MathPIin expression");
+            EnsureNumber(MathSQRT1_2, "0.70710678118655", "MathSQRT1_2in expression");
+            EnsureNumber(MathSQRT2, "1.4142135623731", "MathSQRT2in expression");
 
             // Single consts
             var SingleMaxValue = float.MaxValue;
@@ -1086,9 +1086,9 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             var SingleNegativeInfinity = float.NegativeInfinity;
             var SinglePositiveInfinity = float.PositiveInfinity;
 
-            EnsureNumber(SingleMaxValue, "3.40282347e+38", "SingleMaxValue");
-            EnsureNumber(SingleMinValue, "-3.40282347e+38", "SingleMinValue");
-            EnsureNumber(SingleEpsilon, "1.401298e-45", "SingleEpsilon");
+            EnsureNumber(SingleMaxValue, "3.402823E+38", "SingleMaxValue");
+            EnsureNumber(SingleMinValue, "-3.402823E+38", "SingleMinValue");
+            EnsureNumber(SingleEpsilon, "1.401298E-45", "SingleEpsilon");
             Assert.AreEqual(numberNaN, SingleNaN, "SingleNaN");
             Assert.AreEqual(numberNegativeInfinity, SingleNegativeInfinity, "SingleNegativeInfinity");
             Assert.AreEqual(numberPositiveInfinity, SinglePositiveInfinity, "SinglePositiveInfinity");
@@ -1102,9 +1102,9 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             SingleNegativeInfinity = float.NegativeInfinity + fz;
             SinglePositiveInfinity = float.PositiveInfinity + fz;
 
-            EnsureNumber(SingleMaxValue, "3.40282347e+38", "SingleMaxValuein expression");
-            EnsureNumber(SingleMinValue, "-3.40282347e+38", "SingleMinValuein expression");
-            EnsureNumber(SingleEpsilon, "1.401298e-45", "SingleEpsilonin expression");
+            EnsureNumber(SingleMaxValue, "3.402823E+38", "SingleMaxValuein expression");
+            EnsureNumber(SingleMinValue, "-3.402823E+38", "SingleMinValuein expression");
+            EnsureNumber(SingleEpsilon, "1.401298E-45", "SingleEpsilonin expression");
             Assert.AreEqual(numberNaN, SingleNaN, "SingleNaNin expression");
             Assert.AreEqual(numberNegativeInfinity, SingleNegativeInfinity, "SingleNegativeInfinityin expression");
             Assert.AreEqual(numberPositiveInfinity, SinglePositiveInfinity, "SinglePositiveInfinityin expression");

--- a/Tests/Batch4/SimpleTypes/SByteTests.cs
+++ b/Tests/Batch4/SimpleTypes/SByteTests.cs
@@ -10,7 +10,7 @@ namespace Bridge.ClientTest.Batch4.SimpleTypes
         [Test]
         public void TypePropertiesAreCorrect_SPI_1717()
         {
-            Assert.True((object)(byte)0 is sbyte);
+            Assert.False((object)(byte)0 is sbyte);
             Assert.False((object)0.5 is sbyte);
             Assert.False((object)-129 is sbyte);
             Assert.False((object)128 is sbyte);

--- a/Tests/Runner/Batch1/bridge.test.qunit.js
+++ b/Tests/Runner/Batch1/bridge.test.qunit.js
@@ -11,40 +11,40 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 return Bridge.Test.Assert.assert.async();
             },
             areEqual: function (expected, actual) {
-                Bridge.Test.Assert.assert.deepEqual(actual, expected);
+                Bridge.Test.Assert.assert.deepEqual(Bridge.unbox(actual), Bridge.unbox(expected));
             },
             areEqual$1: function (expected, actual, description) {
-                Bridge.Test.Assert.assert.deepEqual(actual, expected, description);
+                Bridge.Test.Assert.assert.deepEqual(Bridge.unbox(actual), Bridge.unbox(expected), description);
             },
             areDeepEqual: function (expected, actual) {
-                Bridge.Test.Assert.assert.deepEqual(actual, expected);
+                Bridge.Test.Assert.assert.deepEqual(Bridge.unbox(actual), Bridge.unbox(expected));
             },
             areDeepEqual$1: function (expected, actual, description) {
-                Bridge.Test.Assert.assert.deepEqual(actual, expected, description);
+                Bridge.Test.Assert.assert.deepEqual(Bridge.unbox(actual), Bridge.unbox(expected), description);
             },
             areStrictEqual: function (expected, actual) {
-                Bridge.Test.Assert.assert.strictEqual(actual, expected);
+                Bridge.Test.Assert.assert.strictEqual(Bridge.unbox(actual), Bridge.unbox(expected));
             },
             areStrictEqual$1: function (expected, actual, description) {
-                Bridge.Test.Assert.assert.strictEqual(actual, expected, description);
+                Bridge.Test.Assert.assert.strictEqual(Bridge.unbox(actual), Bridge.unbox(expected), description);
             },
             areNotEqual: function (expected, actual) {
-                Bridge.Test.Assert.assert.notDeepEqual(actual, expected);
+                Bridge.Test.Assert.assert.notDeepEqual(Bridge.unbox(actual), Bridge.unbox(expected));
             },
             areNotEqual$1: function (expected, actual, description) {
-                Bridge.Test.Assert.assert.notDeepEqual(actual, expected, description);
+                Bridge.Test.Assert.assert.notDeepEqual(Bridge.unbox(actual), Bridge.unbox(expected), description);
             },
             areNotDeepEqual: function (expected, actual) {
-                Bridge.Test.Assert.assert.notDeepEqual(actual, expected);
+                Bridge.Test.Assert.assert.notDeepEqual(Bridge.unbox(actual), Bridge.unbox(expected));
             },
             areNotDeepEqual$1: function (expected, actual, description) {
-                Bridge.Test.Assert.assert.notDeepEqual(actual, expected, description);
+                Bridge.Test.Assert.assert.notDeepEqual(Bridge.unbox(actual), Bridge.unbox(expected), description);
             },
             areNotStrictEqual: function (expected, actual) {
-                Bridge.Test.Assert.assert.notStrictEqual(actual, expected);
+                Bridge.Test.Assert.assert.notStrictEqual(Bridge.unbox(actual), Bridge.unbox(expected));
             },
             areNotStrictEqual$1: function (expected, actual, description) {
-                Bridge.Test.Assert.assert.notStrictEqual(actual, expected, description);
+                Bridge.Test.Assert.assert.notStrictEqual(Bridge.unbox(actual), Bridge.unbox(expected), description);
             },
             true: function (condition) {
                 Bridge.Test.Assert.assert.ok(condition);
@@ -92,10 +92,10 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 }
             },
             throws$3: function (block, expected) {
-                Bridge.Test.Assert.assert.throws(block, expected);
+                Bridge.Test.Assert.assert.throws(block, Bridge.unbox(expected));
             },
             throws$4: function (block, expected, message) {
-                Bridge.Test.Assert.assert.throws(block, expected, message);
+                Bridge.Test.Assert.assert.throws(block, Bridge.unbox(expected), message);
             },
             throws$1: function (block, expected) {
                 Bridge.Test.Assert.assert.throws(block, expected);

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -35,23 +35,23 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         lengthWorks: function () {
             this.lengthHelper0();
-            this.lengthHelper1(4);
-            this.lengthHelper2(6, "x");
+            this.lengthHelper1(Bridge.box(4, System.Int32));
+            this.lengthHelper2(Bridge.box(6, System.Int32), "x");
         },
         getArgumentWorks: function () {
-            Bridge.Test.Assert.areEqual(this.getArgumentHelper(0, "x", "y"), 0);
-            Bridge.Test.Assert.areEqual(this.getArgumentHelper(1, "x", "y"), "x");
-            Bridge.Test.Assert.areEqual(this.getArgumentHelper(2, "x", "y"), "y");
+            Bridge.Test.Assert.areEqual(Bridge.unbox(this.getArgumentHelper(0, "x", "y")), 0);
+            Bridge.Test.Assert.areEqual(Bridge.unbox(this.getArgumentHelper(1, "x", "y")), "x");
+            Bridge.Test.Assert.areEqual(Bridge.unbox(this.getArgumentHelper(2, "x", "y")), "y");
         },
         toArrayWorks: function () {
-            Bridge.Test.Assert.areEqual(this.toArrayHelper(), System.Array.init(0, null));
-            Bridge.Test.Assert.areEqual(this.toArrayHelper("x"), ["x"]);
-            Bridge.Test.Assert.areEqual(this.toArrayHelper("x", 1), ["x", 1]);
+            Bridge.Test.Assert.areEqual(Bridge.unbox(this.toArrayHelper()), System.Array.init(0, null));
+            Bridge.Test.Assert.areEqual(Bridge.unbox(this.toArrayHelper("x")), ["x"]);
+            Bridge.Test.Assert.areEqual(Bridge.unbox(this.toArrayHelper("x", Bridge.box(1, System.Int32))), ["x", Bridge.box(1, System.Int32)]);
         },
         toArrayOfTWorks: function () {
-            Bridge.Test.Assert.areEqual(this.toArrayHelper$1(String), System.Array.init(0, null));
-            Bridge.Test.Assert.areEqual(this.toArrayHelper$1(String, "x"), ["x"]);
-            Bridge.Test.Assert.areEqual(this.toArrayHelper$1(String, "x", "y"), ["x", "y"]);
+            Bridge.Test.Assert.areEqual(Bridge.unbox(this.toArrayHelper$1(String)), System.Array.init(0, null));
+            Bridge.Test.Assert.areEqual(Bridge.unbox(this.toArrayHelper$1(String, "x")), ["x"]);
+            Bridge.Test.Assert.areEqual(Bridge.unbox(this.toArrayHelper$1(String, "x", "y")), ["x", "y"]);
         }
     });
 
@@ -97,8 +97,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual("y", ["x", "y"][1]);
         },
         getValueWorks: function () {
-            Bridge.Test.Assert.areEqual("x", System.Array.get(["x", "y"], 0));
-            Bridge.Test.Assert.areEqual("y", System.Array.get(["x", "y"], 1));
+            Bridge.Test.Assert.areEqual("x", Bridge.unbox(System.Array.get(["x", "y"], 0)));
+            Bridge.Test.Assert.areEqual("y", Bridge.unbox(System.Array.get(["x", "y"], 1)));
         },
         settingValueByIndexWorks: function () {
             var arr = System.Array.init(2, null);
@@ -128,7 +128,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var arr = ["x", "y"];
             var arr2 = System.Array.clone(arr);
             Bridge.Test.Assert.false(Bridge.referenceEquals(arr, arr2));
-            Bridge.Test.Assert.areDeepEqual(arr2, arr);
+            Bridge.Test.Assert.areDeepEqual(Bridge.unbox(arr2), arr);
         },
         concatWorks: function () {
             var arr = ["a", "b"];
@@ -209,7 +209,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         foreachWithArrayCallbackWorks: function () {
             var result = "";
             Bridge.Linq.Enumerable.from(["a", "b", "c"]).forEach(function (s, i) {
-                    result = System.String.concat(result, (System.String.concat(s, i)));
+                    result = System.String.concat(result, (System.String.concat(s, Bridge.box(i, System.Int32))));
                 });
             Bridge.Test.Assert.areEqual("a0b1c2", result);
         },
@@ -489,9 +489,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var strComparer = new Bridge.ClientTest.ArrayTests.ArrayTestsSet2.StringComparer();
                 var strGenericComparer = new Bridge.ClientTest.ArrayTests.ArrayTestsSet2.StringComparer();
 
-                return [[intArray, 8, intComparer, intGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f1], [intArray, 99, intComparer, intGenericComparer, function (i) {
+                return [[intArray, Bridge.box(8, System.Int32), intComparer, intGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f1], [intArray, Bridge.box(99, System.Int32), intComparer, intGenericComparer, function (i) {
                     return i === ~(intArray.length);
-                }], [intArray, 6, intComparer, intGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f2], [strArray, "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f2], [strArray, null, strComparer, null, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f3]];
+                }], [intArray, Bridge.box(6, System.Int32), intComparer, intGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f2], [strArray, "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f2], [strArray, null, strComparer, null, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f3]];
             },
             getBinarySearchTestDataInRange: function () {
                 var intArray = [1, 3, 6, 6, 8, 10, 12, 16];
@@ -502,9 +502,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var strComparer = new Bridge.ClientTest.ArrayTests.ArrayTestsSet2.StringComparer();
                 var strGenericComparer = new Bridge.ClientTest.ArrayTests.ArrayTestsSet2.StringComparer();
 
-                return [[intArray, 0, 8, 99, intComparer, intGenericComparer, function (i) {
+                return [[intArray, Bridge.box(0, System.Int32), Bridge.box(8, System.Int32), Bridge.box(99, System.Int32), intComparer, intGenericComparer, function (i) {
                     return i === ~(intArray.length);
-                }], [intArray, 0, 8, 6, intComparer, intGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f2], [intArray, 1, 5, 16, intComparer, intGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f4], [strArray, 0, strArray.length, "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f2], [strArray, 3, 4, "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f5], [strArray, 4, 3, "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f6], [strArray, 4, 0, "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f6], [strArray, 0, 7, null, strComparer, null, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f3]];
+                }], [intArray, Bridge.box(0, System.Int32), Bridge.box(8, System.Int32), Bridge.box(6, System.Int32), intComparer, intGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f2], [intArray, Bridge.box(1, System.Int32), Bridge.box(5, System.Int32), Bridge.box(16, System.Int32), intComparer, intGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f4], [strArray, Bridge.box(0, System.Int32), Bridge.box(strArray.length, System.Int32), "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f2], [strArray, Bridge.box(3, System.Int32), Bridge.box(4, System.Int32), "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f5], [strArray, Bridge.box(4, System.Int32), Bridge.box(3, System.Int32), "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f6], [strArray, Bridge.box(4, System.Int32), Bridge.box(0, System.Int32), "bb", strComparer, strGenericComparer, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f6], [strArray, Bridge.box(0, System.Int32), Bridge.box(7, System.Int32), null, strComparer, null, $_.Bridge.ClientTest.ArrayTests.ArrayTestsSet2.f3]];
             },
             testArrayAsIListOfT: function () {
                 var sa = ["Hello", "There"];
@@ -591,12 +591,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.false(System.Array.contains(il, 999, System.Int32));
                 Bridge.Test.Assert.areEqual(System.Array.indexOf(il, 1, 0, null, System.Int32), 0);
                 Bridge.Test.Assert.areEqual(System.Array.indexOf(il, 999, 0, null, System.Int32), -1);
-                var v = System.Array.getItem(il, 0, System.Int32);
-                Bridge.Test.Assert.areEqual(v, 1);
-                v = System.Array.getItem(il, 1, System.Int32);
-                Bridge.Test.Assert.areEqual(v, 2);
-                v = System.Array.getItem(il, 2, System.Int32);
-                Bridge.Test.Assert.areEqual(v, 3);
+                var v = Bridge.box(System.Array.getItem(il, 0, System.Int32), System.Int32);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(v), 1);
+                v = Bridge.box(System.Array.getItem(il, 1, System.Int32), System.Int32);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(v), 2);
+                v = Bridge.box(System.Array.getItem(il, 2, System.Int32), System.Int32);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(v), 3);
                 System.Array.setItem(il, 2, 42, System.Int32);
                 Bridge.Test.Assert.areEqual(Bridge.cast(a, Array)[2], 42);
 
@@ -696,26 +696,26 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var a = idirect;
 
                 var seven = System.Array.get(a, 0);
-                Bridge.Test.Assert.areEqual(7, seven);
+                Bridge.Test.Assert.areEqual(7, Bridge.unbox(seven));
                 System.Array.set(a, 41, 0);
                 Bridge.Test.Assert.areEqual(41, idirect[0]);
 
                 var eight = System.Array.get(a, 1);
-                Bridge.Test.Assert.areEqual(8, eight);
+                Bridge.Test.Assert.areEqual(8, Bridge.unbox(eight));
                 System.Array.set(a, 42, 1);
                 Bridge.Test.Assert.areEqual(42, idirect[1]);
 
                 var nine = System.Array.get(a, 2);
-                Bridge.Test.Assert.areEqual(9, nine);
+                Bridge.Test.Assert.areEqual(9, Bridge.unbox(nine));
                 System.Array.set(a, 43, 2);
                 Bridge.Test.Assert.areEqual(43, idirect[2]);
 
                 var idirect2 = System.Array.create(0, [[1, 2, 3], [4, 5, 6]], 2, 3);
                 var b = idirect2;
-                Bridge.Test.Assert.areEqual(1, System.Array.get(b, 0, 0));
-                Bridge.Test.Assert.areEqual(6, System.Array.get(b, 1, 2));
+                Bridge.Test.Assert.areEqual(1, Bridge.unbox(System.Array.get(b, 0, 0)));
+                Bridge.Test.Assert.areEqual(6, Bridge.unbox(System.Array.get(b, 1, 2)));
                 System.Array.set(b, 42, 1, 2);
-                Bridge.Test.Assert.areEqual(42, System.Array.get(b, 1, 2));
+                Bridge.Test.Assert.areEqual(42, Bridge.unbox(System.Array.get(b, 1, 2)));
 
                 var nullIndices = null;
                 Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
@@ -980,7 +980,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 System.Array.copy(s, 0, d, 0, 5);
                 for (var i = 0; i < d.length; i = (i + 1) | 0) {
                     Bridge.Test.Assert.true(Bridge.is(d[i], Bridge.ClientTest.ArrayTests.ArrayTestsSet2.G));
-                    var g = System.Nullable.getValue(Bridge.cast((d[i]), Bridge.ClientTest.ArrayTests.ArrayTestsSet2.G));
+                    var g = System.Nullable.getValue(Bridge.cast(Bridge.unbox((d[i])), Bridge.ClientTest.ArrayTests.ArrayTestsSet2.G));
                     Bridge.Test.Assert.areEqual(g.x, s[i].x);
                     Bridge.Test.Assert.areEqual(g.s, s[i].s);
                     Bridge.Test.Assert.areEqual(g.z, s[i].z);
@@ -1171,17 +1171,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 b = ie.System$Collections$IEnumerator$moveNext();
                 Bridge.Test.Assert.true(b);
                 v = ie.System$Collections$IEnumerator$getCurrent();
-                Bridge.Test.Assert.areEqual(v, 7);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(v), 7);
 
                 b = ie.System$Collections$IEnumerator$moveNext();
                 Bridge.Test.Assert.true(b);
                 v = ie.System$Collections$IEnumerator$getCurrent();
-                Bridge.Test.Assert.areEqual(v, 8);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(v), 8);
 
                 b = ie.System$Collections$IEnumerator$moveNext();
                 Bridge.Test.Assert.true(b);
                 v = ie.System$Collections$IEnumerator$getCurrent();
-                Bridge.Test.Assert.areEqual(v, 9);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(v), 9);
 
                 b = ie.System$Collections$IEnumerator$moveNext();
                 Bridge.Test.Assert.false(b);
@@ -1190,7 +1190,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 b = ie.System$Collections$IEnumerator$moveNext();
                 Bridge.Test.Assert.true(b);
                 v = ie.System$Collections$IEnumerator$getCurrent();
-                Bridge.Test.Assert.areEqual(v, 7);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(v), 7);
             },
             testIndexOf: function () {
                 var a;
@@ -1530,16 +1530,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
                     System.Array.copy(s, 2, d, 5, 3);
 
-                    Bridge.Test.Assert.areEqual(d[0], null);
-                    Bridge.Test.Assert.areEqual(d[1], null);
-                    Bridge.Test.Assert.areEqual(d[2], null);
-                    Bridge.Test.Assert.areEqual(d[3], null);
-                    Bridge.Test.Assert.areEqual(d[4], null);
-                    Bridge.Test.Assert.areEqual(d[5], 2);
-                    Bridge.Test.Assert.areEqual(d[6], 3);
-                    Bridge.Test.Assert.areEqual(d[7], 4);
-                    Bridge.Test.Assert.areEqual(d[8], null);
-                    Bridge.Test.Assert.areEqual(d[9], null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[0]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[1]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[2]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[3]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[4]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[5]), 2);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[6]), 3);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[7]), 4);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[8]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d[9]), null);
                 }
 
                 {
@@ -1548,16 +1548,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
                     System.Array.copy(s1, 2, d1, 5, 3);
 
-                    Bridge.Test.Assert.areEqual(d1[0], null);
-                    Bridge.Test.Assert.areEqual(d1[1], null);
-                    Bridge.Test.Assert.areEqual(d1[2], null);
-                    Bridge.Test.Assert.areEqual(d1[3], null);
-                    Bridge.Test.Assert.areEqual(d1[4], null);
-                    Bridge.Test.Assert.areEqual(d1[5], 2);
-                    Bridge.Test.Assert.areEqual(d1[6], 3);
-                    Bridge.Test.Assert.areEqual(d1[7], 4);
-                    Bridge.Test.Assert.areEqual(d1[8], null);
-                    Bridge.Test.Assert.areEqual(d1[9], null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[0]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[1]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[2]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[3]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[4]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[5]), 2);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[6]), 3);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[7]), 4);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[8]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d1[9]), null);
                 }
 
                 {
@@ -1566,16 +1566,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
                     System.Array.copy(s2, 2, d2, 5, 3);
 
-                    Bridge.Test.Assert.areEqual(d2[0], null);
-                    Bridge.Test.Assert.areEqual(d2[1], null);
-                    Bridge.Test.Assert.areEqual(d2[2], null);
-                    Bridge.Test.Assert.areEqual(d2[3], null);
-                    Bridge.Test.Assert.areEqual(d2[4], null);
-                    Bridge.Test.Assert.areEqual(d2[5], 2);
-                    Bridge.Test.Assert.areEqual(d2[6], null);
-                    Bridge.Test.Assert.areEqual(d2[7], 4);
-                    Bridge.Test.Assert.areEqual(d2[8], null);
-                    Bridge.Test.Assert.areEqual(d2[9], null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[0]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[1]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[2]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[3]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[4]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[5]), 2);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[6]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[7]), 4);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[8]), null);
+                    Bridge.Test.Assert.areEqual(Bridge.unbox(d2[9]), null);
                 }
 
                 return;
@@ -1586,7 +1586,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 {
                     var s = System.Array.init(10, null);
                     for (var i = 0; i < s.length; i = (i + 1) | 0) {
-                        s[i] = i;
+                        s[i] = Bridge.box(i, System.Int32);
                     }
 
                     var d = System.Array.init(10, 0);
@@ -1610,7 +1610,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 {
                     var s1 = System.Array.init(10, null);
                     for (var i2 = 0; i2 < s1.length; i2 = (i2 + 1) | 0) {
-                        s1[i2] = i2;
+                        s1[i2] = Bridge.box(i2, System.Int32);
                     }
 
                     var d1 = System.Array.init(10, 0);
@@ -1634,7 +1634,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 {
                     var s2 = System.Array.init(10, null);
                     for (var i4 = 0; i4 < s2.length; i4 = (i4 + 1) | 0) {
-                        s2[i4] = i4;
+                        s2[i4] = Bridge.box(i4, System.Int32);
                     }
                     s2[1] = new Bridge.ClientTest.ArrayTests.ArrayTestsSet2.NotInt32();
                     s2[5] = new Bridge.ClientTest.ArrayTests.ArrayTestsSet2.NotInt32();
@@ -1660,7 +1660,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 {
                     var s3 = System.Array.init(10, null);
                     for (var i6 = 0; i6 < s3.length; i6 = (i6 + 1) | 0) {
-                        s3[i6] = i6;
+                        s3[i6] = Bridge.box(i6, System.Int32);
                     }
                     s3[4] = null;
 
@@ -1690,9 +1690,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 // in .NET Native by UTC.
                 var arr = System.Array.create(0, [[[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]], [[[1, 2, 3], [1, 2, 3]], [[1, 2, 3], [1, 2, 3]]]], 2, 2, 2, 3);
                 Bridge.Test.Assert.notNull(arr);
-                Bridge.Test.Assert.areEqual(System.Array.get(arr, 0, 0, 0, 0), 1);
-                Bridge.Test.Assert.areEqual(System.Array.get(arr, 0, 0, 0, 1), 2);
-                Bridge.Test.Assert.areEqual(System.Array.get(arr, 0, 0, 0, 2), 3);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(System.Array.get(arr, 0, 0, 0, 0)), 1);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(System.Array.get(arr, 0, 0, 0, 1)), 2);
+                Bridge.Test.Assert.areEqual(Bridge.unbox(System.Array.get(arr, 0, 0, 0, 2)), 3);
             }
         }
     });
@@ -1821,10 +1821,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             return ((x - y) | 0);
         },
         System$Collections$IEqualityComparer$equals: function (x, y) {
-            return System.Nullable.getValue(Bridge.cast(x, System.Int32)) === System.Nullable.getValue(Bridge.cast(y, System.Int32));
+            return System.Nullable.getValue(Bridge.cast(Bridge.unbox(x), System.Int32)) === System.Nullable.getValue(Bridge.cast(Bridge.unbox(y), System.Int32));
         },
         getHashCode: function (obj) {
-            return System.Nullable.getValue(Bridge.cast(obj, System.Int32)) >> 2;
+            return System.Nullable.getValue(Bridge.cast(Bridge.unbox(obj), System.Int32)) >> 2;
         }
     });
 
@@ -1920,9 +1920,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             },
             staticMethod2: function (p) {
                 if (p === void 0) { p = []; }
-                var i = (System.Nullable.getValue(Bridge.cast(p[0], System.Int32)) + 1000) | 0;
+                var i = (System.Nullable.getValue(Bridge.cast(Bridge.unbox(p[0]), System.Int32)) + 1000) | 0;
                 var s = Bridge.cast(p[1], String);
-                var d = System.Nullable.getValue(Bridge.cast(p[2], System.Double));
+                var d = System.Nullable.getValue(Bridge.cast(Bridge.unbox(p[2]), System.Double));
 
                 return Bridge.ClientTest.BasicCSharp.ClassA.staticMethod1(i, s, d);
             },
@@ -1973,7 +1973,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             }
 
             if (Bridge.is(p[0], System.Int32)) {
-                this.setNumberA(System.Nullable.getValue(Bridge.cast(p[0], System.Int32)));
+                this.setNumberA(System.Nullable.getValue(Bridge.cast(Bridge.unbox(p[0]), System.Int32)));
             }
 
             if (Bridge.is(p[1], String)) {
@@ -1981,15 +1981,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             }
 
             if (Bridge.is(p[2], Boolean)) {
-                this.setBoolA(System.Nullable.getValue(Bridge.cast(p[2], Boolean)));
+                this.setBoolA(System.Nullable.getValue(Bridge.cast(Bridge.unbox(p[2]), Boolean)));
             }
 
             if (Bridge.is(p[3], System.Double)) {
-                this.setDoubleA(System.Nullable.getValue(Bridge.cast(p[3], System.Double)));
+                this.setDoubleA(System.Nullable.getValue(Bridge.cast(Bridge.unbox(p[3]), System.Double)));
             }
 
             if (Bridge.is(p[4], System.Decimal)) {
-                this.setDecimalA(System.Nullable.getValue(Bridge.cast(p[4], System.Decimal)));
+                this.setDecimalA(System.Nullable.getValue(Bridge.cast(Bridge.unbox(p[4]), System.Decimal)));
             }
 
             if (Bridge.is(p[5], Bridge.ClientTest.BasicCSharp.ClassA.Aux1)) {
@@ -2045,7 +2045,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             }
         },
         toString: function () {
-            return System.String.format("{0} Has related {1}", this.getNumber(), this.getRelated() != null ? this.getRelated().getNumber().toString() : "No");
+            return System.String.format("{0} Has related {1}", Bridge.box(this.getNumber(), System.Int32), this.getRelated() != null ? this.getRelated().getNumber().toString() : "No");
         }
     });
 
@@ -2650,7 +2650,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 // Check constructor with parameter
                 Bridge.Test.Assert.throws$7(System.Exception, Bridge.ClientTest.BasicCSharp.TestSet1FailureHelper.testConstructor2Failure, "Should pass six parameters");
 
-                a = new Bridge.ClientTest.BasicCSharp.ClassA.$ctor2([150, "151", true, 1.53, System.Decimal(1.54), Bridge.merge(new Bridge.ClientTest.BasicCSharp.ClassA.Aux1(), {
+                a = new Bridge.ClientTest.BasicCSharp.ClassA.$ctor2([Bridge.box(150, System.Int32), "151", Bridge.box(true, Boolean, $box_.Boolean.toString), Bridge.box(1.53, System.Double, $box_.System.Double.toString), Bridge.box(System.Decimal(1.54), System.Decimal, $box_.System.Decimal.toString), Bridge.merge(new Bridge.ClientTest.BasicCSharp.ClassA.Aux1(), {
                     setNumber: 155
                 } )]);
 
@@ -2711,7 +2711,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.areEqual$1("ASD", Bridge.ClientTest.BasicCSharp.ClassA.statitStringNotInitialized, "ClassA.StatitStringNotInitialized ASD");
                 Bridge.Test.Assert.areDeepEqual$1(Number.NaN, a.getDoubleA(), "DoubleA double.NaN");
 
-                a = Bridge.ClientTest.BasicCSharp.ClassA.staticMethod2([678, "QWE", 234]);
+                a = Bridge.ClientTest.BasicCSharp.ClassA.staticMethod2([Bridge.box(678, System.Int32), "QWE", Bridge.box(234, System.Int32)]);
                 Bridge.Test.Assert.areEqual$1(1678, Bridge.ClientTest.BasicCSharp.ClassA.statitIntNotInitialized, "StatitIntNotInitialized 1678");
                 Bridge.Test.Assert.areEqual$1("QWE", Bridge.ClientTest.BasicCSharp.ClassA.statitStringNotInitialized, "ClassA.StatitStringNotInitialized QWE");
                 Bridge.Test.Assert.areEqual$1(234, a.getDoubleA(), "DoubleA 234");
@@ -3408,7 +3408,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         createInstanceWorks: function () {
             Bridge.Test.Assert.true$1(Bridge.is(Bridge.Reflection.createAssemblyInstance(Bridge.Reflection.getTypeAssembly(Bridge.ClientTest.Batch1.Reflection.AssemblyTests.C), Bridge.Reflection.getTypeFullName(Bridge.ClientTest.Batch1.Reflection.AssemblyTests.C)), Bridge.ClientTest.Batch1.Reflection.AssemblyTests.C), "#1");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.createAssemblyInstance(Bridge.Reflection.getTypeAssembly(System.Int32), Bridge.Reflection.getTypeFullName(System.Int32)), 0, "#2");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.createAssemblyInstance(Bridge.Reflection.getTypeAssembly(System.Int32), Bridge.Reflection.getTypeFullName(System.Int32))), 0, "#2");
             Bridge.Test.Assert.true$1(Bridge.Reflection.createAssemblyInstance(Bridge.Reflection.getTypeAssembly(Bridge.ClientTest.Batch1.Reflection.AssemblyTests.C), "NonExistentType") == null, "#3");
         },
         getCustomAttributesWorks: function () {
@@ -3535,34 +3535,34 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.BridgeConsoleTests", {
         testLogMessageObject: function () {
             this.assertLogMessageObject("#0 - ", "Test Bridge Console Log Message Object", "Test Bridge Console Log Message Object");
-            this.assertLogMessageObject("#1 - ", true, "true");
-            this.assertLogMessageObject("#2 - ", false, "false");
-            this.assertLogMessageObject("#3 - ", -1, "-1");
-            this.assertLogMessageObject("#4 - ", 1, "1");
-            this.assertLogMessageObject("#5 - ", -12345678, "-12345678");
-            this.assertLogMessageObject("#6 - ", 12345678, "12345678");
-            this.assertLogMessageObject("#7 - ", System.Int64(-1), "-1");
-            this.assertLogMessageObject("#8 - ", System.Int64(1), "1");
-            this.assertLogMessageObject("#9 - ", System.Int64(-12345678), "-12345678");
-            this.assertLogMessageObject("#10 - ", System.Int64(12345678), "12345678");
-            this.assertLogMessageObject("#11 - ", System.UInt64(1), "1");
-            this.assertLogMessageObject("#12 - ", System.UInt64(12345678), "12345678");
-            this.assertLogMessageObject("#13 - ", -1.0, "-1");
-            this.assertLogMessageObject("#14 - ", 1.0, "1");
-            this.assertLogMessageObject("#15 - ", -12345678.0, "-12345678");
-            this.assertLogMessageObject("#16 - ", 12345678.0, "12345678");
-            this.assertLogMessageObject("#17 - ", -1.12345678, "-1.12345678");
-            this.assertLogMessageObject("#18 - ", 1.12345678, "1.12345678");
-            this.assertLogMessageObject("#19 - ", -12345678.12345678, "-12345678.12345678");
-            this.assertLogMessageObject("#20 - ", 12345678.12345678, "12345678.12345678");
-            this.assertLogMessageObject("#21 - ", System.Decimal(-1.0), "-1");
-            this.assertLogMessageObject("#22 - ", System.Decimal(1.0), "1");
-            this.assertLogMessageObject("#23 - ", System.Decimal(-12345678.0), "-12345678");
-            this.assertLogMessageObject("#24 - ", System.Decimal(12345678.0), "12345678");
-            this.assertLogMessageObject("#25 - ", System.Decimal(-1.12345678), "-1.12345678");
-            this.assertLogMessageObject("#26 - ", System.Decimal(1.12345678), "1.12345678");
-            this.assertLogMessageObject("#27 - ", System.Decimal("-12345678.12345678"), "-12345678.12345678");
-            this.assertLogMessageObject("#28 - ", System.Decimal("12345678.12345678"), "12345678.12345678");
+            this.assertLogMessageObject("#1 - ", Bridge.box(true, Boolean, $box_.Boolean.toString), "True");
+            this.assertLogMessageObject("#2 - ", Bridge.box(false, Boolean, $box_.Boolean.toString), "False");
+            this.assertLogMessageObject("#3 - ", Bridge.box(-1, System.Int32), "-1");
+            this.assertLogMessageObject("#4 - ", Bridge.box(1, System.Int32), "1");
+            this.assertLogMessageObject("#5 - ", Bridge.box(-12345678, System.Int32), "-12345678");
+            this.assertLogMessageObject("#6 - ", Bridge.box(12345678, System.Int32), "12345678");
+            this.assertLogMessageObject("#7 - ", Bridge.box(System.Int64(-1), System.Int64), "-1");
+            this.assertLogMessageObject("#8 - ", Bridge.box(System.Int64(1), System.Int64), "1");
+            this.assertLogMessageObject("#9 - ", Bridge.box(System.Int64(-12345678), System.Int64), "-12345678");
+            this.assertLogMessageObject("#10 - ", Bridge.box(System.Int64(12345678), System.Int64), "12345678");
+            this.assertLogMessageObject("#11 - ", Bridge.box(System.UInt64(1), System.UInt64), "1");
+            this.assertLogMessageObject("#12 - ", Bridge.box(System.UInt64(12345678), System.UInt64), "12345678");
+            this.assertLogMessageObject("#13 - ", Bridge.box(-1.0, System.Double, $box_.System.Double.toString), "-1");
+            this.assertLogMessageObject("#14 - ", Bridge.box(1.0, System.Double, $box_.System.Double.toString), "1");
+            this.assertLogMessageObject("#15 - ", Bridge.box(-12345678.0, System.Double, $box_.System.Double.toString), "-12345678");
+            this.assertLogMessageObject("#16 - ", Bridge.box(12345678.0, System.Double, $box_.System.Double.toString), "12345678");
+            this.assertLogMessageObject("#17 - ", Bridge.box(-1.12345678, System.Double, $box_.System.Double.toString), "-1.12345678");
+            this.assertLogMessageObject("#18 - ", Bridge.box(1.12345678, System.Double, $box_.System.Double.toString), "1.12345678");
+            this.assertLogMessageObject("#19 - ", Bridge.box(-12345678.12345678, System.Double, $box_.System.Double.toString), "-12345678.1234568");
+            this.assertLogMessageObject("#20 - ", Bridge.box(12345678.12345678, System.Double, $box_.System.Double.toString), "12345678.1234568");
+            this.assertLogMessageObject("#21 - ", Bridge.box(System.Decimal(-1.0), System.Decimal, $box_.System.Decimal.toString), "-1");
+            this.assertLogMessageObject("#22 - ", Bridge.box(System.Decimal(1.0), System.Decimal, $box_.System.Decimal.toString), "1");
+            this.assertLogMessageObject("#23 - ", Bridge.box(System.Decimal(-12345678.0), System.Decimal, $box_.System.Decimal.toString), "-12345678");
+            this.assertLogMessageObject("#24 - ", Bridge.box(System.Decimal(12345678.0), System.Decimal, $box_.System.Decimal.toString), "12345678");
+            this.assertLogMessageObject("#25 - ", Bridge.box(System.Decimal(-1.12345678), System.Decimal, $box_.System.Decimal.toString), "-1.12345678");
+            this.assertLogMessageObject("#26 - ", Bridge.box(System.Decimal(1.12345678), System.Decimal, $box_.System.Decimal.toString), "1.12345678");
+            this.assertLogMessageObject("#27 - ", Bridge.box(System.Decimal("-12345678.12345678"), System.Decimal, $box_.System.Decimal.toString), "-12345678.12345678");
+            this.assertLogMessageObject("#28 - ", Bridge.box(System.Decimal("12345678.12345678"), System.Decimal, $box_.System.Decimal.toString), "12345678.12345678");
             this.assertLogMessageObject("#29 - ", null, "null");
             this.assertLogMessageObject("#30 - ", {  }, "[object Object]");
             this.assertLogMessageObject("#31 - ", new Bridge.ClientTest.BridgeConsoleTests.ClassA(), "I'm ClassA");
@@ -3678,7 +3678,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 subColor = System.String.concat(toAdd, subColor);
             }
 
-            styleColor = (System.String.concat(String.fromCharCode(styleColor.charCodeAt(0)), subColor)).toUpperCase();
+            styleColor = (System.String.concat(String.fromCharCode(Bridge.box(styleColor.charCodeAt(0), System.Char, $box_.System.Char.toString)), subColor)).toUpperCase();
 
             return styleColor;
         },
@@ -3754,16 +3754,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(max + 1, System.Int32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(max + 1, System.Int32), System.Int32));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.Int32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.Int32))), System.Int32));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = Bridge.Int.check(max4 + 1, System.Int32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = Bridge.Int.check(max4 + 1, System.Int32))), System.Int32));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(2 * max, System.Int32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(2 * max, System.Int32), System.Int32));
                 }, "Through parameter *");
 
                 var min = -2147483648;
@@ -3787,16 +3787,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier unary -");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(min - 1, System.Int32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(min - 1, System.Int32), System.Int32));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.Int32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.Int32))), System.Int32));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = Bridge.Int.check(min4 - 1, System.Int32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = Bridge.Int.check(min4 - 1, System.Int32))), System.Int32));
                 }, "Through parameter --pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(-min, System.Int32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(-min, System.Int32), System.Int32));
                 }, "Through parameter unary -");
             },
             testUInt32: function () {
@@ -3821,16 +3821,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(max + 1, System.UInt32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(max + 1, System.UInt32), System.UInt32));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.UInt32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.UInt32))), System.UInt32));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = Bridge.Int.check(max4 + 1, System.UInt32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = Bridge.Int.check(max4 + 1, System.UInt32))), System.UInt32));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(2 * max, System.UInt32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(2 * max, System.UInt32), System.UInt32));
                 }, "Through parameter *");
 
                 var min = 0;
@@ -3851,13 +3851,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier pre--");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(min - 1, System.UInt32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(min - 1, System.UInt32), System.UInt32));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.UInt32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.UInt32))), System.UInt32));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = Bridge.Int.check(min4 - 1, System.UInt32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = Bridge.Int.check(min4 - 1, System.UInt32))), System.UInt32));
                 }, "Through parameter --pre");
             },
             testLong: function () {
@@ -3883,17 +3883,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.Int64(1), 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1), 1), System.Int64));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(1), $t));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(1), $t), System.Int64));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc(1)));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc(1)), System.Int64));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(System.Int64(2).mul(max, 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max, 1), System.Int64));
                 }, "Through parameter *");
 
                 var min = System.Int64.MinValue;
@@ -3918,17 +3918,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier unary -");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.Int64(1), 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1), 1), System.Int64));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(1), $t));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(1), $t), System.Int64));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec(1)));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec(1)), System.Int64));
                 }, "Through parameter --pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(min.neg(1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.neg(1), System.Int64));
                 }, "Through parameter unary -");
             },
             testULong: function () {
@@ -3954,17 +3954,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.UInt64(1), 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1), 1), System.UInt64));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(1), $t));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(1), $t), System.UInt64));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc(1)));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc(1)), System.UInt64));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max, 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max, 1), System.UInt64));
                 }, "Through parameter *");
 
                 var min = System.UInt64.MinValue;
@@ -3986,14 +3986,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier pre--");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1), 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1), 1), System.UInt64));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(1), $t));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(1), $t), System.UInt64));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec(1)));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec(1)), System.UInt64));
                 }, "Through parameter --pre");
             }
         }
@@ -4023,16 +4023,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(max + 1, System.Int32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(max + 1, System.Int32), System.Int32));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.Int32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.Int32))), System.Int32));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = Bridge.Int.check(max4 + 1, System.Int32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = Bridge.Int.check(max4 + 1, System.Int32))), System.Int32));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(2 * max, System.Int32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(2 * max, System.Int32), System.Int32));
                 }, "Through parameter *");
 
                 var min = -2147483648;
@@ -4056,16 +4056,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier unary -");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(min - 1, System.Int32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(min - 1, System.Int32), System.Int32));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.Int32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.Int32))), System.Int32));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = Bridge.Int.check(min4 - 1, System.Int32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = Bridge.Int.check(min4 - 1, System.Int32))), System.Int32));
                 }, "Through parameter --pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(-min, System.Int32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(-min, System.Int32), System.Int32));
                 }, "Through parameter unary -");
             },
             testUInt32: function () {
@@ -4090,16 +4090,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(max + 1, System.UInt32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(max + 1, System.UInt32), System.UInt32));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.UInt32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.UInt32))), System.UInt32));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = Bridge.Int.check(max4 + 1, System.UInt32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = Bridge.Int.check(max4 + 1, System.UInt32))), System.UInt32));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(2 * max, System.UInt32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(2 * max, System.UInt32), System.UInt32));
                 }, "Through parameter *");
 
                 var min = 0;
@@ -4120,13 +4120,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier pre--");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.Int.check(min - 1, System.UInt32));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(min - 1, System.UInt32), System.UInt32));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.UInt32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.UInt32))), System.UInt32));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = Bridge.Int.check(min4 - 1, System.UInt32))));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = Bridge.Int.check(min4 - 1, System.UInt32))), System.UInt32));
                 }, "Through parameter --pre");
             },
             testLong: function () {
@@ -4152,17 +4152,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.Int64(1), 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1), 1), System.Int64));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(1), $t));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(1), $t), System.Int64));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc(1)));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc(1)), System.Int64));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(System.Int64(2).mul(max, 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max, 1), System.Int64));
                 }, "Through parameter *");
 
                 var min = System.Int64.MinValue;
@@ -4187,17 +4187,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier unary -");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.Int64(1), 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1), 1), System.Int64));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(1), $t));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(1), $t), System.Int64));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec(1)));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec(1)), System.Int64));
                 }, "Through parameter --pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(min.neg(1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.neg(1), System.Int64));
                 }, "Through parameter unary -");
             },
             testULong: function () {
@@ -4223,17 +4223,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.UInt64(1), 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1), 1), System.UInt64));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(1), $t));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(1), $t), System.UInt64));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc(1)));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc(1)), System.UInt64));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max, 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max, 1), System.UInt64));
                 }, "Through parameter *");
 
                 var min = System.UInt64.MinValue;
@@ -4255,14 +4255,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }, "Through identifier pre--");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1), 1));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1), 1), System.UInt64));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(1), $t));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(1), $t), System.UInt64));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec(1)));
+                    Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec(1)), System.UInt64));
                 }, "Through parameter --pre");
             }
         }
@@ -4282,15 +4282,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) | 0));
                 var rMax3 = ((max2 = (max2 + 1) | 0));
                 var rMax4 = (2 * max) | 0;
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax1, System.Int32), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMax2, System.Int32), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax3, System.Int32), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int32), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max + 1) | 0)), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) | 0))), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) | 0))), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(((2 * max) | 0)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) | 0), System.Int32)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) | 0)), System.Int32)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) | 0)), System.Int32)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) | 0), System.Int32)), "Through parameter *");
 
                 var min = -2147483648;
 
@@ -4303,15 +4303,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) | 0));
                 var rMin3 = ((min2 = (min2 - 1) | 0));
                 var rMin4 = (-min) | 0;
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin1, System.Int32), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin2, System.Int32), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin3, System.Int32), "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin4, System.Int32), "Through identifier unary -");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min - 1) | 0)), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) | 0))), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) | 0))), "Through parameter --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(((-min) | 0)), "Through parameter unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) | 0), System.Int32)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) | 0)), System.Int32)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) | 0)), System.Int32)), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((-min) | 0), System.Int32)), "Through parameter unary -");
             },
             testUInt32: function () {
                 var max = 4294967295;
@@ -4325,15 +4325,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) >>> 0));
                 var rMax3 = ((max2 = (max2 + 1) >>> 0));
                 var rMax4 = (2 * max) >>> 0;
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt32), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMax2, System.UInt32), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt32), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", Bridge.box(rMax4, System.UInt32), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max + 1) >>> 0)), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0))), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) >>> 0))), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.CheckedUncheckedTests.bypass(((2 * max) >>> 0)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) >>> 0), System.UInt32)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0)), System.UInt32)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) >>> 0)), System.UInt32)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) >>> 0), System.UInt32)), "Through parameter *");
 
                 var min = 0;
 
@@ -4346,15 +4346,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) >>> 0));
                 var rMin3 = ((min2 = (min2 - 1) >>> 0));
                 var rMin4 = System.Int64(min).neg();
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin1, System.UInt32), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt32), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin3, System.UInt32), "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min - 1) >>> 0)), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0))), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) >>> 0))), "Through parameter --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(System.Int64(min).neg()), "Through parameter unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) >>> 0), System.UInt32)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0)), System.UInt32)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) >>> 0)), System.UInt32)), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(min).neg(), System.Int64)), "Through parameter unary -");
             },
             testLong: function () {
                 var $t;
@@ -4369,15 +4369,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.Int64(2).mul(max);
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax1, System.Int64), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMax2, System.Int64), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax3, System.Int64), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int64), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.Int64(1))), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(System.Int64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1)), System.Int64)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.Int64)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.Int64)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max), System.Int64)), "Through parameter *");
 
                 var min = System.Int64.MinValue;
 
@@ -4390,15 +4390,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
                 var rMin4 = min.neg();
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin1, System.Int64), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin2, System.Int64), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin3, System.Int64), "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.Int64(1))), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(min.neg()), "Through parameter unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1)), System.Int64)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.Int64)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.Int64)), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.neg(), System.Int64)), "Through parameter unary -");
             },
             testULong: function () {
                 var $t;
@@ -4413,15 +4413,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.UInt64(2).mul(max);
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt64), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMax2, System.UInt64), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt64), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.box(rMax4, System.UInt64), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.UInt64(1))), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1)), System.UInt64)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.UInt64)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.UInt64)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max), System.UInt64)), "Through parameter *");
 
                 var min = System.UInt64.MinValue;
 
@@ -4433,13 +4433,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin1 = min.sub(System.UInt64(1));
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin3, "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin1, System.UInt64), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt64), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin3, System.UInt64), "Through identifier --pre");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1))), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1)), System.UInt64)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.UInt64)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.UInt64)), "Through parameter --pre");
             }
         }
     });
@@ -4458,15 +4458,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) | 0));
                 var rMax3 = ((max2 = (max2 + 1) | 0));
                 var rMax4 = (2 * max) | 0;
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax1, System.Int32), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMax2, System.Int32), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax3, System.Int32), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int32), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max + 1) | 0)), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) | 0))), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) | 0))), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(((2 * max) | 0)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) | 0), System.Int32)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) | 0)), System.Int32)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) | 0)), System.Int32)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) | 0), System.Int32)), "Through parameter *");
 
                 var min = -2147483648;
 
@@ -4479,15 +4479,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) | 0));
                 var rMin3 = ((min2 = (min2 - 1) | 0));
                 var rMin4 = (-min) | 0;
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin1, System.Int32), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin2, System.Int32), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin3, System.Int32), "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin4, System.Int32), "Through identifier unary -");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min - 1) | 0)), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) | 0))), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) | 0))), "Through parameter --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(((-min) | 0)), "Through parameter unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) | 0), System.Int32)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) | 0)), System.Int32)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) | 0)), System.Int32)), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((-min) | 0), System.Int32)), "Through parameter unary -");
             },
             testUInt32: function () {
                 var max = 4294967295;
@@ -4501,15 +4501,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) >>> 0));
                 var rMax3 = ((max2 = (max2 + 1) >>> 0));
                 var rMax4 = (2 * max) >>> 0;
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt32), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMax2, System.UInt32), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt32), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", Bridge.box(rMax4, System.UInt32), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max + 1) >>> 0)), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0))), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) >>> 0))), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.CheckedUncheckedTests.bypass(((2 * max) >>> 0)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) >>> 0), System.UInt32)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0)), System.UInt32)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) >>> 0)), System.UInt32)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) >>> 0), System.UInt32)), "Through parameter *");
 
                 var min = 0;
 
@@ -4522,15 +4522,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) >>> 0));
                 var rMin3 = ((min2 = (min2 - 1) >>> 0));
                 var rMin4 = System.Int64(min).neg();
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin1, System.UInt32), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt32), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin3, System.UInt32), "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min - 1) >>> 0)), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0))), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) >>> 0))), "Through parameter --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(System.Int64(min).neg()), "Through parameter unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) >>> 0), System.UInt32)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0)), System.UInt32)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) >>> 0)), System.UInt32)), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(min).neg(), System.Int64)), "Through parameter unary -");
             },
             testLong: function () {
                 var $t;
@@ -4545,15 +4545,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.Int64(2).mul(max);
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax1, System.Int64), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMax2, System.Int64), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax3, System.Int64), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int64), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.Int64(1))), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(System.Int64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1)), System.Int64)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.Int64)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.Int64)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max), System.Int64)), "Through parameter *");
 
                 var min = System.Int64.MinValue;
 
@@ -4566,15 +4566,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
                 var rMin4 = min.neg();
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin1, System.Int64), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin2, System.Int64), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin3, System.Int64), "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.Int64(1))), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(min.neg()), "Through parameter unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1)), System.Int64)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.Int64)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.Int64)), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.neg(), System.Int64)), "Through parameter unary -");
             },
             testULong: function () {
                 var $t;
@@ -4589,15 +4589,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.UInt64(2).mul(max);
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt64), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMax2, System.UInt64), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt64), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.box(rMax4, System.UInt64), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.UInt64(1))), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1)), System.UInt64)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.UInt64)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.UInt64)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max), System.UInt64)), "Through parameter *");
 
                 var min = System.UInt64.MinValue;
 
@@ -4609,13 +4609,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin1 = min.sub(System.UInt64(1));
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin3, "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin1, System.UInt64), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt64), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin3, System.UInt64), "Through identifier --pre");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1))), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1)), System.UInt64)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.UInt64)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.UInt64)), "Through parameter --pre");
             }
         }
     });
@@ -4634,15 +4634,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) | 0));
                 var rMax3 = ((max2 = (max2 + 1) | 0));
                 var rMax4 = (2 * max) | 0;
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax1, System.Int32), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMax2, System.Int32), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax3, System.Int32), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int32), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max + 1) | 0)), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) | 0))), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) | 0))), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(((2 * max) | 0)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) | 0), System.Int32)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) | 0)), System.Int32)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) | 0)), System.Int32)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) | 0), System.Int32)), "Through parameter *");
 
                 var min = -2147483648;
 
@@ -4655,15 +4655,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) | 0));
                 var rMin3 = ((min2 = (min2 - 1) | 0));
                 var rMin4 = (-min) | 0;
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin1, System.Int32), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin2, System.Int32), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin3, System.Int32), "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin4, System.Int32), "Through identifier unary -");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min - 1) | 0)), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) | 0))), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) | 0))), "Through parameter --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(((-min) | 0)), "Through parameter unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) | 0), System.Int32)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) | 0)), System.Int32)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) | 0)), System.Int32)), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((-min) | 0), System.Int32)), "Through parameter unary -");
             },
             testUInt32: function () {
                 var max = 4294967295;
@@ -4677,15 +4677,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) >>> 0));
                 var rMax3 = ((max2 = (max2 + 1) >>> 0));
                 var rMax4 = (2 * max) >>> 0;
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt32), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMax2, System.UInt32), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt32), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", Bridge.box(rMax4, System.UInt32), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max + 1) >>> 0)), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0))), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) >>> 0))), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.CheckedUncheckedTests.bypass(((2 * max) >>> 0)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) >>> 0), System.UInt32)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0)), System.UInt32)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) >>> 0)), System.UInt32)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) >>> 0), System.UInt32)), "Through parameter *");
 
                 var min = 0;
 
@@ -4698,15 +4698,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) >>> 0));
                 var rMin3 = ((min2 = (min2 - 1) >>> 0));
                 var rMin4 = System.Int64(min).neg();
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin1, System.UInt32), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt32), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin3, System.UInt32), "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min - 1) >>> 0)), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0))), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) >>> 0))), "Through parameter --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(System.Int64(min).neg()), "Through parameter unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) >>> 0), System.UInt32)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0)), System.UInt32)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) >>> 0)), System.UInt32)), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(min).neg(), System.Int64)), "Through parameter unary -");
             },
             testLong: function () {
                 var $t;
@@ -4721,15 +4721,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.Int64(2).mul(max);
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax1, System.Int64), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMax2, System.Int64), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax3, System.Int64), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int64), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.Int64(1))), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(System.Int64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1)), System.Int64)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.Int64)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.Int64)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max), System.Int64)), "Through parameter *");
 
                 var min = System.Int64.MinValue;
 
@@ -4742,15 +4742,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
                 var rMin4 = min.neg();
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin1, System.Int64), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin2, System.Int64), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin3, System.Int64), "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.Int64(1))), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(min.neg()), "Through parameter unary -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1)), System.Int64)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.Int64)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.Int64)), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.neg(), System.Int64)), "Through parameter unary -");
             },
             testULong: function () {
                 var $t;
@@ -4765,15 +4765,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.UInt64(2).mul(max);
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", rMax2, "Through identifier post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", rMax4, "Through identifier *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt64), "Through identifier +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMax2, System.UInt64), "Through identifier post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt64), "Through identifier ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.box(rMax4, System.UInt64), "Through identifier *");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(max.add(System.UInt64(1))), "Through parameter +");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1)), System.UInt64)), "Through parameter +");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.UInt64)), "Through parameter post++");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.UInt64)), "Through parameter ++pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max), System.UInt64)), "Through parameter *");
 
                 var min = System.UInt64.MinValue;
 
@@ -4785,13 +4785,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var rMin1 = min.sub(System.UInt64(1));
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin1, "Through identifier -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin3, "Through identifier --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin1, System.UInt64), "Through identifier -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt64), "Through identifier post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin3, System.UInt64), "Through identifier --pre");
 
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1))), "Through parameter -");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1)), System.UInt64)), "Through parameter -");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.UInt64)), "Through parameter post--");
+                Bridge.ClientTest.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.UInt64)), "Through parameter --pre");
             }
         }
     });
@@ -4868,16 +4868,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         defaultComparerReturnsZeroAsHashCodeForNullAndUndefined: function () {
             Bridge.Test.Assert.areEqual(0, System.Collections.Generic.EqualityComparer$1(Object).def.getHashCode2(null));
-            Bridge.Test.Assert.areEqual(0, System.Collections.Generic.EqualityComparer$1(Object).def.getHashCode2(undefined));
+            Bridge.Test.Assert.areEqual(0, System.Collections.Generic.EqualityComparer$1(Object).def.getHashCode2(Bridge.unbox(undefined)));
         },
         defaultComparerCanDetermineEquality: function () {
             var o1 = {  }, o2 = {  };
 
             Bridge.Test.Assert.true$1(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(null, null), "null, null");
-            Bridge.Test.Assert.false$1(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(null, o1), "null, o1");
-            Bridge.Test.Assert.false$1(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(o1, null), "o1, null");
-            Bridge.Test.Assert.true$1(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(o1, o1), "o1, o1");
-            Bridge.Test.Assert.false$1(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(o1, o2), "o1, o2");
+            Bridge.Test.Assert.false$1(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(null, Bridge.unbox(o1)), "null, o1");
+            Bridge.Test.Assert.false$1(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(Bridge.unbox(o1), null), "o1, null");
+            Bridge.Test.Assert.true$1(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(Bridge.unbox(o1), Bridge.unbox(o1)), "o1, o1");
+            Bridge.Test.Assert.false$1(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(Bridge.unbox(o1), Bridge.unbox(o2)), "o1, o2");
         },
         defaultComparerInvokesOverriddenGetHashCode: function () {
             Bridge.Test.Assert.areEqual(42158, System.Collections.Generic.EqualityComparer$1(Object).def.getHashCode2(Bridge.merge(new Bridge.ClientTest.Collections.Generic.EqualityComparerTests.MyClass(), {
@@ -4889,17 +4889,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var other = new Bridge.ClientTest.Collections.Generic.EqualityComparerTests.MyClass();
             c.shouldEqual = false;
             Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(c, other));
-            Bridge.Test.Assert.areStrictEqual(other, c.other);
+            Bridge.Test.Assert.areStrictEqual(other, Bridge.unbox(c.other));
 
             c.shouldEqual = true;
             c.other = null;
             Bridge.Test.Assert.true(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(c, other));
-            Bridge.Test.Assert.areStrictEqual(other, c.other);
+            Bridge.Test.Assert.areStrictEqual(other, Bridge.unbox(c.other));
 
             c.shouldEqual = true;
             c.other = other;
             Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(c, null)); // We should not invoke our own equals so its return value does not matter.
-            Bridge.Test.Assert.areEqual(other, c.other); // We should not invoke our own equals so the 'other' member should not be set.
+            Bridge.Test.Assert.areEqual(other, Bridge.unbox(c.other)); // We should not invoke our own equals so the 'other' member should not be set.
         }
     });
 
@@ -5098,9 +5098,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var o = { };
 
             Bridge.Test.Assert.true(d.tryGetValue("a", o));
-            Bridge.Test.Assert.areEqual(1, o.v);
+            Bridge.Test.Assert.areEqual(1, Bridge.unbox(o.v));
             Bridge.Test.Assert.false(d.tryGetValue("c", o));
-            Bridge.Test.Assert.areStrictEqual(null, o.v);
+            Bridge.Test.Assert.areStrictEqual(null, Bridge.unbox(o.v));
         },
         canUseCustomComparer: function () {
             var d = $_.Bridge.ClientTest.Collections.Generic.GenericDictionaryTests.f14(new (System.Collections.Generic.Dictionary$2(String, System.Int32))(null, new Bridge.ClientTest.Collections.Generic.GenericDictionaryTests.TestEqualityComparer()));
@@ -5712,11 +5712,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         arrayGetEnumeratorMethodWorks: function () {
             var e = Bridge.getEnumerator(["x", "y", "z"]);
             Bridge.Test.Assert.true(e.System$Collections$IEnumerator$moveNext());
-            Bridge.Test.Assert.areEqual("x", e.System$Collections$IEnumerator$getCurrent());
+            Bridge.Test.Assert.areEqual("x", Bridge.unbox(e.System$Collections$IEnumerator$getCurrent()));
             Bridge.Test.Assert.true(e.System$Collections$IEnumerator$moveNext());
-            Bridge.Test.Assert.areEqual("y", e.System$Collections$IEnumerator$getCurrent());
+            Bridge.Test.Assert.areEqual("y", Bridge.unbox(e.System$Collections$IEnumerator$getCurrent()));
             Bridge.Test.Assert.true(e.System$Collections$IEnumerator$moveNext());
-            Bridge.Test.Assert.areEqual("z", e.System$Collections$IEnumerator$getCurrent());
+            Bridge.Test.Assert.areEqual("z", Bridge.unbox(e.System$Collections$IEnumerator$getCurrent()));
             Bridge.Test.Assert.false(e.System$Collections$IEnumerator$moveNext());
         },
         arrayCastToIEnumerableCanBeEnumerated: function () {
@@ -6037,7 +6037,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var enm = new Bridge.ClientTest.Collections.Generic.IteratorBlockTests.C(sb).getEnumerator(2);
 
             while (enm.System$Collections$IEnumerator$moveNext()) {
-                sb.appendLine("got " + enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
+                sb.appendLine("got " + Bridge.box(enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")](), System.Int32));
             }
 
             this.assertEqual(sb.toString(), "yielding 0\nyielding 1\nyielding -1\nin finally\ngot 0\ngot 1\ngot -1\n");
@@ -6050,7 +6050,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             for (var i = 0; i < 2; i = (i + 1) | 0) {
                 enm.System$Collections$IEnumerator$moveNext();
-                sb.appendLine("got " + enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
+                sb.appendLine("got " + Bridge.box(enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")](), System.Int32));
             }
             enm.System$IDisposable$dispose();
 
@@ -6065,7 +6065,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var enm = new Bridge.ClientTest.Collections.Generic.IteratorBlockTests.C(sb).getEnumeratorThrows();
                 for (var i = 0; i < 100; i = (i + 1) | 0) {
                     enm.System$Collections$IEnumerator$moveNext();
-                    sb.appendLine("got " + enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
+                    sb.appendLine("got " + Bridge.box(enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")](), System.Int32));
                 }
                 Bridge.Test.Assert.fail$1("Should have thrown an exception in the loop");
             }
@@ -6090,7 +6090,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             $t = Bridge.getEnumerator(enm, System.Int32);
             while ($t.moveNext()) {
                 var i = $t.getCurrent();
-                sb.appendLine("got " + i);
+                sb.appendLine("got " + Bridge.box(i, System.Int32));
             }
 
             sb.appendLine("-");
@@ -6098,7 +6098,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             $t1 = Bridge.getEnumerator(enm, System.Int32);
             while ($t1.moveNext()) {
                 var i1 = $t1.getCurrent();
-                sb.appendLine("got " + i1);
+                sb.appendLine("got " + Bridge.box(i1, System.Int32));
             }
 
             this.assertEqual(sb.toString(), "yielding 0\nyielding 1\nyielding -1\nin finally\ngot 0\ngot 1\ngot -1\n-\ngot 0\ngot 1\ngot -1\n");
@@ -6112,7 +6112,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             $t = Bridge.getEnumerator(new Bridge.ClientTest.Collections.Generic.IteratorBlockTests.C(sb).getEnumerable(5), System.Int32);
             while ($t.moveNext()) {
                 var i = $t.getCurrent();
-                sb.appendLine("got " + i);
+                sb.appendLine("got " + Bridge.box(i, System.Int32));
                 if (((n = (n + 1) | 0)) === 2) {
                     break;
                 }
@@ -6131,7 +6131,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var enumerator = Bridge.getEnumerator(enumerable, System.Int32);
                 for (var i = 0; i < 100; i = (i + 1) | 0) {
                     enumerator.System$Collections$IEnumerator$moveNext();
-                    sb.appendLine("got " + enumerator[Bridge.geti(enumerator, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
+                    sb.appendLine("got " + Bridge.box(enumerator[Bridge.geti(enumerator, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")](), System.Int32));
                 }
                 Bridge.Test.Assert.fail$1("Should have thrown");
             }
@@ -6187,7 +6187,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var $yield = [];
             try {
                 for (var i = 0; i < n; i = (i + 1) | 0) {
-                    this._sb.appendLine("yielding " + i);
+                    this._sb.appendLine("yielding " + Bridge.box(i, System.Int32));
                     $yield.push(i);
                 }
                 this._sb.appendLine("yielding -1");
@@ -6219,7 +6219,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var $yield = [];
             try {
                 for (var i = 0; i < n; i = (i + 1) | 0) {
-                    this._sb.appendLine("yielding " + i);
+                    this._sb.appendLine("yielding " + Bridge.box(i, System.Int32));
                     $yield.push(i);
                 }
                 this._sb.appendLine("yielding -1");
@@ -6437,7 +6437,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         foreachWithListCallbackWorks: function () {
             var result = "";
             Bridge.Linq.Enumerable.from($_.Bridge.ClientTest.Collections.Generic.ListTests.f22(new (System.Collections.Generic.List$1(String))())).forEach(function (s, i) {
-                    result = System.String.concat(result, (System.String.concat(s, i)));
+                    result = System.String.concat(result, (System.String.concat(s, Bridge.box(i, System.Int32))));
                 });
             Bridge.Test.Assert.areEqual("a0b1c2", result);
         },
@@ -7294,17 +7294,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(amap.has(someKey), "Has someKey");
             Bridge.Test.Assert.false$1(amap.has(someOtherKey), "Does not have someOtherKey");
             var v = amap.get(someKey);
-            Bridge.Test.Assert.notNull$1(v, "Get not null");
+            Bridge.Test.Assert.notNull$1(Bridge.unbox(v), "Get not null");
             var typedV = Bridge.as(v, Bridge.ClientTest.Collections.Generic.WeakMapTests.SomeCustomClass);
             Bridge.Test.Assert.notNull$1(typedV, "Get not null SomeCustomClass");
             Bridge.Test.Assert.areEqual$1(typedV.getSomeProperty(), 456, "Check SomeProperty");
-            Bridge.Test.Assert.areEqual$1(someValue, v, "Check references");
+            Bridge.Test.Assert.areEqual$1(someValue, Bridge.unbox(v), "Check references");
 
             Bridge.Test.Assert.true$1(amap.delete(someKey), "Delete someKey");
             Bridge.Test.Assert.false$1(amap.delete(someKey), "Another delete someKey");
             Bridge.Test.Assert.false$1(amap.has(someKey), "Check if has deleted someKey");
 
-            Bridge.Test.Assert.areEqual$1(undefined, amap.get(someKey), "Get deleted someKey");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(undefined), Bridge.unbox(amap.get(someKey)), "Get deleted someKey");
         }
     });
 
@@ -7551,12 +7551,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Collections.Native.Float32ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", System.Single.format(actual[i], 'G')));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", System.Single.format(Bridge.box(actual[i], System.Single, $box_.System.Single.toString), 'G')));
                     return;
                 }
             }
@@ -7779,12 +7779,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Collections.Native.Float64ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", System.Double.format(actual[i], 'G')));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", System.Double.format(Bridge.box(actual[i], System.Double, $box_.System.Double.toString), 'G')));
                     return;
                 }
             }
@@ -8007,12 +8007,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Collections.Native.Int16ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.Int16)));
                     return;
                 }
             }
@@ -8235,12 +8235,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Collections.Native.Int32ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.Int32)));
                     return;
                 }
             }
@@ -8463,12 +8463,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Collections.Native.Int8ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.SByte)));
                     return;
                 }
             }
@@ -8691,12 +8691,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Collections.Native.Uint16ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.UInt16)));
                     return;
                 }
             }
@@ -8919,12 +8919,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Collections.Native.Uint32ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (System.Int64(actual[i]).ne(System.Int64(expected[i]))) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.UInt32)));
                     return;
                 }
             }
@@ -9147,12 +9147,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Collections.Native.Uint8ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.Byte)));
                     return;
                 }
             }
@@ -9375,12 +9375,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Collections.Native.Uint8ClampedArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.Byte)));
                     return;
                 }
             }
@@ -10030,14 +10030,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                     var expected = expectedValues[i];
 
                     if (useTrue) {
-                        Bridge.Test.Assert.true$1(Bridge.equals(expected, result), System.String.concat("Test: ", testValue, " Expected: ", expected.toString(), " Result: ", result.toString()));
+                        Bridge.Test.Assert.true$1(Bridge.equals(expected, result), System.String.concat("Test: ", Bridge.box(testValue, TInput), " Expected: ", expected.toString(), " Result: ", result.toString()));
                     } else {
-                        Bridge.Test.Assert.areEqual$1(expected, result, System.String.concat("Test: ", testValue, " Expected: ", expected.toString(), " Result: ", result.toString()));
+                        Bridge.Test.Assert.areEqual$1(expected, result, System.String.concat("Test: ", Bridge.box(testValue, TInput), " Expected: ", expected.toString(), " Result: ", result.toString()));
                     }
                 }
                 catch (ex) {
                     ex = System.Exception.create(ex);
-                    Bridge.Test.Assert.fail$1(System.String.concat("Exception occurred while Verify ", testValue, " Exception: ", ex.toString()));
+                    Bridge.Test.Assert.fail$1(System.String.concat("Exception occurred while Verify ", Bridge.box(testValue, TInput), " Exception: ", ex.toString()));
                 }
             }
         },
@@ -10073,7 +10073,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }
                 catch (ex) {
                     ex = System.Exception.create(ex);
-                    Bridge.Test.Assert.fail$1(System.String.concat("Exception occurred while VerifyViaObj ", testValue, " Exception: ", ex.toString()));
+                    Bridge.Test.Assert.fail$1(System.String.concat("Exception occurred while VerifyViaObj ", Bridge.box(testValue, TInput), " Exception: ", ex.toString()));
                 }
             }
         },
@@ -10114,7 +10114,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         verifyFromObject: function (convert, convertWithFormatProvider, testValues, expectedValues) {
             this.verify(Object, convert, testValues, expectedValues);
             this.verify(Object, function (input) {
-                return convertWithFormatProvider(input, Bridge.ClientTest.ConvertTests.ConvertTestBase$1.TestFormatProvider(TOutput).s_instance);
+                return convertWithFormatProvider(Bridge.unbox(input), Bridge.ClientTest.ConvertTests.ConvertTestBase$1.TestFormatProvider(TOutput).s_instance);
             }, testValues, expectedValues);
         },
         /**
@@ -10148,14 +10148,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                     var expected = expectedValues[i];
 
                     if (useTrue) {
-                        Bridge.Test.Assert.true$1(Bridge.equals(expected, result), System.String.concat("Test: ", testValue, " Radix: ", radix, " Expected: ", expected.toString(), " Result: ", result.toString()));
+                        Bridge.Test.Assert.true$1(Bridge.equals(expected, result), System.String.concat("Test: ", testValue, " Radix: ", Bridge.box(radix, System.Int32), " Expected: ", expected.toString(), " Result: ", result.toString()));
                     } else {
                         Bridge.Test.Assert.areEqual(expected, result);
                     }
                 }
                 catch (ex) {
                     ex = System.Exception.create(ex);
-                    Bridge.Test.Assert.fail$1(System.String.concat("Exception occurred while VerifyFromStringWithBase ", testValue, " Radix: ", radix, " Exception: ", ex.toString()));
+                    Bridge.Test.Assert.fail$1(System.String.concat("Exception occurred while VerifyFromStringWithBase ", testValue, " Radix: ", Bridge.box(radix, System.Int32), " Exception: ", ex.toString()));
                 }
             }
         },
@@ -10185,11 +10185,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                             convert(testValues[i], testBases[i]);
                         }, function (err) {
                             return Bridge.referenceEquals(Bridge.Reflection.getTypeFullName(Bridge.getType(err)), Bridge.Reflection.getTypeFullName(TException));
-                        }, System.String.concat("Value ", testValues[i], " base ", testBases[i]));
+                        }, System.String.concat("Value ", testValues[i], " base ", Bridge.box(testBases[i], System.Int32)));
                     }
                     catch (e) {
                         e = System.Exception.create(e);
-                        var message = System.String.format("Expected {0} converting '{1}' (base {2}) to '{3}'", Bridge.Reflection.getTypeFullName(TException), testValues[i], testBases[i], Bridge.Reflection.getTypeFullName(TOutput));
+                        var message = System.String.format("Expected {0} converting '{1}' (base {2}) to '{3}'", Bridge.Reflection.getTypeFullName(TException), testValues[i], Bridge.box(testBases[i], System.Int32), Bridge.Reflection.getTypeFullName(TOutput));
                         throw new System.AggregateException(message, [e]);
                     }
                 }).call(this);
@@ -10216,11 +10216,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                             convert(testValues[i]);
                         }, function (err) {
                             return Bridge.referenceEquals(Bridge.Reflection.getTypeFullName(Bridge.getType(err)), Bridge.Reflection.getTypeFullName(TException));
-                        }, System.String.concat("Value ", testValues[i]));
+                        }, System.String.concat("Value ", Bridge.box(testValues[i], TInput)));
                     }
                     catch (e) {
                         e = System.Exception.create(e);
-                        var message = System.String.format("Expected {0} converting '{1}' ({2}) to {3}", Bridge.Reflection.getTypeFullName(TException), testValues[i], Bridge.Reflection.getTypeFullName(TInput), Bridge.Reflection.getTypeFullName(TOutput));
+                        var message = System.String.format("Expected {0} converting '{1}' ({2}) to {3}", Bridge.Reflection.getTypeFullName(TException), Bridge.box(testValues[i], TInput), Bridge.Reflection.getTypeFullName(TInput), Bridge.Reflection.getTypeFullName(TOutput));
                         throw new System.AggregateException(message, [e]);
                     }
                 }).call(this);
@@ -10248,11 +10248,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                             convert(testValues[i]);
                         }, function (err) {
                             return Bridge.referenceEquals(Bridge.Reflection.getTypeFullName(Bridge.getType(err)), Bridge.Reflection.getTypeFullName(TException));
-                        }, System.String.concat("Value ", testValues[i]));
+                        }, System.String.concat("Value ", Bridge.box(testValues[i], TInput)));
                     }
                     catch (e) {
                         e = System.Exception.create(e);
-                        var message = System.String.format("Expected {0} converting '{1}' ({2}) to {3}", Bridge.Reflection.getTypeFullName(TException), testValues[i], Bridge.Reflection.getTypeFullName(TInput), Bridge.Reflection.getTypeFullName(TOutput));
+                        var message = System.String.format("Expected {0} converting '{1}' ({2}) to {3}", Bridge.Reflection.getTypeFullName(TException), Bridge.box(testValues[i], TInput), Bridge.Reflection.getTypeFullName(TInput), Bridge.Reflection.getTypeFullName(TOutput));
                         throw new System.AggregateException(message, [e]);
                     }
                 }).call(this);
@@ -10293,7 +10293,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         verifyFromObjectThrows: function (TException, convert, convertWithFormatProvider, testValues) {
             this.verifyThrows(TException, Object, convert, testValues);
             this.verifyThrows(TException, Object, function (input) {
-                return convertWithFormatProvider(input, Bridge.ClientTest.ConvertTests.ConvertTestBase$1.TestFormatProvider(TOutput).s_instance);
+                return convertWithFormatProvider(Bridge.unbox(input), Bridge.ClientTest.ConvertTests.ConvertTestBase$1.TestFormatProvider(TOutput).s_instance);
             }, testValues);
         }
     }; });
@@ -10524,12 +10524,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.ConvertTests.ConvertToStringTests", {
         statics: {
             fromBoxedObject: function () {
-                var testValues = [true, false, System.Decimal.Zero, System.Decimal.One, System.Decimal.MinusOne, System.Decimal.MaxValue, System.Decimal.MinValue, System.Decimal("1.234567890123456789012345678", System.Globalization.NumberFormatInfo.invariantInfo), System.Decimal("1234.56", System.Globalization.NumberFormatInfo.invariantInfo), System.Decimal("-1234.56", System.Globalization.NumberFormatInfo.invariantInfo), -12.2364, -12.236465923406483, -1.7753E-83, 1.2345E+235, 120.0, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, Number.NaN, -12.2364, 0.0, 120.0, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, Number.NaN, -128, 0, 127, -32768, 0, 32767, -2147483648, 0, 2147483647, System.Int64.MinValue, System.Int64(0), System.Int64.MaxValue, 0, 100, 255, 0, 100, 65535, 0, 100, 4294967295, System.UInt64.MinValue, System.UInt64(100), System.UInt64.MaxValue];
+                var testValues = [Bridge.box(true, Boolean, $box_.Boolean.toString), Bridge.box(false, Boolean, $box_.Boolean.toString), Bridge.box(System.Decimal.Zero, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.One, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MaxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("1.234567890123456789012345678", System.Globalization.NumberFormatInfo.invariantInfo), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("1234.56", System.Globalization.NumberFormatInfo.invariantInfo), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-1234.56", System.Globalization.NumberFormatInfo.invariantInfo), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-12.2364, System.Double, $box_.System.Double.toString), Bridge.box(-12.236465923406483, System.Double, $box_.System.Double.toString), Bridge.box(-1.7753E-83, System.Double, $box_.System.Double.toString), Bridge.box(1.2345E+235, System.Double, $box_.System.Double.toString), Bridge.box(120.0, System.Double, $box_.System.Double.toString), Bridge.box(Number.NEGATIVE_INFINITY, System.Double, $box_.System.Double.toString), Bridge.box(Number.POSITIVE_INFINITY, System.Double, $box_.System.Double.toString), Bridge.box(Number.NaN, System.Double, $box_.System.Double.toString), Bridge.box(-12.2364, System.Single, $box_.System.Single.toString), Bridge.box(0.0, System.Single, $box_.System.Single.toString), Bridge.box(120.0, System.Single, $box_.System.Single.toString), Bridge.box(Number.NEGATIVE_INFINITY, System.Single, $box_.System.Single.toString), Bridge.box(Number.POSITIVE_INFINITY, System.Single, $box_.System.Single.toString), Bridge.box(Number.NaN, System.Single, $box_.System.Single.toString), Bridge.box(-128, System.SByte), Bridge.box(0, System.SByte), Bridge.box(127, System.SByte), Bridge.box(-32768, System.Int16), Bridge.box(0, System.Int32), Bridge.box(32767, System.Int16), Bridge.box(-2147483648, System.Int32), Bridge.box(0, System.Int32), Bridge.box(2147483647, System.Int32), Bridge.box(System.Int64.MinValue, System.Int64), Bridge.box(System.Int64(0), System.Int64), Bridge.box(System.Int64.MaxValue, System.Int64), Bridge.box(0, System.Byte), Bridge.box(100, System.Byte), Bridge.box(255, System.Byte), Bridge.box(0, System.UInt16), Bridge.box(100, System.UInt16), Bridge.box(65535, System.UInt16), Bridge.box(0, System.UInt32), Bridge.box(100, System.UInt32), Bridge.box(4294967295, System.UInt32), Bridge.box(System.UInt64.MinValue, System.UInt64), Bridge.box(System.UInt64(100), System.UInt64), Bridge.box(System.UInt64.MaxValue, System.UInt64)];
 
                 var expectedValues = ["True", "False", "0", "1", "-1", Bridge.ClientTest.ConvertTests.ConvertConstants.DECIMAL_MAX_STRING, Bridge.ClientTest.ConvertTests.ConvertConstants.DECIMAL_MIN_STRING, "1.234567890123456789012345678", "1234.56", "-1234.56", "-12.2364", "-12.2364659234065", "-1.7753e-83", "1.2345e+235", "120", "-Infinity", "Infinity", "NaN", "-12.2364", "0", "120", "-Infinity", "Infinity", "NaN", (-128).toString(), "0", (127).toString(), (-32768).toString(), "0", (32767).toString(), (-2147483648).toString(), "0", (2147483647).toString(), System.Int64.MinValue.toString(), "0", System.Int64.MaxValue.toString(), (0).toString(), "100", (255).toString(), (0).toString(), "100", (65535).toString(), (0).toString(), "100", (4294967295).toString(), System.UInt64.MinValue.toString(), "100", System.UInt64.MaxValue.toString()];
 
                 for (var i = 0; i < testValues.length; i = (i + 1) | 0) {
-                    Bridge.Test.Assert.areEqual$1(expectedValues[i].toLowerCase(), System.Convert.toString(testValues[i], System.Globalization.NumberFormatInfo.invariantInfo).toLowerCase(), "Index in testValues " + i);
+                    Bridge.Test.Assert.areEqual$1(expectedValues[i].toLowerCase(), System.Convert.toString(Bridge.unbox(testValues[i]), System.Globalization.NumberFormatInfo.invariantInfo).toLowerCase(), "Index in testValues " + Bridge.box(i, System.Int32));
                 }
             },
             fromObject: function () {
@@ -10893,9 +10893,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         toString$1: function (provider) {
             if (provider != null) {
-                return System.String.format("{0}: {1}", provider, this._value);
+                return System.String.format("{0}: {1}", provider, Bridge.box(this._value, System.Int32));
             } else {
-                return System.String.format("Foo: {0}", this._value);
+                return System.String.format("Foo: {0}", Bridge.box(this._value, System.Int32));
             }
         }
     });
@@ -10914,9 +10914,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         format: function (format, formatProvider) {
             if (formatProvider != null) {
-                return System.String.format("{0}: {1}", Bridge.Reflection.getTypeFullName(Bridge.getType(formatProvider)), this._value);
+                return System.String.format("{0}: {1}", Bridge.Reflection.getTypeFullName(Bridge.getType(formatProvider)), Bridge.box(this._value, System.Int32));
             } else {
-                return System.String.format("FooFormattable: {0}", (this._value));
+                return System.String.format("FooFormattable: {0}", Bridge.box((this._value), System.Int32));
             }
         },
         format$1: function (format, formatProvider) {
@@ -11071,13 +11071,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var customers1 = null;
                 var customers2 = [new Bridge.ClientTest.CSharp6.TestConditionAccess.Customer(null), new Bridge.ClientTest.CSharp6.TestConditionAccess.Customer(["1", "2"]), null];
 
-                Bridge.Test.Assert.null(customers1 != null && ($t = customers1[0].method1(customers1 != null ? System.Linq.Enumerable.from(customers1[0].getOrders()).count() : null)) != null ? $t.length : null);
-                Bridge.Test.Assert.null(($t1 = customers2[2]) != null && ($t2 = $t1.method1(customers2 != null ? System.Linq.Enumerable.from(customers2[0].getOrders()).count() : null)) != null ? $t2.length : null);
-                Bridge.Test.Assert.areEqual(1, customers2 != null && ($t3 = customers2[1].method1(customers2 != null ? System.Linq.Enumerable.from(customers2[1].getOrders()).count() : null)) != null ? $t3.length : null);
+                Bridge.Test.Assert.null(customers1 != null && ($t = customers1[0].method1(Bridge.box(customers1 != null ? System.Linq.Enumerable.from(customers1[0].getOrders()).count() : null, System.Int32, $box_.System.Nullable$1.toString))) != null ? $t.length : null);
+                Bridge.Test.Assert.null(($t1 = customers2[2]) != null && ($t2 = $t1.method1(Bridge.box(customers2 != null ? System.Linq.Enumerable.from(customers2[0].getOrders()).count() : null, System.Int32, $box_.System.Nullable$1.toString))) != null ? $t2.length : null);
+                Bridge.Test.Assert.areEqual(1, customers2 != null && ($t3 = customers2[1].method1(Bridge.box(customers2 != null ? System.Linq.Enumerable.from(customers2[1].getOrders()).count() : null, System.Int32, $box_.System.Nullable$1.toString))) != null ? $t3.length : null);
 
-                Bridge.Test.Assert.null(($t4 = Bridge.ClientTest.CSharp6.TestConditionAccess.getCustomers(customers1)) != null && ($t5 = $t4[0].method1(customers1 != null ? System.Linq.Enumerable.from(customers1[0].getOrders()).count() : null)) != null ? $t5.length : null);
-                Bridge.Test.Assert.null(($t6 = Bridge.ClientTest.CSharp6.TestConditionAccess.getCustomers(customers2)[2]) != null && ($t7 = $t6.method1(customers2 != null ? System.Linq.Enumerable.from(customers2[0].getOrders()).count() : null)) != null ? $t7.length : null);
-                Bridge.Test.Assert.areEqual(1, ($t8 = Bridge.ClientTest.CSharp6.TestConditionAccess.getCustomers(customers2)) != null && ($t9 = $t8[1].method1(($t10 = Bridge.ClientTest.CSharp6.TestConditionAccess.getCustomers(customers2)) != null ? System.Linq.Enumerable.from($t10[1].getOrders()).count() : null)) != null ? $t9.length : null);
+                Bridge.Test.Assert.null(($t4 = Bridge.ClientTest.CSharp6.TestConditionAccess.getCustomers(customers1)) != null && ($t5 = $t4[0].method1(Bridge.box(customers1 != null ? System.Linq.Enumerable.from(customers1[0].getOrders()).count() : null, System.Int32, $box_.System.Nullable$1.toString))) != null ? $t5.length : null);
+                Bridge.Test.Assert.null(($t6 = Bridge.ClientTest.CSharp6.TestConditionAccess.getCustomers(customers2)[2]) != null && ($t7 = $t6.method1(Bridge.box(customers2 != null ? System.Linq.Enumerable.from(customers2[0].getOrders()).count() : null, System.Int32, $box_.System.Nullable$1.toString))) != null ? $t7.length : null);
+                Bridge.Test.Assert.areEqual(1, ($t8 = Bridge.ClientTest.CSharp6.TestConditionAccess.getCustomers(customers2)) != null && ($t9 = $t8[1].method1(Bridge.box(($t10 = Bridge.ClientTest.CSharp6.TestConditionAccess.getCustomers(customers2)) != null ? System.Linq.Enumerable.from($t10[1].getOrders()).count() : null, System.Int32, $box_.System.Nullable$1.toString))) != null ? $t9.length : null);
 
                 Bridge.Test.Assert.null(customers1 != null && ($t11 = customers1[0].getOrders()) != null && ($t12 = $t11.concat.apply($t11, null)) != null ? $t12.length : null);
                 Bridge.Test.Assert.null(($t13 = customers2[2]) != null && ($t14 = $t13.getOrders()) != null && ($t15 = $t14.concat.apply($t14, null)) != null ? $t15.length : null);
@@ -11415,25 +11415,25 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 var $t;
                 var p = new Bridge.ClientTest.CSharp6.TestInterpolatedStrings.Person();
 
-                Bridge.Test.Assert.areEqual("Jane is 10 year{s} old", System.String.format("{0} is {1} year{{s}} old", p.getName(), p.getAge()));
-                Bridge.Test.Assert.areEqual("                Jane is 010 year{s} old", System.String.format("{0,20} is {1:D3} year{{s}} old", p.getName(), p.getAge()));
+                Bridge.Test.Assert.areEqual("Jane is 10 year{s} old", System.String.format("{0} is {1} year{{s}} old", p.getName(), Bridge.box(p.getAge(), System.Int32)));
+                Bridge.Test.Assert.areEqual("                Jane is 010 year{s} old", System.String.format("{0,20} is {1:D3} year{{s}} old", p.getName(), Bridge.box(p.getAge(), System.Int32)));
 
-                Bridge.Test.Assert.areEqual("Jane is 10 years old", System.String.format("{0} is {1} year{2} old", p.getName(), p.getAge(), (p.getAge() === 1 ? "" : "s")));
+                Bridge.Test.Assert.areEqual("Jane is 10 years old", System.String.format("{0} is {1} year{2} old", p.getName(), Bridge.box(p.getAge(), System.Int32), (p.getAge() === 1 ? "" : "s")));
                 p.setAge(1);
-                Bridge.Test.Assert.areEqual("Jane is 1 year old", System.String.format("{0} is {1} year{2} old", p.getName(), p.getAge(), (p.getAge() === 1 ? "" : "s")));
+                Bridge.Test.Assert.areEqual("Jane is 1 year old", System.String.format("{0} is {1} year{2} old", p.getName(), Bridge.box(p.getAge(), System.Int32), (p.getAge() === 1 ? "" : "s")));
 
                 var i = 0, j = 1, k = 2;
-                Bridge.Test.Assert.areEqual("i = 0, j = 1", System.String.format("i = {0}, j = {1}", i, j));
-                Bridge.Test.Assert.areEqual("{0, 1}", System.String.format("{{{0}, {1}}}", i, j));
-                Bridge.Test.Assert.areEqual("i = 00, j = 1, k =            2", System.String.format("i = {0:00}, j = {1:##}, k = {2,12:#0}", i, j, k));
-                Bridge.Test.Assert.areEqual("0, 0, 0", System.String.format("{0}, {1}, {2}", Bridge.ClientTest.CSharp6.TestInterpolatedStrings.F1(), ($t = Bridge.ClientTest.CSharp6.TestInterpolatedStrings.F2(), Bridge.ClientTest.CSharp6.TestInterpolatedStrings.setP($t), $t), Bridge.ClientTest.CSharp6.TestInterpolatedStrings.F3()));
+                Bridge.Test.Assert.areEqual("i = 0, j = 1", System.String.format("i = {0}, j = {1}", Bridge.box(i, System.Int32), Bridge.box(j, System.Int32)));
+                Bridge.Test.Assert.areEqual("{0, 1}", System.String.format("{{{0}, {1}}}", Bridge.box(i, System.Int32), Bridge.box(j, System.Int32)));
+                Bridge.Test.Assert.areEqual("i = 00, j = 1, k =            2", System.String.format("i = {0:00}, j = {1:##}, k = {2,12:#0}", Bridge.box(i, System.Int32), Bridge.box(j, System.Int32), Bridge.box(k, System.Int32)));
+                Bridge.Test.Assert.areEqual("0, 0, 0", System.String.format("{0}, {1}, {2}", Bridge.box(Bridge.ClientTest.CSharp6.TestInterpolatedStrings.F1(), System.Int32), ($t = Bridge.ClientTest.CSharp6.TestInterpolatedStrings.F2(), Bridge.ClientTest.CSharp6.TestInterpolatedStrings.setP($t), $t), Bridge.box(Bridge.ClientTest.CSharp6.TestInterpolatedStrings.F3(), System.Int32)));
 
-                var f1 = System.Runtime.CompilerServices.FormattableStringFactory.create("i = {0}, j = {1}", [i, j]);
-                var f2 = System.Runtime.CompilerServices.FormattableStringFactory.create("i = {0}, j = {1}", [i, j]);
+                var f1 = System.Runtime.CompilerServices.FormattableStringFactory.create("i = {0}, j = {1}", [Bridge.box(i, System.Int32), Bridge.box(j, System.Int32)]);
+                var f2 = System.Runtime.CompilerServices.FormattableStringFactory.create("i = {0}, j = {1}", [Bridge.box(i, System.Int32), Bridge.box(j, System.Int32)]);
                 Bridge.Test.Assert.areEqual(2, f2.getArgumentCount());
                 Bridge.Test.Assert.areEqual("i = {0}, j = {1}", f2.getFormat());
-                Bridge.Test.Assert.areEqual(0, f2.getArgument(0));
-                Bridge.Test.Assert.areEqual(1, f2.getArgument(1));
+                Bridge.Test.Assert.areEqual(0, Bridge.unbox(f2.getArgument(0)));
+                Bridge.Test.Assert.areEqual(1, Bridge.unbox(f2.getArgument(1)));
                 Bridge.Test.Assert.areEqual(2, f2.getArguments().length);
                 Bridge.Test.Assert.areEqual("i = 0, j = 1", f2.toString());
             }
@@ -11518,9 +11518,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         getFormatWorks: function () {
             var culture = System.Globalization.CultureInfo.invariantCulture;
-            Bridge.Test.Assert.areEqual(null, culture.getFormat(System.Int32));
-            Bridge.Test.Assert.areEqual(culture.numberFormat, culture.getFormat(System.Globalization.NumberFormatInfo));
-            Bridge.Test.Assert.areEqual(culture.dateTimeFormat, culture.getFormat(System.Globalization.DateTimeFormatInfo));
+            Bridge.Test.Assert.areEqual(null, Bridge.unbox(culture.getFormat(System.Int32)));
+            Bridge.Test.Assert.areEqual(culture.numberFormat, Bridge.unbox(culture.getFormat(System.Globalization.NumberFormatInfo)));
+            Bridge.Test.Assert.areEqual(culture.dateTimeFormat, Bridge.unbox(culture.getFormat(System.Globalization.DateTimeFormatInfo)));
         },
         invariantWorks: function () {
             var culture = System.Globalization.CultureInfo.invariantCulture;
@@ -11547,11 +11547,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 init: function () {
                     this.maxValue = System.Decimal.MaxValue;
                     this.minValue = System.Decimal.MinValue;
-                    this.inputAdd = System.Array.create(null, [[Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(47.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(-47.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(-47.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(47.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.33478923476"), System.Decimal(47.0), System.Decimal("443534569034923.33478923476")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.12345678901235"), System.Decimal(47.000000000001), System.Decimal("443534569034923.12345678901335")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.12345678901235"), System.Decimal("9436905724146.297872340425532"), System.Decimal("452971474759022.42132912943788")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("4435345690348766678656790453"), System.Decimal(17.0), System.Decimal("4435345690348766678656790470")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(17.2345324), System.Decimal("4435345690348766678656790453"), System.Decimal("4435345690348766678656790470.2")], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, "0.00000000000005", System.Decimal("-943456769034871.4234"), System.Decimal("47.00000000003455"), System.Decimal("-943456769034824.4233999999654")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("6999545690348766678656790453"), System.Decimal(-13.0), System.Decimal("6999545690348766678656790440")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(11.0), System.Decimal("-6435345690348766678656790453"), System.Decimal("-6435345690348766678656790442")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal.MinusOne, Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal("79228162514264337593543950334")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal.MinusOne, System.Decimal("79228162514264337593543950334")]], 15, 5);
-                    this.inputSubtract = System.Array.create(null, [[Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(-47.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(47.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(47.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(-47.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.33478923476"), System.Decimal(47.0), System.Decimal("443534569034829.33478923476")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.12345678901235"), System.Decimal(47.000000000001), System.Decimal("443534569034829.12345678901135")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.12345678901235"), System.Decimal("9436905724146.297872340425532"), System.Decimal("434097663310729.82558444858682")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("4435345690348766678656790453"), System.Decimal(17.0), System.Decimal("4435345690348766678656790436")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(17.2345324), System.Decimal("4435345690348766678656790453"), System.Decimal("-4435345690348766678656790435.8")], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, System.Decimal("-5E-14"), System.Decimal("-943456769034871.4234"), System.Decimal("47.00000000003455"), System.Decimal("-943456769034918.4234000000346")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("6999545690348766678656790453"), System.Decimal(-13.0), System.Decimal("6999545690348766678656790466")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(11.0), System.Decimal("-6435345690348766678656790453"), System.Decimal("6435345690348766678656790464")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal.MinusOne, Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal("79228162514264337593543950334")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal.One, System.Decimal("79228162514264337593543950334")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal.MinusOne, System.Decimal("-79228162514264337593543950334")]], 16, 5);
-                    this.inputMultiply = System.Array.create(null, [[Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(0.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.33478923476"), System.Decimal(0.47), System.Decimal("208461247446391.8773509403372")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("43534569034876.12345678901235"), System.Decimal(47.000000000001), System.Decimal("2046124744639221.3370381184566")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("44.353456903487612345678901235"), System.Decimal("9436905724146.297872340425532"), System.Decimal("418559391338198.38088395328596")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("4435345690348766678656790453"), System.Decimal(0.17), System.Decimal("754008767359290335371654377.01")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(17.2345324), System.Decimal("443534569034876667865679045.37"), System.Decimal("7644110900551618662335084355.4")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("-943456769034871.4234"), System.Decimal("0.4700000000003455"), System.Decimal("-443424681446715.53331170154808")], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, System.Decimal(-0.01), System.Decimal("6999545690348766678656790453"), System.Decimal(-0.13), System.Decimal("-909940939745339668225382758.9")], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, System.Decimal(0.0001), System.Decimal(0.11), System.Decimal("-64353456903487666786567904.535"), System.Decimal("-7078880259383643346522469.4988")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal.MinusOne, Bridge.ClientTest.DecimalMathTests.minValue], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal.MinusOne, Bridge.ClientTest.DecimalMathTests.minValue, Bridge.ClientTest.DecimalMathTests.maxValue], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal.One, Bridge.ClientTest.DecimalMathTests.maxValue], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal.MinusOne, Bridge.ClientTest.DecimalMathTests.maxValue]], 17, 5);
-                    this.inputDivide = System.Array.create(null, [[Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal.One, System.Decimal(2.0), System.Decimal(0.5)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(3.0), System.Decimal(4.0), System.Decimal(0.75)], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, "-0.00000000000000000000000000003", System.Decimal(5.0), System.Decimal(6.0), System.Decimal("0.8333333333333333333333333333")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(7.0), System.Decimal(8.0), System.Decimal(0.875)], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, "-0.0000000000000005", System.Decimal("443534569034876.33478923476"), System.Decimal(47.0), System.Decimal("9436905724146.304995515633191")], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, "0.0000000000000002", System.Decimal("443534569034876.12345678901235"), System.Decimal(47.000000000001), System.Decimal("9436905724146.099713852443963")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.12345678901235"), System.Decimal("9436905724146.297872340425532"), System.Decimal("47.000000000000013082337857467")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("4435345690348766678656790453"), System.Decimal(17.0), System.Decimal("260902687667574510509222967.82")], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, "0.0000000000000000000000000000142752779107986686908967873", System.Decimal(17.2345324), System.Decimal("4435345690348766678656790453"), System.Decimal("3.9000000000000004E-27")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("-943456769034871.4234"), System.Decimal("47.00000000003455"), System.Decimal("-20073548277322.933666106776439")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("6999545690348766678656790453"), System.Decimal(-13.0), System.Decimal("-538426591565289744512060804.08")], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, "0.0000000000000000000000000000093098847039324132480985641", System.Decimal(11.0), System.Decimal("-6435345690348766678656790453"), System.Decimal("-1.7000000000000002E-27")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal.MinusOne], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, "-0.000000000000000000000000000012621774483536188886587657045", System.Decimal.MinusOne, Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal.MinusOne, Bridge.ClientTest.DecimalMathTests.minValue], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal.MinusOne, Bridge.ClientTest.DecimalMathTests.maxValue]], 20, 5);
-                    this.inputRemainder = System.Array.create(null, [[Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(-47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(47.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.33478923476"), System.Decimal(47.0), System.Decimal(14.33478923476)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.12345678901235"), System.Decimal(47.000000000001), System.Decimal(4.68655106486635)], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, System.Decimal("4E-15"), System.Decimal("443534569034876.12345678901235"), System.Decimal("9436905724146.297872340425532"), System.Decimal(0.12345678901235)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("4435345690348766678656790453"), System.Decimal(17.0), System.Decimal(14.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(17.2345324), System.Decimal("4435345690348766678656790453"), System.Decimal(17.2345324)], [Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, System.Decimal("1E-13"), System.Decimal("-943456769034871.4234"), System.Decimal("47.00000000003455"), System.Decimal(-43.8823070185248)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("6999545690348766678656790453"), System.Decimal(-13.0), System.Decimal.One], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(11.0), System.Decimal("-6435345690348766678656790453"), System.Decimal(11.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal.MinusOne, Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal.MinusOne], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal.One, System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal.MinusOne, System.Decimal(0.0)]], 16, 5);
+                    this.inputAdd = System.Array.create(null, [[Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.33478923476"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("443534569034923.33478923476"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.000000000001), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("443534569034923.12345678901335"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("9436905724146.297872340425532"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("452971474759022.42132912943788"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(17.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("4435345690348766678656790470"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(17.2345324), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("4435345690348766678656790470.2"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), "0.00000000000005", Bridge.box(System.Decimal("-943456769034871.4234"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("47.00000000003455"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-943456769034824.4233999999654"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("6999545690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-13.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("6999545690348766678656790440"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(11.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-6435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-6435345690348766678656790442"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("79228162514264337593543950334"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("79228162514264337593543950334"), System.Decimal, $box_.System.Decimal.toString)]], 15, 5);
+                    this.inputSubtract = System.Array.create(null, [[Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.33478923476"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("443534569034829.33478923476"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.000000000001), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("443534569034829.12345678901135"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("9436905724146.297872340425532"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("434097663310729.82558444858682"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(17.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("4435345690348766678656790436"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(17.2345324), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-4435345690348766678656790435.8"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), Bridge.box(System.Decimal("-5E-14"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-943456769034871.4234"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("47.00000000003455"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-943456769034918.4234000000346"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("6999545690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-13.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("6999545690348766678656790466"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(11.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-6435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("6435345690348766678656790464"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("79228162514264337593543950334"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.One, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("79228162514264337593543950334"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-79228162514264337593543950334"), System.Decimal, $box_.System.Decimal.toString)]], 16, 5);
+                    this.inputMultiply = System.Array.create(null, [[Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.33478923476"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.47), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("208461247446391.8773509403372"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("43534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.000000000001), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("2046124744639221.3370381184566"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("44.353456903487612345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("9436905724146.297872340425532"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("418559391338198.38088395328596"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.17), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("754008767359290335371654377.01"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(17.2345324), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("443534569034876667865679045.37"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("7644110900551618662335084355.4"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("-943456769034871.4234"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("0.4700000000003455"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-443424681446715.53331170154808"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), Bridge.box(System.Decimal(-0.01), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("6999545690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-0.13), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-909940939745339668225382758.9"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), Bridge.box(System.Decimal(0.0001), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.11), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-64353456903487666786567904.535"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-7078880259383643346522469.4988"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.One, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString)]], 17, 5);
+                    this.inputDivide = System.Array.create(null, [[Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal.One, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(2.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.5), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(3.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(4.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.75), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), "-0.00000000000000000000000000003", Bridge.box(System.Decimal(5.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(6.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("0.8333333333333333333333333333"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(7.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(8.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.875), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), "-0.0000000000000005", Bridge.box(System.Decimal("443534569034876.33478923476"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("9436905724146.304995515633191"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), "0.0000000000000002", Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.000000000001), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("9436905724146.099713852443963"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("9436905724146.297872340425532"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("47.000000000000013082337857467"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(17.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("260902687667574510509222967.82"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), "0.0000000000000000000000000000142752779107986686908967873", Bridge.box(System.Decimal(17.2345324), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("3.9000000000000004E-27"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("-943456769034871.4234"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("47.00000000003455"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-20073548277322.933666106776439"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("6999545690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-13.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-538426591565289744512060804.08"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), "0.0000000000000000000000000000093098847039324132480985641", Bridge.box(System.Decimal(11.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-6435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-1.7000000000000002E-27"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), "-0.000000000000000000000000000012621774483536188886587657045", Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString)]], 20, 5);
+                    this.inputRemainder = System.Array.create(null, [[Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.33478923476"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(14.33478923476), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(47.000000000001), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(4.68655106486635), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), Bridge.box(System.Decimal("4E-15"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("9436905724146.297872340425532"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.12345678901235), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(17.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(14.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(17.2345324), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(17.2345324), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.HasDotNetDiff, Boolean, $box_.Boolean.toString), Bridge.box(System.Decimal("1E-13"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-943456769034871.4234"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("47.00000000003455"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-43.8823070185248), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("6999545690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-13.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.One, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(11.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("-6435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(11.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.One, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)]], 16, 5);
                 }
             },
             testSubtractOperator: function () {
@@ -11585,12 +11585,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.ClientTest.DecimalMathTests.runOperationSet$1(Bridge.ClientTest.DecimalMathTests.inputSubtract, "SubtractMethod", $_.Bridge.ClientTest.DecimalMathTests.f1);
             },
             testCeilingMethod: function () {
-                var input = System.Array.create(null, [[Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("-443534569034876.12345678901235"), System.Decimal(-443534569034876.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("-443534569034876.82345678901235"), System.Decimal(-443534569034876.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.12345678901235"), System.Decimal(443534569034877.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.62345678901235"), System.Decimal(443534569034877.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.49999999999999"), System.Decimal(443534569034877.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.50000000000001"), System.Decimal(443534569034877.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.99999999999999"), System.Decimal(443534569034877.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("4435345690348766678656790453"), System.Decimal("4435345690348766678656790453")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(17.9345324), System.Decimal(18.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("-0.9434567690348714234"), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("6999545690348766678656790453"), System.Decimal("6999545690348766678656790453")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, Bridge.ClientTest.DecimalMathTests.maxValue], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal.MinusOne, System.Decimal.MinusOne], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.minValue, Bridge.ClientTest.DecimalMathTests.minValue]], 15, 4);
+                var input = System.Array.create(null, [[Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("-443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-443534569034876.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("-443534569034876.82345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-443534569034876.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034877.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.62345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034877.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.49999999999999"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034877.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.50000000000001"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034877.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.99999999999999"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034877.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(17.9345324), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(18.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("-0.9434567690348714234"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("6999545690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("6999545690348766678656790453"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString)]], 15, 4);
 
                 Bridge.ClientTest.DecimalMathTests.runOperationSet(input, "CeilingMethod", $_.Bridge.ClientTest.DecimalMathTests.f6);
             },
             testFloorMethod: function () {
-                var input = System.Array.create(null, [[Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(0.0), System.Decimal(0.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("-443534569034876.12345678901235"), System.Decimal(-443534569034877.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("-443534569034876.82345678901235"), System.Decimal(-443534569034877.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.12345678901235"), System.Decimal(443534569034876.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.62345678901235"), System.Decimal(443534569034876.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.49999999999999"), System.Decimal(443534569034876.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.50000000000001"), System.Decimal(443534569034876.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("443534569034876.99999999999999"), System.Decimal(443534569034876.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("4435345690348766678656790453"), System.Decimal("4435345690348766678656790453")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal(17.9345324), System.Decimal(17.0)], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("-0.9434567690348714234"), System.Decimal.MinusOne], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal("6999545690348766678656790453"), System.Decimal("6999545690348766678656790453")], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.maxValue, Bridge.ClientTest.DecimalMathTests.maxValue], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, System.Decimal.MinusOne, System.Decimal.MinusOne], [Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, null, Bridge.ClientTest.DecimalMathTests.minValue, Bridge.ClientTest.DecimalMathTests.minValue]], 15, 4);
+                var input = System.Array.create(null, [[Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("-443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-443534569034877.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("-443534569034876.82345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-443534569034877.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.12345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034876.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.62345678901235"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034876.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.49999999999999"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034876.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.50000000000001"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034876.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("443534569034876.99999999999999"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(443534569034876.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("4435345690348766678656790453"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal(17.9345324), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(17.0), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("-0.9434567690348714234"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal("6999545690348766678656790453"), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal("6999545690348766678656790453"), System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.maxValue, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString)], [Bridge.box(Bridge.ClientTest.DecimalMathTests.NoDotNetDiff, Boolean, $box_.Boolean.toString), null, Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.DecimalMathTests.minValue, System.Decimal, $box_.System.Decimal.toString)]], 15, 4);
 
                 Bridge.ClientTest.DecimalMathTests.runOperationSet(input, "FloorMethod", $_.Bridge.ClientTest.DecimalMathTests.f7);
             },
@@ -11605,14 +11605,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                     var a = input.get([i, ((lowerBound + 2) | 0)]);
                     var b = input.get([i, ((lowerBound + 3) | 0)]);
                     var expected = input.get([i, ((lowerBound + 4) | 0)]);
-                    var result = Bridge.ClientTest.DecimalMathTests.runOperation(System.Nullable.getValue(Bridge.cast(a, System.Decimal)), System.Nullable.getValue(Bridge.cast(b, System.Decimal)), operation);
+                    var result = Bridge.ClientTest.DecimalMathTests.runOperation(System.Nullable.getValue(Bridge.cast(Bridge.unbox(a), System.Decimal)), System.Nullable.getValue(Bridge.cast(Bridge.unbox(b), System.Decimal)), operation);
 
-                    logger.onLog([dotNetDiff, a, b, result]);
+                    logger.onLog([Bridge.box(dotNetDiff, System.Decimal, $box_.System.Nullable$1.toString), a, b, result]);
 
                     var diff = Bridge.ClientTest.DecimalMathTests.getDifference(expected, result);
                     var diffReport = Bridge.ClientTest.DecimalMathTests.getDifferenceReport(diff);
 
-                    Bridge.ClientTest.DecimalMathTests.assertDecimal(dotNetDiff, expected, result, diffReport, System.String.format("{0} for row {1} with operand {2} and {3} .NetDiff {4}{5}", name, i, a, b, dotNetDiff, diffReport));
+                    Bridge.ClientTest.DecimalMathTests.assertDecimal(dotNetDiff, expected, result, diffReport, System.String.format("{0} for row {1} with operand {2} and {3} .NetDiff {4}{5}", name, Bridge.box(i, System.Int32), a, b, Bridge.box(dotNetDiff, System.Decimal, $box_.System.Nullable$1.toString), diffReport));
                 }
 
                 logger.onLogEnd();
@@ -11626,14 +11626,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                     var dotNetDiff = Bridge.ClientTest.DecimalMathTests.parseDotNetDiff(input, i, lowerBound);
                     var a = input.get([i, ((lowerBound + 2) | 0)]);
                     var expected = input.get([i, ((lowerBound + 3) | 0)]);
-                    var result = Bridge.ClientTest.DecimalMathTests.runOperation$1(System.Nullable.getValue(Bridge.cast(a, System.Decimal)), operation);
+                    var result = Bridge.ClientTest.DecimalMathTests.runOperation$1(System.Nullable.getValue(Bridge.cast(Bridge.unbox(a), System.Decimal)), operation);
 
-                    logger.onLog([dotNetDiff, a, result]);
+                    logger.onLog([Bridge.box(dotNetDiff, System.Decimal, $box_.System.Nullable$1.toString), a, result]);
 
                     var diff = Bridge.ClientTest.DecimalMathTests.getDifference(expected, result);
                     var diffReport = Bridge.ClientTest.DecimalMathTests.getDifferenceReport(diff);
 
-                    Bridge.ClientTest.DecimalMathTests.assertDecimal(dotNetDiff, expected, result, diffReport, System.String.format("{0} for row {1} with operand {2} .NetDiff {3}{4}", name, i, a, dotNetDiff, diffReport));
+                    Bridge.ClientTest.DecimalMathTests.assertDecimal(dotNetDiff, expected, result, diffReport, System.String.format("{0} for row {1} with operand {2} .NetDiff {3}{4}", name, Bridge.box(i, System.Int32), a, Bridge.box(dotNetDiff, System.Decimal, $box_.System.Nullable$1.toString), diffReport));
                 }
 
                 logger.onLogEnd();
@@ -11648,12 +11648,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                     return System.Decimal(o.toString());
                 }
 
-                var dotNetDiff = Bridge.cast(input.get([i, ((lowerBound + 1) | 0)]), System.Decimal, true);
+                var dotNetDiff = Bridge.cast(Bridge.unbox(input.get([i, ((lowerBound + 1) | 0)])), System.Decimal, true);
                 return dotNetDiff;
             },
             assertDecimal: function (dotNetDiff, expected, result, differenceReport, message) {
                 if (Bridge.ClientTest.DecimalMathTests.jSMode) {
-                    Bridge.ClientTest.DecimalMathTests.assertIsDecimalAndEqualTo(result, System.Nullable.getValue(Bridge.cast(expected, System.Decimal)).sub((System.Nullable.hasValue(dotNetDiff) ? System.Nullable.getValue(dotNetDiff) : System.Decimal(0.0))), message);
+                    Bridge.ClientTest.DecimalMathTests.assertIsDecimalAndEqualTo(result, Bridge.box(System.Nullable.getValue(Bridge.cast(Bridge.unbox(expected), System.Decimal)).sub((System.Nullable.hasValue(dotNetDiff) ? System.Nullable.getValue(dotNetDiff) : System.Decimal(0.0))), System.Decimal, $box_.System.Decimal.toString), message);
                 } else {
                     Bridge.ClientTest.DecimalMathTests.assertIsDecimalAndEqualTo(result, expected, message);
                 }
@@ -11669,7 +11669,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             getDifference: function (expected, result) {
                 var difference;
                 if ((Bridge.is(result, System.Decimal) || Bridge.is(result, System.Int32)) && (Bridge.is(expected, System.Decimal) || Bridge.is(expected, System.Int32))) {
-                    difference = System.Nullable.getValue(Bridge.cast(expected, System.Decimal)).sub(System.Nullable.getValue(Bridge.cast(result, System.Decimal)));
+                    difference = System.Nullable.getValue(Bridge.cast(Bridge.unbox(expected), System.Decimal)).sub(System.Nullable.getValue(Bridge.cast(Bridge.unbox(result), System.Decimal)));
                 } else {
                     difference = System.Decimal(0.0);
                 }
@@ -11689,25 +11689,25 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.apply($_.Bridge.ClientTest.DecimalMathTests, {
         f1: function (a, b) {
-            return a.sub(b);
+            return Bridge.box(a.sub(b), System.Decimal, $box_.System.Decimal.toString);
         },
         f2: function (a, b) {
-            return a.mod(b);
+            return Bridge.box(a.mod(b), System.Decimal, $box_.System.Decimal.toString);
         },
         f3: function (a, b) {
-            return a.mul(b);
+            return Bridge.box(a.mul(b), System.Decimal, $box_.System.Decimal.toString);
         },
         f4: function (a, b) {
-            return a.div(b);
+            return Bridge.box(a.div(b), System.Decimal, $box_.System.Decimal.toString);
         },
         f5: function (a, b) {
-            return a.add(b);
+            return Bridge.box(a.add(b), System.Decimal, $box_.System.Decimal.toString);
         },
         f6: function (a) {
-            return a.ceil();
+            return Bridge.box(a.ceil(), System.Decimal, $box_.System.Decimal.toString);
         },
         f7: function (a) {
-            return a.floor();
+            return Bridge.box(a.floor(), System.Decimal, $box_.System.Decimal.toString);
         }
     });
 
@@ -11719,7 +11719,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
                 for (var i = 0; i < parameters.length; i = (i + 1) | 0) {
                     if (i === 0) {
-                        var d = Bridge.cast(parameters[0], System.Decimal, true);
+                        var d = Bridge.cast(Bridge.unbox(parameters[0]), System.Decimal, true);
                         result[0] = System.Nullable.hasValue(d) ? "HasDotNetDiff" : "NoDotNetDiff";
                         result[1] = System.Nullable.hasValue(d) ? System.String.concat(System.Nullable.toString(d, function ($t) { return Bridge.Int.format($t, 'G'); }), "m") : "null";
 
@@ -11729,7 +11729,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                     var o = parameters[i];
                     var j = (i + 1) | 0;
                     if (Bridge.is(o, System.Decimal)) {
-                        var d1 = System.Nullable.getValue(Bridge.cast(o, System.Decimal));
+                        var d1 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(o), System.Decimal));
                         if (d1.equalsT(Bridge.ClientTest.DecimalMathTests.maxValue)) {
                             result[j] = "DecimalMathTests.MaxValue";
                         } else {
@@ -11797,10 +11797,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             //this.Text.AppendFormat(format, ConvertParameters(parameters));
             var convertedParams = Bridge.ClientTest.DecimalMathTests.Logger.convertParameters(parameters);
             if (convertedParams.length === 4) {
-                this.getText().appendFormat(format, convertedParams[0], convertedParams[1], convertedParams[2], convertedParams[3]);
+                this.getText().appendFormat(format, Bridge.unbox(convertedParams[0]), Bridge.unbox(convertedParams[1]), Bridge.unbox(convertedParams[2]), Bridge.unbox(convertedParams[3]));
             }
             if (convertedParams.length === 5) {
-                this.getText().appendFormat(format, convertedParams[0], convertedParams[1], convertedParams[2], convertedParams[3], convertedParams[4]);
+                this.getText().appendFormat(format, Bridge.unbox(convertedParams[0]), Bridge.unbox(convertedParams[1]), Bridge.unbox(convertedParams[2]), Bridge.unbox(convertedParams[3]), Bridge.unbox(convertedParams[4]));
             }
         },
         onLogEnd: function () {
@@ -12060,17 +12060,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             watch.stop();
 
             Bridge.Test.Assert.true$1(hasIncreased, "Times should increase inside the loop");
-            Bridge.Test.Assert.true$1(watch.milliseconds().gt(System.Int64(150)), "ElapsedMilliseconds > 150 Actual: " + watch.milliseconds());
+            Bridge.Test.Assert.true$1(watch.milliseconds().gt(System.Int64(150)), "ElapsedMilliseconds > 150 Actual: " + Bridge.box(watch.milliseconds(), System.Int64));
             Bridge.Test.Assert.true$1(System.TimeSpan.eq(watch.timeSpan(), new System.TimeSpan(0, 0, 0, 0, System.Int64.clip32(watch.milliseconds()))), "Elapsed");
 
             var value = watch.ticks() / System.Int64.toNumber(System.Diagnostics.Stopwatch.frequency);
 
-            Bridge.Test.Assert.true$1(value > 0.15 && value < 0.25, System.String.format("value > 0.15 && value < 0.25 Actual: {0}, Ticks: {1}", value, watch.ticks()));
+            Bridge.Test.Assert.true$1(value > 0.15 && value < 0.25, System.String.format("value > 0.15 && value < 0.25 Actual: {0}, Ticks: {1}", Bridge.box(value, System.Double, $box_.System.Double.toString), Bridge.box(watch.ticks(), System.Int64)));
         },
         getTimestampWorks: function () {
             var t1 = System.Diagnostics.Stopwatch.getTimestamp();
 
-            Bridge.Test.Assert.true$1(Bridge.is(t1, System.Int64), "is long");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(t1, System.Int64), System.Int64), "is long");
 
             var before = new Date();
 
@@ -12393,7 +12393,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(Bridge.is(ex, System.ArgumentOutOfRangeException), "is ArgumentOutOfRangeException");
             Bridge.Test.Assert.areEqual$1(null, ex.getParamName(), "ParamName");
             Bridge.Test.Assert.areEqual$1(null, ex.getInnerException(), "InnerException");
-            Bridge.Test.Assert.areEqual$1(null, ex.getActualValue(), "ActualValue");
+            Bridge.Test.Assert.areEqual$1(null, Bridge.unbox(ex.getActualValue()), "ActualValue");
             Bridge.Test.Assert.areEqual("Value is out of range.", ex.getMessage());
         },
         constructorWithParamNameWorks: function () {
@@ -12401,7 +12401,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(Bridge.is(ex, System.ArgumentOutOfRangeException), "is ArgumentOutOfRangeException");
             Bridge.Test.Assert.areEqual$1("someParam", ex.getParamName(), "ParamName");
             Bridge.Test.Assert.areEqual$1(null, ex.getInnerException(), "InnerException");
-            Bridge.Test.Assert.areEqual$1(null, ex.getActualValue(), "ActualValue");
+            Bridge.Test.Assert.areEqual$1(null, Bridge.unbox(ex.getActualValue()), "ActualValue");
             Bridge.Test.Assert.areEqual("Value is out of range.\nParameter name: someParam", ex.getMessage());
         },
         constructorWithParamNameAndMessageWorks: function () {
@@ -12409,7 +12409,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(Bridge.is(ex, System.ArgumentOutOfRangeException), "is ArgumentOutOfRangeException");
             Bridge.Test.Assert.areEqual$1("someParam", ex.getParamName(), "ParamName");
             Bridge.Test.Assert.areEqual$1(null, ex.getInnerException(), "InnerException");
-            Bridge.Test.Assert.areEqual$1(null, ex.getActualValue(), "ActualValue");
+            Bridge.Test.Assert.areEqual$1(null, Bridge.unbox(ex.getActualValue()), "ActualValue");
             Bridge.Test.Assert.areEqual("The message", ex.getMessage());
         },
         constructorWithMessageAndInnerExceptionWorks: function () {
@@ -12418,15 +12418,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(Bridge.is(ex, System.ArgumentOutOfRangeException), "is ArgumentOutOfRangeException");
             Bridge.Test.Assert.null$1(ex.getParamName(), "ParamName");
             Bridge.Test.Assert.true$1(Bridge.referenceEquals(ex.getInnerException(), inner), "InnerException");
-            Bridge.Test.Assert.areEqual$1(null, ex.getActualValue(), "ActualValue");
+            Bridge.Test.Assert.areEqual$1(null, Bridge.unbox(ex.getActualValue()), "ActualValue");
             Bridge.Test.Assert.areEqual("The message", ex.getMessage());
         },
         constructorWithParamNameAndActualValueAndMessageWorks: function () {
-            var ex = new System.ArgumentOutOfRangeException("someParam", "The message", null, 42);
+            var ex = new System.ArgumentOutOfRangeException("someParam", "The message", null, Bridge.box(42, System.Int32));
             Bridge.Test.Assert.true$1(Bridge.is(ex, System.ArgumentOutOfRangeException), "is ArgumentOutOfRangeException");
             Bridge.Test.Assert.areEqual$1("someParam", ex.getParamName(), "ParamName");
             Bridge.Test.Assert.null$1(ex.getInnerException(), "InnerException");
-            Bridge.Test.Assert.areEqual$1(42, ex.getActualValue(), "ActualValue");
+            Bridge.Test.Assert.areEqual$1(42, Bridge.unbox(ex.getActualValue()), "ActualValue");
             Bridge.Test.Assert.areEqual("The message", ex.getMessage());
         },
         rangeErrorIsConvertedToArgumentOutOfRangeException: function () {
@@ -13119,7 +13119,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(Bridge.is(d, System.Exception), "is Exception");
         },
         argumentsOnlyConstructorWorks: function () {
-            var args = ["a", 1];
+            var args = ["a", Bridge.box(1, System.Int32)];
             var ex = new Bridge.PromiseException(args);
             Bridge.Test.Assert.true$1(Bridge.is(ex, Bridge.PromiseException), "is PromiseException");
             Bridge.Test.Assert.areEqual$1(args, ex.arguments, "Arguments");
@@ -13128,7 +13128,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1("Promise exception: [a, 1]", ex.getMessage(), "Message");
         },
         argumentsAndMessageConstructorWorks: function () {
-            var args = ["a", 1];
+            var args = ["a", Bridge.box(1, System.Int32)];
             var ex = new Bridge.PromiseException(args, "Some message");
             Bridge.Test.Assert.true$1(Bridge.is(ex, Bridge.PromiseException), "is PromiseException");
             Bridge.Test.Assert.true$1(ex.getInnerException() == null, "InnerException");
@@ -13137,7 +13137,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         argumentsAndMessageAndInnerExceptionConstructorWorks: function () {
             var inner = new System.Exception("a");
-            var args = ["a", 1];
+            var args = ["a", Bridge.box(1, System.Int32)];
             var ex = new Bridge.PromiseException(args, "Some message", inner);
             Bridge.Test.Assert.true$1(Bridge.is(ex, Bridge.PromiseException), "is PromiseException");
             Bridge.Test.Assert.true$1(Bridge.referenceEquals(ex.getInnerException(), inner), "InnerException");
@@ -13328,8 +13328,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         getFormatWorks: function () {
             var format = System.Globalization.DateTimeFormatInfo.invariantInfo;
-            Bridge.Test.Assert.areEqual(null, format.getFormat(System.Int32));
-            Bridge.Test.Assert.areEqual(format, format.getFormat(System.Globalization.DateTimeFormatInfo));
+            Bridge.Test.Assert.areEqual(null, Bridge.unbox(format.getFormat(System.Int32)));
+            Bridge.Test.Assert.areEqual(format, Bridge.unbox(format.getFormat(System.Globalization.DateTimeFormatInfo)));
         },
         invariantWorks: function () {
             var format = System.Globalization.DateTimeFormatInfo.invariantInfo;
@@ -13365,8 +13365,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         getFormatWorks: function () {
             var format = System.Globalization.NumberFormatInfo.invariantInfo;
-            Bridge.Test.Assert.areEqual(null, format.getFormat(System.Int32));
-            Bridge.Test.Assert.areEqual(format, format.getFormat(System.Globalization.NumberFormatInfo));
+            Bridge.Test.Assert.areEqual(null, Bridge.unbox(format.getFormat(System.Int32)));
+            Bridge.Test.Assert.areEqual(format, Bridge.unbox(format.getFormat(System.Globalization.NumberFormatInfo)));
         },
         invariantWorks: function () {
             var format = System.Globalization.NumberFormatInfo.invariantInfo;
@@ -13552,7 +13552,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         customPerMileFormatSpecifierWorks: function () {
             var value = 0.00354;
-            Bridge.Test.Assert.areEqual("3.54 ‰", System.Double.format(value, "#0.## " + String.fromCharCode(8240)));
+            Bridge.Test.Assert.areEqual("3.54 ‰", System.Double.format(value, "#0.## " + String.fromCharCode(Bridge.box(8240, System.Char, $box_.System.Char.toString))));
         },
         customEscapeFormatSpecifierWorks: function () {
             var value = 123;
@@ -13578,12 +13578,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.Format.StringFormatTests", {
         simple: function () {
             var pricePerOunce = System.Decimal(17.36);
-            var s = System.String.format("The current price is {0} per ounce.", pricePerOunce);
+            var s = System.String.format("The current price is {0} per ounce.", Bridge.box(pricePerOunce, System.Decimal, $box_.System.Decimal.toString));
             Bridge.Test.Assert.areEqual("The current price is 17.36 per ounce.", s);
         },
         valueFormating: function () {
             var pricePerOunce = System.Decimal(17.36);
-            var s = System.String.format("The current price is {0:C2} per ounce.", pricePerOunce);
+            var s = System.String.format("The current price is {0:C2} per ounce.", Bridge.box(pricePerOunce, System.Decimal, $box_.System.Decimal.toString));
             Bridge.Test.Assert.areEqual("The current price is ¤17.36 per ounce.", s);
         },
         spaceControlling: function () {
@@ -13592,13 +13592,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var s = System.String.format("{0,6} {1,15}", "Year", "Population");
             Bridge.Test.Assert.areEqual("  Year      Population", s);
 
-            s = System.String.format("{0,6} {1,15:N0}", years[0], population[0]);
+            s = System.String.format("{0,6} {1,15:N0}", Bridge.box(years[0], System.Int32), Bridge.box(population[0], System.Int32));
             Bridge.Test.Assert.areEqual("  2013       1,025,632", s);
 
-            s = System.String.format("{0,6} {1,15:N0}", years[1], population[1]);
+            s = System.String.format("{0,6} {1,15:N0}", Bridge.box(years[1], System.Int32), Bridge.box(population[1], System.Int32));
             Bridge.Test.Assert.areEqual("  2014       1,105,967", s);
 
-            s = System.String.format("{0,6} {1,15:N0}", years[2], population[2]);
+            s = System.String.format("{0,6} {1,15:N0}", Bridge.box(years[2], System.Int32), Bridge.box(population[2], System.Int32));
             Bridge.Test.Assert.areEqual("  2015       1,148,203", s);
         },
         aligment: function () {
@@ -13609,16 +13609,16 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var header = System.String.format("{0,-12}{1,8}{2,12}{1,8}{2,12}{3,14}", "City", "Year", "Population", "Change (%)");
             Bridge.Test.Assert.areEqual("City            Year  Population    Year  Population    Change (%)", header);
 
-            var output = System.String.format("{0,-12}{1,8:yyyy}{2,12:N0}{3,8:yyyy}{4,12:N0}{5,14:P1}", cities[0].item1, cities[0].item2, cities[0].item3, cities[0].item4, cities[0].item5, (((cities[0].item5 - cities[0].item3) | 0)) / cities[0].item3);
+            var output = System.String.format("{0,-12}{1,8:yyyy}{2,12:N0}{3,8:yyyy}{4,12:N0}{5,14:P1}", cities[0].item1, Bridge.box(cities[0].item2, Date, $box_.Date.toString), Bridge.box(cities[0].item3, System.Int32), Bridge.box(cities[0].item4, Date, $box_.Date.toString), Bridge.box(cities[0].item5, System.Int32), Bridge.box((((cities[0].item5 - cities[0].item3) | 0)) / cities[0].item3, System.Double, $box_.System.Double.toString));
             Bridge.Test.Assert.areEqual("Los Angeles     1940   1,504,277    1950   1,970,358        31.0 %", output);
 
-            output = System.String.format("{0,-12}{1,8:yyyy}{2,12:N0}{3,8:yyyy}{4,12:N0}{5,14:P1}", cities[1].item1, cities[1].item2, cities[1].item3, cities[1].item4, cities[1].item5, (((cities[1].item5 - cities[1].item3) | 0)) / cities[1].item3);
+            output = System.String.format("{0,-12}{1,8:yyyy}{2,12:N0}{3,8:yyyy}{4,12:N0}{5,14:P1}", cities[1].item1, Bridge.box(cities[1].item2, Date, $box_.Date.toString), Bridge.box(cities[1].item3, System.Int32), Bridge.box(cities[1].item4, Date, $box_.Date.toString), Bridge.box(cities[1].item5, System.Int32), Bridge.box((((cities[1].item5 - cities[1].item3) | 0)) / cities[1].item3, System.Double, $box_.System.Double.toString));
             Bridge.Test.Assert.areEqual("New York        1940   7,454,995    1950   7,891,957         5.9 %", output);
 
-            output = System.String.format("{0,-12}{1,8:yyyy}{2,12:N0}{3,8:yyyy}{4,12:N0}{5,14:P1}", cities[2].item1, cities[2].item2, cities[2].item3, cities[2].item4, cities[2].item5, (((cities[2].item5 - cities[2].item3) | 0)) / cities[2].item3);
+            output = System.String.format("{0,-12}{1,8:yyyy}{2,12:N0}{3,8:yyyy}{4,12:N0}{5,14:P1}", cities[2].item1, Bridge.box(cities[2].item2, Date, $box_.Date.toString), Bridge.box(cities[2].item3, System.Int32), Bridge.box(cities[2].item4, Date, $box_.Date.toString), Bridge.box(cities[2].item5, System.Int32), Bridge.box((((cities[2].item5 - cities[2].item3) | 0)) / cities[2].item3, System.Double, $box_.System.Double.toString));
             Bridge.Test.Assert.areEqual("Chicago         1940   3,396,808    1950   3,620,962         6.6 %", output);
 
-            output = System.String.format("{0,-12}{1,8:yyyy}{2,12:N0}{3,8:yyyy}{4,12:N0}{5,14:P1}", cities[3].item1, cities[3].item2, cities[3].item3, cities[3].item4, cities[3].item5, (((cities[3].item5 - cities[3].item3) | 0)) / cities[3].item3);
+            output = System.String.format("{0,-12}{1,8:yyyy}{2,12:N0}{3,8:yyyy}{4,12:N0}{5,14:P1}", cities[3].item1, Bridge.box(cities[3].item2, Date, $box_.Date.toString), Bridge.box(cities[3].item3, System.Int32), Bridge.box(cities[3].item4, Date, $box_.Date.toString), Bridge.box(cities[3].item5, System.Int32), Bridge.box((((cities[3].item5 - cities[3].item3) | 0)) / cities[3].item3, System.Double, $box_.System.Double.toString));
             Bridge.Test.Assert.areEqual("Detroit         1940   1,623,452    1950   1,849,568        13.9 %", output);
         },
         padIntegerWithLeadingZeros: function () {
@@ -13633,11 +13633,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual("              01023983               000F9FEF", System.String.format("{0,22} {1,22}", System.Int32.format(intValue, "D8"), System.Int32.format(intValue, "X8")));
             Bridge.Test.Assert.areEqual("              06985321               006A9669", System.String.format("{0,22} {1,22}", lngValue.toString("D8"), lngValue.toString("X8")));
             Bridge.Test.Assert.areEqual("  18446744073709551615       FFFFFFFFFFFFFFFF", System.String.format("{0,22} {1,22}", ulngValue.toString("D8"), ulngValue.toString("X8")));
-            Bridge.Test.Assert.areEqual("              00000254               000000FE", System.String.format("{0,22:D8} {0,22:X8}", byteValue));
-            Bridge.Test.Assert.areEqual("              00010342               00002866", System.String.format("{0,22:D8} {0,22:X8}", shortValue));
-            Bridge.Test.Assert.areEqual("              01023983               000F9FEF", System.String.format("{0,22:D8} {0,22:X8}", intValue));
-            Bridge.Test.Assert.areEqual("              06985321               006A9669", System.String.format("{0,22:D8} {0,22:X8}", lngValue));
-            Bridge.Test.Assert.areEqual("  18446744073709551615       FFFFFFFFFFFFFFFF", System.String.format("{0,22:D8} {0,22:X8}", ulngValue));
+            Bridge.Test.Assert.areEqual("              00000254               000000FE", System.String.format("{0,22:D8} {0,22:X8}", Bridge.box(byteValue, System.Byte)));
+            Bridge.Test.Assert.areEqual("              00010342               00002866", System.String.format("{0,22:D8} {0,22:X8}", Bridge.box(shortValue, System.Int16)));
+            Bridge.Test.Assert.areEqual("              01023983               000F9FEF", System.String.format("{0,22:D8} {0,22:X8}", Bridge.box(intValue, System.Int32)));
+            Bridge.Test.Assert.areEqual("              06985321               006A9669", System.String.format("{0,22:D8} {0,22:X8}", Bridge.box(lngValue, System.Int64)));
+            Bridge.Test.Assert.areEqual("  18446744073709551615       FFFFFFFFFFFFFFFF", System.String.format("{0,22:D8} {0,22:X8}", Bridge.box(ulngValue, System.UInt64)));
         },
         padIntegerWithSpecificNumberLeadingZeros: function () {
             var value = 160934;
@@ -13654,9 +13654,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             // Display the numbers using composite formatting.
             var formatString = System.String.concat(" {0,15:", fmt, "}");
-            Bridge.Test.Assert.areEqual("        01053240", System.String.format(formatString, intValue));
-            Bridge.Test.Assert.areEqual("     00103932.52", System.String.format(formatString, decValue));
-            Bridge.Test.Assert.areEqual("   9034521202.93", System.String.format(formatString, dblValue));
+            Bridge.Test.Assert.areEqual("        01053240", System.String.format(formatString, Bridge.box(intValue, System.Int32)));
+            Bridge.Test.Assert.areEqual("     00103932.52", System.String.format(formatString, Bridge.box(decValue, System.Decimal, $box_.System.Decimal.toString)));
+            Bridge.Test.Assert.areEqual("   9034521202.93", System.String.format(formatString, Bridge.box(dblValue, System.Double, $box_.System.Double.toString)));
         },
         padNumericWithSpecificNumberOfLeadingZeros: function () {
             var $t;
@@ -13677,7 +13677,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }
                 formatString = System.String.concat("{0,20:", fmt, "}");
 
-                Bridge.Test.Assert.areEqual(result[Bridge.identity(i, (i = (i + 1) | 0))], System.String.format(formatString, dblValue));
+                Bridge.Test.Assert.areEqual(result[Bridge.identity(i, (i = (i + 1) | 0))], System.String.format(formatString, Bridge.box(dblValue, System.Double, $box_.System.Double.toString)));
             }
         }
     });
@@ -13706,30 +13706,30 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         getArgumentWorks: function () {
             var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
-            Bridge.Test.Assert.areEqual$1("x", s.getArgument(0), "0");
-            Bridge.Test.Assert.areEqual$1("y", s.getArgument(1), "1");
+            Bridge.Test.Assert.areEqual$1("x", Bridge.unbox(s.getArgument(0)), "0");
+            Bridge.Test.Assert.areEqual$1("y", Bridge.unbox(s.getArgument(1)), "1");
         },
         getArgumentsWorks: function () {
             var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
             var args = s.getArguments();
-            Bridge.Test.Assert.areEqual$1("x", args[0], "0");
-            Bridge.Test.Assert.areEqual$1("y", args[1], "1");
+            Bridge.Test.Assert.areEqual$1("x", Bridge.unbox(args[0]), "0");
+            Bridge.Test.Assert.areEqual$1("y", Bridge.unbox(args[1]), "1");
         },
         arrayReturnedByGetArgumentsCanBeModified: function () {
             var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
             var args = s.getArguments();
-            Bridge.Test.Assert.areEqual$1("x", args[0], "#1");
+            Bridge.Test.Assert.areEqual$1("x", Bridge.unbox(args[0]), "#1");
             args[0] = "z";
             var args2 = s.getArguments();
-            Bridge.Test.Assert.areEqual$1("z", args2[0], "#2");
+            Bridge.Test.Assert.areEqual$1("z", Bridge.unbox(args2[0]), "#2");
             Bridge.Test.Assert.areEqual$1("x = z, y = y", s.toString(), "#3");
         },
         toStringWorks: function () {
-            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", 291]);
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", Bridge.box(291, System.Int32)]);
             Bridge.Test.Assert.areEqual("x = x, y = 123", s.toString());
         },
         invariantWorks: function () {
-            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", 291]);
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", Bridge.box(291, System.Int32)]);
             Bridge.Test.Assert.areEqual("x = x, y = 123", System.FormattableString.invariant(s));
         }
     });
@@ -13789,100 +13789,100 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         applySetInt: function (f) {
             var a1 = f.apply(null);
-            var i1 = System.Nullable.getValue(Bridge.cast(a1, System.Int32));
+            var i1 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a1), System.Int32));
             Bridge.Test.Assert.areEqual$1(45, i1, "Apply1");
 
             var a2 = f.apply(null, [1, 2]);
-            var i2 = System.Nullable.getValue(Bridge.cast(a2, System.Int32));
+            var i2 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a2), System.Int32));
             Bridge.Test.Assert.areEqual$1(3, i2, "Apply2");
 
             var s3 = new $_.$AnonymousType$1(3, 5);
             var a3 = f.apply(null, [null, null, s3]);
-            var i3 = System.Nullable.getValue(Bridge.cast(a3, System.Int32));
+            var i3 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a3), System.Int32));
             Bridge.Test.Assert.areEqual$1(8, i3, "Apply3");
 
             var s4 = new $_.$AnonymousType$2(7);
             var a4 = f.apply(null, [1, 2, s4]);
-            var i4 = System.Nullable.getValue(Bridge.cast(a4, System.Int32));
+            var i4 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a4), System.Int32));
             Bridge.Test.Assert.areEqual$1(-48, i4, "Apply4");
 
             var s5 = new $_.$AnonymousType$3(9, undefined);
-            var a5 = f.apply(null, [undefined, 10, s5]);
-            var i5 = System.Nullable.getValue(Bridge.cast(a5, System.Int32));
+            var a5 = f.apply(null, [Bridge.unbox(undefined), 10, s5]);
+            var i5 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a5), System.Int32));
             Bridge.Test.Assert.areEqual$1(-46, i5, "Apply5");
 
             var scope = new $_.$AnonymousType$4(70, 51);
 
             var a6 = f.apply(scope);
-            var i6 = System.Nullable.getValue(Bridge.cast(a6, System.Int32));
+            var i6 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a6), System.Int32));
             Bridge.Test.Assert.areEqual$1(121, i6, "Apply6");
 
             var a7 = f.apply(scope, [1, 2]);
-            var i7 = System.Nullable.getValue(Bridge.cast(a7, System.Int32));
+            var i7 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a7), System.Int32));
             Bridge.Test.Assert.areEqual$1(121, i7, "Apply7");
 
             var s8 = new $_.$AnonymousType$1(3, 5);
             var a8 = f.apply(scope, [null, null, s8]);
-            var i8 = System.Nullable.getValue(Bridge.cast(a8, System.Int32));
+            var i8 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a8), System.Int32));
             Bridge.Test.Assert.areEqual$1(8, i8, "Apply8");
 
             var s9 = new $_.$AnonymousType$2(7);
             var a9 = f.apply(scope, [1, 2, s9]);
-            var i9 = System.Nullable.getValue(Bridge.cast(a9, System.Int32));
+            var i9 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a9), System.Int32));
             Bridge.Test.Assert.areEqual$1(-48, i9, "Apply9");
 
             var s10 = new $_.$AnonymousType$3(9, undefined);
-            var a10 = f.apply(scope, [undefined, 10, s10]);
-            var i10 = System.Nullable.getValue(Bridge.cast(a10, System.Int32));
+            var a10 = f.apply(scope, [Bridge.unbox(undefined), 10, s10]);
+            var i10 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a10), System.Int32));
             Bridge.Test.Assert.areEqual$1(-46, i10, "Apply10");
         },
         callSetInt: function (f) {
             var a1 = f.call(null);
-            var i1 = System.Nullable.getValue(Bridge.cast(a1, System.Int32));
+            var i1 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a1), System.Int32));
             Bridge.Test.Assert.areEqual$1(45, i1, "Call1");
 
             var a2 = f.call(null, 1, 2);
-            var i2 = System.Nullable.getValue(Bridge.cast(a2, System.Int32));
+            var i2 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a2), System.Int32));
             Bridge.Test.Assert.areEqual$1(3, i2, "Call2");
 
             var s3 = new $_.$AnonymousType$1(3, 5);
             var a3 = f.call(null, null, null, s3);
-            var i3 = System.Nullable.getValue(Bridge.cast(a3, System.Int32));
+            var i3 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a3), System.Int32));
             Bridge.Test.Assert.areEqual$1(8, i3, "Call3");
 
             var s4 = new $_.$AnonymousType$2(7);
             var a4 = f.call(null, 1, 2, s4);
-            var i4 = System.Nullable.getValue(Bridge.cast(a4, System.Int32));
+            var i4 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a4), System.Int32));
             Bridge.Test.Assert.areEqual$1(-48, i4, "Call4");
 
             var s5 = new $_.$AnonymousType$3(9, undefined);
-            var a5 = f.call(null, undefined, 10, s5);
-            var i5 = System.Nullable.getValue(Bridge.cast(a5, System.Int32));
+            var a5 = f.call(null, Bridge.unbox(undefined), 10, s5);
+            var i5 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a5), System.Int32));
             Bridge.Test.Assert.areEqual$1(-46, i5, "Call5");
 
             var scope = new $_.$AnonymousType$4(70, 51);
 
             var a6 = f.call(scope);
-            var i6 = System.Nullable.getValue(Bridge.cast(a6, System.Int32));
+            var i6 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a6), System.Int32));
             Bridge.Test.Assert.areEqual$1(121, i6, "Call6");
 
             var a7 = f.call(scope, 1, 2);
-            var i7 = System.Nullable.getValue(Bridge.cast(a7, System.Int32));
+            var i7 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a7), System.Int32));
             Bridge.Test.Assert.areEqual$1(121, i7, "Call7");
 
             var s8 = new $_.$AnonymousType$1(3, 5);
             var a8 = f.call(scope, null, null, s8);
-            var i8 = System.Nullable.getValue(Bridge.cast(a8, System.Int32));
+            var i8 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a8), System.Int32));
             Bridge.Test.Assert.areEqual$1(8, i8, "Call8");
 
             var s9 = new $_.$AnonymousType$2(7);
             var a9 = f.call(scope, 1, 2, s9);
-            var i9 = System.Nullable.getValue(Bridge.cast(a9, System.Int32));
+            var i9 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a9), System.Int32));
             Bridge.Test.Assert.areEqual$1(-48, i9, "Call9");
 
             var s10 = new $_.$AnonymousType$3(9, undefined);
-            var a10 = f.call(scope, undefined, 10, s10);
-            var i10 = System.Nullable.getValue(Bridge.cast(a10, System.Int32));
+            var a10 = f.call(scope, Bridge.unbox(undefined), 10, s10);
+            var i10 = System.Nullable.getValue(Bridge.cast(Bridge.unbox(a10), System.Int32));
             Bridge.Test.Assert.areEqual$1(-46, i10, "Call10");
         }
     });
@@ -14006,12 +14006,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         typePropertiesAreCorrect: function () {
             Bridge.Test.Assert.areEqual(Bridge.Reflection.getTypeFullName(System.Guid), "System.Guid");
 
-            var o = new System.Guid.ctor();
+            var o = Bridge.box(new System.Guid.ctor(), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(o, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(o, System.IComparable$1(System.Guid)));
             Bridge.Test.Assert.true(Bridge.is(o, System.IEquatable$1(System.Guid)));
 
-            Bridge.Test.Assert.false(Bridge.is(1, System.Guid));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(1, System.Int32), System.Guid));
             Bridge.Test.Assert.false(Bridge.is("abcd", System.Guid));
             Bridge.Test.Assert.false(Bridge.is("{00000000-0000-0000-0000-000000000000}", System.Guid));
         },
@@ -14021,12 +14021,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(result.toString(), "00000000-0000-0000-0000-000000000000");
         },
         createInstanceWorks: function () {
-            var result = Bridge.createInstance(System.Guid);
+            var result = Bridge.box(Bridge.createInstance(System.Guid), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(result, System.Guid));
             Bridge.Test.Assert.areEqual(result.toString(), "00000000-0000-0000-0000-000000000000");
         },
         defaultConstructorWorks: function () {
-            var result = new System.Guid.ctor();
+            var result = Bridge.box(new System.Guid.ctor(), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(result, System.Guid));
             Bridge.Test.Assert.areEqual(result.toString(), "00000000-0000-0000-0000-000000000000");
         },
@@ -14039,30 +14039,30 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         byteArrayConstructorWorks: function () {
             var g = new System.Guid.$ctor1([120, 149, 98, 168, 38, 122, 69, 97, 144, 50, 217, 26, 61, 84, 189, 104]);
-            Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Should be Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Should be Guid");
             Bridge.Test.Assert.areEqual$1(g.toString(), "a8629578-7a26-6145-9032-d91a3d54bd68", "value");
             Bridge.Test.Assert.throws$4($_.Bridge.ClientTest.GuidTests.f1, System.ArgumentException, "Invalid array should throw");
         },
         int32Int16Int16ByteArrayConstructorWorks: function () {
             var g = new System.Guid.$ctor3(2023056040, 9850, 17761, [144, 50, 217, 26, 61, 84, 189, 104]);
-            Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Should be Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Should be Guid");
             Bridge.Test.Assert.areEqual$1(g.toString(), "789562a8-267a-4561-9032-d91a3d54bd68", "value");
         },
         int32Int16Int16BytesConstructorWorks: function () {
             var g = new System.Guid.$ctor2(2023056040, 9850, 17761, 144, 50, 217, 26, 61, 84, 189, 104);
-            Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Should be Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Should be Guid");
             Bridge.Test.Assert.areEqual$1(g.toString(), "789562a8-267a-4561-9032-d91a3d54bd68", "value");
         },
         uInt32UInt16UInt16BytesConstructorWorks: function () {
             var g = new System.Guid.$ctor5(2023056040, 9850, 17761, 144, 50, 217, 26, 61, 84, 189, 104);
-            Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Should be Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Should be Guid");
             Bridge.Test.Assert.areEqual$1(g.toString(), "789562a8-267a-4561-9032-d91a3d54bd68", "value");
         },
         stringConstructorWorks: function () {
-            var g1 = new System.Guid.$ctor4("A6993C0A-A8CB-45D9-994B-90E7203E4FC6");
-            var g2 = new System.Guid.$ctor4("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}");
-            var g3 = new System.Guid.$ctor4("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)");
-            var g4 = new System.Guid.$ctor4("A6993C0AA8CB45D9994B90E7203E4FC6");
+            var g1 = Bridge.box(new System.Guid.$ctor4("A6993C0A-A8CB-45D9-994B-90E7203E4FC6"), System.Guid);
+            var g2 = Bridge.box(new System.Guid.$ctor4("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}"), System.Guid);
+            var g3 = Bridge.box(new System.Guid.$ctor4("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)"), System.Guid);
+            var g4 = Bridge.box(new System.Guid.$ctor4("A6993C0AA8CB45D9994B90E7203E4FC6"), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(g1, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g2, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g3, System.Guid));
@@ -14074,10 +14074,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.throws$4($_.Bridge.ClientTest.GuidTests.f2, System.FormatException, "Invalid should throw");
         },
         parseWorks: function () {
-            var g1 = System.Guid.parse("A6993C0A-A8CB-45D9-994B-90E7203E4FC6");
-            var g2 = System.Guid.parse("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}");
-            var g3 = System.Guid.parse("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)");
-            var g4 = System.Guid.parse("A6993C0AA8CB45D9994B90E7203E4FC6");
+            var g1 = Bridge.box(System.Guid.parse("A6993C0A-A8CB-45D9-994B-90E7203E4FC6"), System.Guid);
+            var g2 = Bridge.box(System.Guid.parse("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}"), System.Guid);
+            var g3 = Bridge.box(System.Guid.parse("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)"), System.Guid);
+            var g4 = Bridge.box(System.Guid.parse("A6993C0AA8CB45D9994B90E7203E4FC6"), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(g1, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g2, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g3, System.Guid));
@@ -14089,10 +14089,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.throws$4($_.Bridge.ClientTest.GuidTests.f3, System.FormatException, "Invalid should throw");
         },
         parseExactWorks: function () {
-            var g1 = System.Guid.parseExact("A6993C0A-A8CB-45D9-994B-90E7203E4FC6", "D");
-            var g2 = System.Guid.parseExact("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}", "B");
-            var g3 = System.Guid.parseExact("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)", "P");
-            var g4 = System.Guid.parseExact("A6993C0AA8CB45D9994B90E7203E4FC6", "N");
+            var g1 = Bridge.box(System.Guid.parseExact("A6993C0A-A8CB-45D9-994B-90E7203E4FC6", "D"), System.Guid);
+            var g2 = Bridge.box(System.Guid.parseExact("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}", "B"), System.Guid);
+            var g3 = Bridge.box(System.Guid.parseExact("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)", "P"), System.Guid);
+            var g4 = Bridge.box(System.Guid.parseExact("A6993C0AA8CB45D9994B90E7203E4FC6", "N"), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(g1, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g2, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g3, System.Guid));
@@ -14113,11 +14113,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(System.Guid.tryParse("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)", g3), "g3 result");
             Bridge.Test.Assert.true$1(System.Guid.tryParse("A6993C0AA8CB45D9994B90E7203E4FC6", g4), "g4 result");
             Bridge.Test.Assert.false$1(System.Guid.tryParse("x", g5), "Invalid should throw");
-            Bridge.Test.Assert.true$1(Bridge.is(g1.v, System.Guid), "g1 is Guid");
-            Bridge.Test.Assert.true$1(Bridge.is(g2.v, System.Guid), "g2 is Guid");
-            Bridge.Test.Assert.true$1(Bridge.is(g3.v, System.Guid), "g3 is Guid");
-            Bridge.Test.Assert.true$1(Bridge.is(g4.v, System.Guid), "g4 is Guid");
-            Bridge.Test.Assert.true$1(Bridge.is(g5.v, System.Guid), "g5 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g1.v, System.Guid), System.Guid), "g1 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g2.v, System.Guid), System.Guid), "g2 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g3.v, System.Guid), System.Guid), "g3 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g4.v, System.Guid), System.Guid), "g4 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g5.v, System.Guid), System.Guid), "g5 is Guid");
             Bridge.Test.Assert.areEqual$1(g1.v.toString(), "a6993c0a-a8cb-45d9-994b-90e7203e4fc6", "g1");
             Bridge.Test.Assert.areEqual$1(g2.v.toString(), "a6993c0a-a8cb-45d9-994b-90e7203e4fc6", "g2");
             Bridge.Test.Assert.areEqual$1(g3.v.toString(), "a6993c0a-a8cb-45d9-994b-90e7203e4fc6", "g3");
@@ -14134,14 +14134,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.false$1(System.Guid.tryParseExact("A6993C0A-A8CB-45D9-994B-90E7203E4FC6", "P", g6), "g6 result");
             Bridge.Test.Assert.false$1(System.Guid.tryParseExact("A6993C0A-A8CB-45D9-994B-90E7203E4FC6", "N", g7), "g7 result");
             Bridge.Test.Assert.false$1(System.Guid.tryParseExact("A6993C0AA8CB45D9994B90E7203E4FC6", "D", g8), "g8 result");
-            Bridge.Test.Assert.true(Bridge.is(g1.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g2.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g3.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g4.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g5.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g6.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g7.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g8.v, System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g1.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g2.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g3.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g4.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g5.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g6.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g7.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g8.v, System.Guid), System.Guid));
             Bridge.Test.Assert.areEqual$1(g1.v.toString(), "a6993c0a-a8cb-45d9-994b-90e7203e4fc6", "g1");
             Bridge.Test.Assert.areEqual$1(g2.v.toString(), "a6993c0a-a8cb-45d9-994b-90e7203e4fc6", "g2");
             Bridge.Test.Assert.areEqual$1(g3.v.toString(), "a6993c0a-a8cb-45d9-994b-90e7203e4fc6", "g3");
@@ -14157,14 +14157,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual$1(g.compareTo(new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0")), 0, "not equal");
         },
         iComparableCompareToWorks: function () {
-            var g = Bridge.cast(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.IComparable$1(System.Guid));
+            var g = Bridge.cast(Bridge.box(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.Guid), System.IComparable$1(System.Guid));
             Bridge.Test.Assert.areEqual$1(Bridge.compare(g, new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), false, System.Guid), 0, "Equal");
             Bridge.Test.Assert.areNotEqual$1(Bridge.compare(g, new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0"), false, System.Guid), 0, "Not equal");
         },
         equalsObjectWorks: function () {
             var g = new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C");
-            Bridge.Test.Assert.true$1(Bridge.equals(g, new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C")), "Equal");
-            Bridge.Test.Assert.false$1(Bridge.equals(g, new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0")), "Not equal");
+            Bridge.Test.Assert.true$1(Bridge.equals(g, Bridge.unbox(Bridge.box(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.Guid))), "Equal");
+            Bridge.Test.Assert.false$1(Bridge.equals(g, Bridge.unbox(Bridge.box(new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0"), System.Guid))), "Not equal");
             Bridge.Test.Assert.false$1(Bridge.equals(g, "X"), "Not equal");
         },
         equalsGuidWorks: function () {
@@ -14173,7 +14173,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.false$1(g.equalsT(new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0")), "Not equal");
         },
         iEquatableEqualsWorks: function () {
-            var g = Bridge.cast(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.IEquatable$1(System.Guid));
+            var g = Bridge.cast(Bridge.box(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.Guid), System.IEquatable$1(System.Guid));
             Bridge.Test.Assert.true$1(Bridge.equalsT(g, new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.Guid), "Equal");
             Bridge.Test.Assert.false$1(Bridge.equalsT(g, new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0"), System.Guid), "Not equal");
         },
@@ -14202,7 +14202,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var d = new (System.Collections.Generic.Dictionary$2(String,Object))();
             for (var i = 0; i < 1000; i = (i + 1) | 0) {
                 var g = System.Guid.newGuid();
-                Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Generated Guid should be Guid");
+                Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Generated Guid should be Guid");
                 var s = g.toString$1("N");
                 Bridge.Test.Assert.true$1(s.charCodeAt(16) === 56 || s.charCodeAt(16) === 57 || s.charCodeAt(16) === 97 || s.charCodeAt(16) === 98, "Should be standard guid");
                 Bridge.Test.Assert.true$1(s.charCodeAt(12) === 52, "Should be type 4 guid");
@@ -14487,7 +14487,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.apply($_.Bridge.ClientTest.JsonTests, {
         f1: function (s, x) {
             if (Bridge.referenceEquals(s, "i")) {
-                return 100;
+                return Bridge.box(100, System.Int32);
             }
             return x;
         },
@@ -14573,7 +14573,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(f.rt, System.Int32);
             Bridge.Test.Assert.areEqual(f.body.ntype, 9);
             Bridge.Test.Assert.areEqual(f.body.t, System.Int32);
-            Bridge.Test.Assert.areEqual(($t1 = f.body, Bridge.cast($t1, Bridge.hasValue($t1) && ($t1.ntype === 9))).value, 42);
+            Bridge.Test.Assert.areEqual(Bridge.unbox(($t1 = f.body, Bridge.cast($t1, Bridge.hasValue($t1) && ($t1.ntype === 9))).value), 42);
         },
         lambdaWorks: function () {
             var $t, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9;
@@ -14635,9 +14635,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(c1.t, System.Int32, "c1.Type");
             Bridge.Test.Assert.areEqual$1(c2.t, String, "c2.Type");
             Bridge.Test.Assert.areEqual$1(c3.t, System.Int32, "c3.Type");
-            Bridge.Test.Assert.areEqual$1(c1.value, 42, "c1.Value");
-            Bridge.Test.Assert.areEqual$1(c2.value, "Hello, world", "c2.Value");
-            Bridge.Test.Assert.areEqual$1(c3.value, 17, "c3.Value");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(c1.value), 42, "c1.Value");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(c2.value), "Hello, world", "c2.Value");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(c3.value), 17, "c3.Value");
 
             Bridge.Test.Assert.false$1(($t = { ntype: 38, t: System.Int32 }, Bridge.is($t, Bridge.hasValue($t) && ($t.ntype === 9))), "Parameter is ConstantExpression");
         },
@@ -15090,7 +15090,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.areEqual$1(me.method.n, "Get", System.String.concat(title, " method name"));
                 Bridge.Test.Assert.areEqual$1(me.method.td, Array, System.String.concat(title, " method declaring type"));
                 Bridge.Test.Assert.areEqual$1((me.method.p || []), [System.Int32, System.Int32], System.String.concat(title, " method parameter types"));
-                Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(me.method, arr)(1, 2), 2.5, System.String.concat(title, " method invoke result"));
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(me.method, arr)(1, 2)), 2.5, System.String.concat(title, " method invoke result"));
             };
 
             asserter(e1.body, "e1");
@@ -15144,7 +15144,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             Bridge.Test.Assert.true$1(Bridge.referenceEquals(($t21 = e9.body, Bridge.cast($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))).method, Bridge.Reflection.getMembers(Bridge.ClientTest.Linq.Expressions.ExpressionTests.C, 8, 284, "M1")), "e9 member");
             Bridge.Test.Assert.areEqual$1(($t21 = e10.body, Bridge.cast($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))).method.n, "M3", "e10 member name");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(($t21 = e10.body, Bridge.cast($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))).method, new Bridge.ClientTest.Linq.Expressions.ExpressionTests.C.ctor())(39), 73, "e10 member result");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(($t21 = e10.body, Bridge.cast($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))).method, new Bridge.ClientTest.Linq.Expressions.ExpressionTests.C.ctor())(39)), 73, "e10 member result");
 
             Bridge.Test.Assert.false$1(($t21 = { ntype: 9, t: Object, value: null }, Bridge.is($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))), "Constant should not be MethodCallExpression");
         },
@@ -15352,10 +15352,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var propB = ne.m.get(1);
             Bridge.Test.Assert.true$1(Bridge.is(propA, System.Reflection.PropertyInfo), "A should be property");
             Bridge.Test.Assert.areEqual$1(propA.n, "A", "A name");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(Bridge.cast(propA, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$5(42, 17))(null), 42, "A getter result");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(Bridge.cast(propA, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$5(42, 17))(null)), 42, "A getter result");
             Bridge.Test.Assert.true$1(Bridge.is(propB, System.Reflection.PropertyInfo), "B should be property");
             Bridge.Test.Assert.areEqual$1(propB.n, "B", "B name");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(Bridge.cast(propB, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$5(42, 17))(null), 17, "B getter result");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(Bridge.cast(propB, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$5(42, 17))(null)), 17, "B getter result");
 
             var instance = Bridge.Reflection.invokeCI(ne.constructor, [42, 17]);
             Bridge.Test.Assert.areEqual$1(instance.a, 42, "Constructor invocation result A");
@@ -15383,10 +15383,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var propB = ne.m.get(1);
             Bridge.Test.Assert.true$1(Bridge.is(propA, System.Reflection.PropertyInfo), "A should be property");
             Bridge.Test.Assert.areEqual$1(propA.n, "a", "a name");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(Bridge.cast(propA, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$6(42, 17))(null), 42, "a getter result");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(Bridge.cast(propA, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$6(42, 17))(null)), 42, "a getter result");
             Bridge.Test.Assert.true$1(Bridge.is(propB, System.Reflection.PropertyInfo), "B should be property");
             Bridge.Test.Assert.areEqual$1(propB.n, "b", "b name");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(Bridge.cast(propB, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$6(42, 17))(null), 17, "b getter result");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(Bridge.cast(propB, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$6(42, 17))(null)), 17, "b getter result");
 
             var instance = Bridge.Reflection.invokeCI(ne.constructor, [42, 17]);
             Bridge.Test.Assert.areEqual$1(instance.a, 42, "Constructor invocation result a");
@@ -15748,8 +15748,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(prop.s.rt, Object, "setter return type");
             Bridge.Test.Assert.areEqual$1((prop.s.tpc || 0), 0, "setter type parameter count");
 
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(prop.g, expr.value)(), 42, "property get");
-            Bridge.Reflection.midel(prop.s, expr.value)(120);
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(prop.g, Bridge.unbox(expr.value))()), 42, "property get");
+            Bridge.Reflection.midel(prop.s, Bridge.unbox(expr.value))(120);
             Bridge.Test.Assert.areEqual$1(a, 120, "property set");
         },
         throwAndRethrowWork: function () {
@@ -16237,9 +16237,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(expr.rt, returnType, System.String.concat(title, " return type"));
             Bridge.Test.Assert.areEqual$1(expr.p.getCount(), parmTypes.length, System.String.concat(title, " param count"));
             for (var i = 0; i < expr.p.getCount(); i = (i + 1) | 0) {
-                Bridge.Test.Assert.areEqual$1(expr.p.get(i).ntype, 38, System.String.concat(title, " parameter ", i, " node type"));
-                Bridge.Test.Assert.areEqual$1(expr.p.get(i).n, parmNames[i], System.String.concat(title, " parameter ", i, " name"));
-                Bridge.Test.Assert.areEqual$1(expr.p.get(i).t, parmTypes[i], System.String.concat(title, " parameter ", i, " type"));
+                Bridge.Test.Assert.areEqual$1(expr.p.get(i).ntype, 38, System.String.concat(title, " parameter ", Bridge.box(i, System.Int32), " node type"));
+                Bridge.Test.Assert.areEqual$1(expr.p.get(i).n, parmNames[i], System.String.concat(title, " parameter ", Bridge.box(i, System.Int32), " name"));
+                Bridge.Test.Assert.areEqual$1(expr.p.get(i).t, parmTypes[i], System.String.concat(title, " parameter ", Bridge.box(i, System.Int32), " type"));
             }
         },
         f2: function (expr, nodeType, type, method, title) {
@@ -16310,12 +16310,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(me.t, System.Int32, System.String.concat(title, " type"));
             Bridge.Test.Assert.true$1(($t22 = me.expression, Bridge.is($t22, Bridge.hasValue($t22) && ($t22.ntype === 38))) && Bridge.referenceEquals(($t22 = me.expression, Bridge.cast($t22, Bridge.hasValue($t22) && ($t22.ntype === 38))).n, "a"), System.String.concat(title, " expression"));
             if (Bridge.referenceEquals(memberName, "F1") || Bridge.referenceEquals(memberName, "P1")) {
-                Bridge.Test.Assert.true$1(Bridge.referenceEquals(me.member, System.String.startsWith(memberName, "F") ? Bridge.Reflection.getMembers(Bridge.ClientTest.Linq.Expressions.ExpressionTests.C, 4, 284, memberName) : Bridge.Reflection.getMembers(Bridge.ClientTest.Linq.Expressions.ExpressionTests.C, 16, 284, memberName)), System.String.concat(title, " member"));
+                Bridge.Test.Assert.true$1(Bridge.referenceEquals(me.member, Bridge.unbox(System.String.startsWith(memberName, "F") ? Bridge.Reflection.getMembers(Bridge.ClientTest.Linq.Expressions.ExpressionTests.C, 4, 284, memberName) : Bridge.Reflection.getMembers(Bridge.ClientTest.Linq.Expressions.ExpressionTests.C, 16, 284, memberName))), System.String.concat(title, " member"));
             } else {
                 Bridge.Test.Assert.areEqual$1(me.member.t, System.String.startsWith(memberName, "F") ? 4 : 16, System.String.concat(title, " member type"));
                 Bridge.Test.Assert.areEqual$1(me.member.n, memberName, System.String.concat(title, " name"));
             }
-            Bridge.Test.Assert.areEqual$1(Bridge.is(me.member, System.Reflection.FieldInfo) ? Bridge.Reflection.fieldAccess(Bridge.cast(me.member, System.Reflection.FieldInfo), new Bridge.ClientTest.Linq.Expressions.ExpressionTests.C.ctor()) : Bridge.Reflection.midel(Bridge.cast(me.member, System.Reflection.PropertyInfo).g, new Bridge.ClientTest.Linq.Expressions.ExpressionTests.C.ctor())(null), result, System.String.concat(title, " member result"));
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.is(me.member, System.Reflection.FieldInfo) ? Bridge.Reflection.fieldAccess(Bridge.cast(me.member, System.Reflection.FieldInfo), new Bridge.ClientTest.Linq.Expressions.ExpressionTests.C.ctor()) : Bridge.Reflection.midel(Bridge.cast(me.member, System.Reflection.PropertyInfo).g, new Bridge.ClientTest.Linq.Expressions.ExpressionTests.C.ctor())(null)), result, System.String.concat(title, " member result"));
         },
         f7: function (expr, member, type, title) {
             var $t;
@@ -16337,11 +16337,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(ne.t, Bridge.ClientTest.Linq.Expressions.ExpressionTests.C, System.String.concat(title, " type"));
             Bridge.Test.Assert.areEqual$1(ne.arguments.getCount(), argTypes.length, System.String.concat(title, " argument count"));
             for (var i = 0; i < ne.arguments.getCount(); i = (i + 1) | 0) {
-                Bridge.Test.Assert.true$1(($t = ne.arguments.get(i), Bridge.is($t, Bridge.hasValue($t) && ($t.ntype === 38))) && Bridge.referenceEquals(($t = ne.arguments.get(i), Bridge.cast($t, Bridge.hasValue($t) && ($t.ntype === 38))).n, String.fromCharCode((((((97 + i) | 0))) & 65535))), System.String.concat(title, " argument ", i));
+                Bridge.Test.Assert.true$1(($t = ne.arguments.get(i), Bridge.is($t, Bridge.hasValue($t) && ($t.ntype === 38))) && Bridge.referenceEquals(($t = ne.arguments.get(i), Bridge.cast($t, Bridge.hasValue($t) && ($t.ntype === 38))).n, String.fromCharCode((((((97 + i) | 0))) & 65535))), System.String.concat(title, " argument ", Bridge.box(i, System.Int32)));
             }
             Bridge.Test.Assert.areEqual$1((ne.constructor.p || []).length, argTypes.length, System.String.concat(title, " constructor argument length"));
             for (var i1 = 0; i1 < (ne.constructor.p || []).length; i1 = (i1 + 1) | 0) {
-                Bridge.Test.Assert.areEqual$1((ne.constructor.p || [])[i1], argTypes[i1], System.String.concat(title, " constructor parameter type ", i1));
+                Bridge.Test.Assert.areEqual$1((ne.constructor.p || [])[i1], argTypes[i1], System.String.concat(title, " constructor parameter type ", Bridge.box(i1, System.Int32)));
             }
             if (checkReference) {
                 var $ctor = Bridge.Reflection.getMembers(Bridge.ClientTest.Linq.Expressions.ExpressionTests.C, 1, 284, null, argTypes);
@@ -16395,7 +16395,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(Bridge.referenceEquals(se.defaultBody, defaultBody), System.String.concat(title, " default value"));
             Bridge.Test.Assert.areEqual$1(se.cases.getCount(), cases.length, System.String.concat(title, " cases count"));
             for (var i = 0; i < se.cases.getCount(); i = (i + 1) | 0) {
-                Bridge.Test.Assert.true$1(Bridge.referenceEquals(se.cases.get(i), cases[i]), System.String.concat(title, " case ", i));
+                Bridge.Test.Assert.true$1(Bridge.referenceEquals(se.cases.get(i), cases[i]), System.String.concat(title, " case ", Bridge.box(i, System.Int32)));
             }
         }
     });
@@ -16510,7 +16510,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             this.$initialize();
         },
         getItem: function (a, b) {
-            return System.String.concat(this.F1 + " " + a + " ", b);
+            return System.String.concat(Bridge.box(this.F1, System.Int32) + " " + Bridge.box(a, System.Int32) + " ", b);
         },
         M1: function (a, b) {
             return 0;
@@ -17077,11 +17077,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.areDeepEqual$1(expectedGroupDictionary1, groupDictionary3, "ToDictionary(keySelector) conversion for <string, Group> - check content");
 
                 // TEST
-                var numbers = [null, 1.0, "two", 3, "four", 5, "six", 7.0];
+                var numbers = [null, Bridge.box(1.0, System.Double, $box_.System.Double.toString), "two", Bridge.box(3, System.Int32), "four", Bridge.box(5, System.Int32), "six", Bridge.box(7.0, System.Double, $box_.System.Double.toString)];
 
                 var doubleNumbers = System.Linq.Enumerable.from(numbers).ofType(System.Double).toArray();
 
-                Bridge.Test.Assert.areDeepEqual$1([1.0, 3, 5, 7.0], doubleNumbers, "Issue #218. OfType<double> should get only double type items");
+                Bridge.Test.Assert.areDeepEqual$1([1.0, 7.0], doubleNumbers, "Issue #218. OfType<double> should get only double type items");
             }
         }
     });
@@ -17142,7 +17142,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.areEqual$1(null, System.Linq.Enumerable.from(persons).where($_.Bridge.ClientTest.Linq.TestLinqElementOperators.f4).firstOrDefault(null, null), "FirstOrDefault() with Where() unexisting element by lambda");
                 Bridge.Test.Assert.areEqual$1(persons.getItem(7), System.Linq.Enumerable.from(persons).firstOrDefault($_.Bridge.ClientTest.Linq.TestLinqElementOperators.f5, null), "FirstOrDefault() with Name = 'Nemo' by lambda");
                 Bridge.Test.Assert.areEqual$1(persons.getItem(7), System.Linq.Enumerable.from(persons).where($_.Bridge.ClientTest.Linq.TestLinqElementOperators.f5).firstOrDefault(null, null), "FirstOrDefault() with Where() with Name = 'Nemo' by lambda");
-                Bridge.Test.Assert.areEqual$1(null, System.Linq.Enumerable.from(([])).firstOrDefault(null, null), "FirstOrDefault() within zero-length array by lambda");
+                Bridge.Test.Assert.areEqual$1(null, Bridge.unbox(System.Linq.Enumerable.from(([])).firstOrDefault(null, null)), "FirstOrDefault() within zero-length array by lambda");
 
                 // TEST
                 var lastPerson = (System.Linq.Enumerable.from(Bridge.ClientTest.Utilities.Person.getPersons()).select($_.Bridge.ClientTest.Linq.TestLinqElementOperators.f6)).last();
@@ -17157,7 +17157,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.areEqual$1(null, System.Linq.Enumerable.from(persons).lastOrDefault($_.Bridge.ClientTest.Linq.TestLinqElementOperators.f4, null), "LastOrDefault() unexisting element by lambda");
                 Bridge.Test.Assert.areEqual$1(null, System.Linq.Enumerable.from(persons).where($_.Bridge.ClientTest.Linq.TestLinqElementOperators.f4).lastOrDefault(null, null), "LastOrDefault() with Where() unexisting element by lambda");
                 Bridge.Test.Assert.areEqual$1(persons.getItem(7), System.Linq.Enumerable.from(persons).lastOrDefault($_.Bridge.ClientTest.Linq.TestLinqElementOperators.f5, null), "LastOrDefault() with Name = 'Nemo' by lambda");
-                Bridge.Test.Assert.areEqual$1(null, System.Linq.Enumerable.from(([])).lastOrDefault(null, null), "LastOrDefault() within zero-length array by lambda");
+                Bridge.Test.Assert.areEqual$1(null, Bridge.unbox(System.Linq.Enumerable.from(([])).lastOrDefault(null, null)), "LastOrDefault() within zero-length array by lambda");
 
                 // TEST
                 var numbers = [5, 4, 1, 3, 9, 8, 6, 7, 2, 0];
@@ -17336,7 +17336,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                     })).toArray();
 
                 var complexGroupingExpected = Bridge.ClientTest.Linq.TestLinqGroupingOperators.getComplexGroupingExpectedResult();
-                Bridge.Test.Assert.areDeepEqual$1(complexGroupingExpected, complexGrouping, "Complex grouping for numbers and words");
+                Bridge.Test.Assert.areDeepEqual$1(Bridge.unbox(complexGroupingExpected), complexGrouping, "Complex grouping for numbers and words");
             },
             testAnagrams: function () {
                 // TEST
@@ -18462,7 +18462,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(17.5, Math.abs(-17.5));
         },
         absOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(-10.0).abs(), 10.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-10.0).abs(), System.Decimal, $box_.System.Decimal.toString), Bridge.box(10.0, System.Double, $box_.System.Double.toString));
         },
         acosWorks: function () {
             this.assertAlmostEqual(Math.acos(0.5), 1.0471975511965979);
@@ -18507,8 +18507,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(-4.0, Math.floor(-3.6));
         },
         floorOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.6).floor(), 3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal(-3.6).floor(), -4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.6).floor(), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3.0, System.Double, $box_.System.Double.toString));
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-3.6).floor(), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4.0, System.Double, $box_.System.Double.toString));
         },
         logWorks: function () {
             this.assertAlmostEqual(Math.log(0.5), -0.69314718055994529);
@@ -18518,8 +18518,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(5.0, Math.max(5, 3));
         },
         maxOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.max(System.Decimal(-14.5), System.Decimal(3.0)), 3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.max(System.Decimal(5.4), System.Decimal(3.0)), 5.4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.max(System.Decimal(-14.5), System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3.0, System.Double, $box_.System.Double.toString));
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.max(System.Decimal(5.4), System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), Bridge.box(5.4, System.Double, $box_.System.Double.toString));
         },
         maxOfDoubleWorks: function () {
             Bridge.Test.Assert.areEqual(3.0, Math.max(1.0, 3.0));
@@ -18562,8 +18562,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(3.0, Math.min(5, 3));
         },
         minOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.min(System.Decimal(-14.5), System.Decimal(3.0)), -14.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal.min(System.Decimal(5.4), System.Decimal(3.0)), 3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.min(System.Decimal(-14.5), System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-14.5, System.Double, $box_.System.Double.toString));
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.min(System.Decimal(5.4), System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3.0, System.Double, $box_.System.Double.toString));
         },
         minOfDoubleWorks: function () {
             Bridge.Test.Assert.areEqual(1.0, Math.min(1.0, 3.0));
@@ -18623,154 +18623,154 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(-4.0, Bridge.Math.round(-4.5, 0, 6));
         },
         roundDecimalWithModeWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 6), 4, "3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 6), 4, "3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 6), 3, "3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 6), -3, "-3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 6), -4, "-3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 6), -4, "-3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "-3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "-3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "-3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 0), 4, "Up 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 0), 4, "Up 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 0), 4, "Up 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 0), -4, "Up -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 0), -4, "Up -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 0), -4, "Up -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "Up 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "Up 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "Up 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "Up -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "Up -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "Up -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 1), 3, "Down 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 1), 3, "Down 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 1), 3, "Down 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 1), -3, "Down -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 1), -3, "Down -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 1), -3, "Down -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "Down 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "Down 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "Down 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "Down -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "Down -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "Down -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 2), 4, "InfinityPos 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 2), 4, "InfinityPos 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 2), 4, "InfinityPos 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 2), -3, "InfinityPos -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 2), -3, "InfinityPos -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 2), -3, "InfinityPos -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "InfinityPos 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "InfinityPos 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "InfinityPos 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "InfinityPos -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "InfinityPos -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "InfinityPos -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 3), 3, "InfinityNeg 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 3), 3, "InfinityNeg 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 3), 3, "InfinityNeg 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 3), -4, "InfinityNeg -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 3), -4, "InfinityNeg -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 3), -4, "InfinityNeg -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "InfinityNeg 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "InfinityNeg 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "InfinityNeg 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "InfinityNeg -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "InfinityNeg -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "InfinityNeg -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 5), 4, "TowardsZero 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 5), 3, "TowardsZero 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 5), 3, "TowardsZero 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 5), -3, "TowardsZero -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 5), -3, "TowardsZero -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 5), -4, "TowardsZero -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "TowardsZero 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "TowardsZero 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "TowardsZero 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "TowardsZero -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "TowardsZero -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "TowardsZero -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 4), 4, "AwayFromZero 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 4), 4, "AwayFromZero 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 4), 3, "AwayFromZero 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 4), -3, "AwayFromZero -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 4), -4, "AwayFromZero -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 4), -4, "AwayFromZero -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "AwayFromZero 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "AwayFromZero 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "AwayFromZero 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "AwayFromZero -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "AwayFromZero -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "AwayFromZero -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 7), 4, "Ceil 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 7), 4, "Ceil 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 7), 3, "Ceil 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 7), -3, "Ceil -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 7), -3, "Ceil -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 7), -4, "Ceil -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "Ceil 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "Ceil 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "Ceil 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "Ceil -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "Ceil -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "Ceil -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 8), 4, "Floor 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 8), 3, "Floor 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 8), 3, "Floor 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 8), -3, "Floor -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 8), -4, "Floor -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 8), -4, "Floor -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "Floor 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "Floor 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "Floor 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "Floor -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "Floor -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "Floor -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 6), 4, "ToEven 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 6), 4, "ToEven 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 6), 3, "ToEven 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 6), -3, "ToEven -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 6), -4, "ToEven -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 6), -4, "ToEven -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "ToEven 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(4, System.Int32), "ToEven 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(3, System.Int32), "ToEven 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-3, System.Int32), "ToEven -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "ToEven -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-4, System.Int32), "ToEven -3.8m");
         },
         roundDecimalWithPrecisionAndModeWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 6), System.Decimal(1.4), "Bridge584 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 6), System.Decimal(1.6), "Bridge584 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 6), System.Decimal(123.4568), "Bridge584 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 6), System.Decimal(123.456789), "Bridge584 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 6), System.Decimal(123.456789), "Bridge584 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 6), System.Decimal(-123.0), "Bridge584 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(1.4), System.Decimal, $box_.System.Decimal.toString), "Bridge584 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(1.6), System.Decimal, $box_.System.Decimal.toString), "Bridge584 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(123.4568), System.Decimal, $box_.System.Decimal.toString), "Bridge584 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(123.456789), System.Decimal, $box_.System.Decimal.toString), "Bridge584 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(123.456789), System.Decimal, $box_.System.Decimal.toString), "Bridge584 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal(-123.0), System.Decimal, $box_.System.Decimal.toString), "Bridge584 6");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 0), 1.5, "Bridge584 Up 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 0), 1.6, "Bridge584 Up 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 0), 123.4568, "Bridge584 Up 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 0), 123.456789, "Bridge584 Up 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 0), 123.456789, "Bridge584 Up 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 0), -124.0, "Bridge584 Up 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.5, System.Double, $box_.System.Double.toString), "Bridge584 Up 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.6, System.Double, $box_.System.Double.toString), "Bridge584 Up 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 Up 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 Up 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 Up 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-124.0, System.Double, $box_.System.Double.toString), "Bridge584 Up 6");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 4), 1.5, "Bridge584 AwayFromZero 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 4), 1.6, "Bridge584 AwayFromZero 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 4), 123.4568, "Bridge584 AwayFromZero 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 4), 123.456789, "Bridge584 AwayFromZero 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 4), 123.456789, "Bridge584 AwayFromZero 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 4), -123.0, "Bridge584 AwayFromZero 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.5, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.6, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 4), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-123.0, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 6");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 1), 1.4, "Bridge584 Down 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 1), 1.5, "Bridge584 Down 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 1), 123.4567, "Bridge584 Down 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 1), 123.456789, "Bridge584 Down 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 1), 123.456789, "Bridge584 Down 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 1), -123.0, "Bridge584 Down 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.4, System.Double, $box_.System.Double.toString), "Bridge584 Down 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.5, System.Double, $box_.System.Double.toString), "Bridge584 Down 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.4567, System.Double, $box_.System.Double.toString), "Bridge584 Down 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 Down 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 Down 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 1), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-123.0, System.Double, $box_.System.Double.toString), "Bridge584 Down 6");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 2), 1.5, "Bridge584 InfinityPos 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 2), 1.6, "Bridge584 InfinityPos 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 2), 123.4568, "Bridge584 InfinityPos 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 2), 123.456789, "Bridge584 InfinityPos 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 2), 123.456789, "Bridge584 InfinityPos 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 2), -123.0, "Bridge584 InfinityPos 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.5, System.Double, $box_.System.Double.toString), "Bridge584 InfinityPos 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.6, System.Double, $box_.System.Double.toString), "Bridge584 InfinityPos 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 InfinityPos 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 InfinityPos 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 InfinityPos 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 2), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-123.0, System.Double, $box_.System.Double.toString), "Bridge584 InfinityPos 6");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 3), 1.4, "Bridge584 InfinityNeg 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 3), 1.5, "Bridge584 InfinityNeg 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 3), 123.4567, "Bridge584 InfinityNeg 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 3), 123.456789, "Bridge584 InfinityNeg 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 3), 123.456789, "Bridge584 InfinityNeg 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 3), -124.0, "Bridge584 InfinityNeg 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.4, System.Double, $box_.System.Double.toString), "Bridge584 InfinityNeg 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.5, System.Double, $box_.System.Double.toString), "Bridge584 InfinityNeg 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.4567, System.Double, $box_.System.Double.toString), "Bridge584 InfinityNeg 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 InfinityNeg 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 InfinityNeg 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 3), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-124.0, System.Double, $box_.System.Double.toString), "Bridge584 InfinityNeg 6");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 5), 1.4, "Bridge584 TowardsZero 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 5), 1.5, "Bridge584 TowardsZero 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 5), 123.4568, "Bridge584 TowardsZero 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 5), 123.456789, "Bridge584 TowardsZero 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 5), 123.456789, "Bridge584 TowardsZero 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 5), -123.0, "Bridge584 TowardsZero 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.4, System.Double, $box_.System.Double.toString), "Bridge584 TowardsZero 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.5, System.Double, $box_.System.Double.toString), "Bridge584 TowardsZero 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 TowardsZero 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 TowardsZero 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 TowardsZero 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-123.0, System.Double, $box_.System.Double.toString), "Bridge584 TowardsZero 6");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 6), 1.4, "Bridge584 ToEven 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 6), 1.6, "Bridge584 ToEven 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 6), 123.4568, "Bridge584 ToEven 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 6), 123.456789, "Bridge584 ToEven 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 6), 123.456789, "Bridge584 ToEven 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 6), -123.0, "Bridge584 ToEven 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.4, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.6, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 6), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-123.0, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 6");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 7), 1.5, "Bridge584 Ceil 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 7), 1.6, "Bridge584 Ceil 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 7), 123.4568, "Bridge584 Ceil 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 7), 123.456789, "Bridge584 Ceil 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 7), 123.456789, "Bridge584 Ceil 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 7), -123.0, "Bridge584 Ceil 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.5, System.Double, $box_.System.Double.toString), "Bridge584 Ceil 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.6, System.Double, $box_.System.Double.toString), "Bridge584 Ceil 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 Ceil 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 Ceil 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 Ceil 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 7), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-123.0, System.Double, $box_.System.Double.toString), "Bridge584 Ceil 6");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 8), 1.4, "Bridge584 Floor 1");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 8), 1.5, "Bridge584 Floor 2");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 8), 123.4568, "Bridge584 Floor 3");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 8), 123.456789, "Bridge584 Floor 4");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 8), 123.456789, "Bridge584 Floor 5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 8), -123.0, "Bridge584 Floor 6");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.4, System.Double, $box_.System.Double.toString), "Bridge584 Floor 1");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(1.5, System.Double, $box_.System.Double.toString), "Bridge584 Floor 2");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 Floor 3");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 Floor 4");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 Floor 5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 8), System.Decimal, $box_.System.Decimal.toString), Bridge.box(-123.0, System.Double, $box_.System.Double.toString), "Bridge584 Floor 6");
         },
         roundDoubleWithModeWorks: function () {
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(3.8, 0, 6), 4, "3.8");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(3.5, 0, 6), 4, "3.5");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(3.2, 0, 6), 3, "3.2");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-3.2, 0, 6), -3, "-3.2");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-3.5, 0, 6), -4, "-3.5");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-3.8, 0, 6), -4, "-3.8");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(3.8, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(4, System.Int32), "3.8");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(3.5, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(4, System.Int32), "3.5");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(3.2, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(3, System.Int32), "3.2");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-3.2, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(-3, System.Int32), "-3.2");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-3.5, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(-4, System.Int32), "-3.5");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-3.8, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(-4, System.Int32), "-3.8");
 
             //AssertIsDoubleAndEqualTo(Math.Round(3.8, MidpointRounding.Up), 4, "Up 3.8");
             //AssertIsDoubleAndEqualTo(Math.Round(3.5, MidpointRounding.Up), 4, "Up 3.5");
@@ -18807,12 +18807,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             //AssertIsDoubleAndEqualTo(Math.Round(-3.5, MidpointRounding.TowardsZero), -3, "TowardsZero -3.5");
             //AssertIsDoubleAndEqualTo(Math.Round(-3.8, MidpointRounding.TowardsZero), -4, "TowardsZero -3.8");
 
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(3.8, 0, 4), 4, "AwayFromZero 3.8");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(3.5, 0, 4), 4, "AwayFromZero 3.5");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(3.2, 0, 4), 3, "AwayFromZero 3.2");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-3.2, 0, 4), -3, "AwayFromZero -3.2");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-3.5, 0, 4), -4, "AwayFromZero -3.5");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-3.8, 0, 4), -4, "AwayFromZero -3.8");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(3.8, 0, 4), System.Double, $box_.System.Double.toString), Bridge.box(4, System.Int32), "AwayFromZero 3.8");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(3.5, 0, 4), System.Double, $box_.System.Double.toString), Bridge.box(4, System.Int32), "AwayFromZero 3.5");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(3.2, 0, 4), System.Double, $box_.System.Double.toString), Bridge.box(3, System.Int32), "AwayFromZero 3.2");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-3.2, 0, 4), System.Double, $box_.System.Double.toString), Bridge.box(-3, System.Int32), "AwayFromZero -3.2");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-3.5, 0, 4), System.Double, $box_.System.Double.toString), Bridge.box(-4, System.Int32), "AwayFromZero -3.5");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-3.8, 0, 4), System.Double, $box_.System.Double.toString), Bridge.box(-4, System.Int32), "AwayFromZero -3.8");
 
             //AssertIsDoubleAndEqualTo(Math.Round(3.8, MidpointRounding.Ceil), 4, "Ceil 3.8");
             //AssertIsDoubleAndEqualTo(Math.Round(3.5, MidpointRounding.Ceil), 4, "Ceil 3.5");
@@ -18828,20 +18828,20 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             //AssertIsDoubleAndEqualTo(Math.Round(-3.5, MidpointRounding.Floor), -4, "Floor -3.5");
             //AssertIsDoubleAndEqualTo(Math.Round(-3.8, MidpointRounding.Floor), -4, "Floor -3.8");
 
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(3.8, 0, 6), 4, "ToEven 3.8");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(3.5, 0, 6), 4, "ToEven 3.5");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(3.2, 0, 6), 3, "ToEven 3.2");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-3.2, 0, 6), -3, "ToEven -3.2");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-3.5, 0, 6), -4, "ToEven -3.5");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-3.8, 0, 6), -4, "ToEven -3.8");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(3.8, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(4, System.Int32), "ToEven 3.8");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(3.5, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(4, System.Int32), "ToEven 3.5");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(3.2, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(3, System.Int32), "ToEven 3.2");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-3.2, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(-3, System.Int32), "ToEven -3.2");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-3.5, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(-4, System.Int32), "ToEven -3.5");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-3.8, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(-4, System.Int32), "ToEven -3.8");
         },
         roundDoubleWithPrecisionAndModeWorks: function () {
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(1.45, 1, 6), 1.4, "Bridge584 1");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(1.55, 1, 6), 1.6, "Bridge584 2");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(123.456789, 4, 6), 123.4568, "Bridge584 3");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(123.456789, 6, 6), 123.456789, "Bridge584 4");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(123.456789, 8, 6), 123.456789, "Bridge584 5");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-123.456, 0, 6), -123, "Bridge584 6");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(1.45, 1, 6), System.Double, $box_.System.Double.toString), Bridge.box(1.4, System.Double, $box_.System.Double.toString), "Bridge584 1");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(1.55, 1, 6), System.Double, $box_.System.Double.toString), Bridge.box(1.6, System.Double, $box_.System.Double.toString), "Bridge584 2");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(123.456789, 4, 6), System.Double, $box_.System.Double.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 3");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(123.456789, 6, 6), System.Double, $box_.System.Double.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 4");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(123.456789, 8, 6), System.Double, $box_.System.Double.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 5");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-123.456, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(-123, System.Int32), "Bridge584 6");
 
             //AssertIsDoubleAndEqualTo(Math.Round(1.45, 1, MidpointRounding.Up), 1.5, "Bridge584 Up 1");
             //AssertIsDoubleAndEqualTo(Math.Round(1.55, 1, MidpointRounding.Up), 1.6, "Bridge584 Up 2");
@@ -18850,12 +18850,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             //AssertIsDoubleAndEqualTo(Math.Round(123.456789, 8, MidpointRounding.Up), 123.456789, "Bridge584 Up 5");
             //AssertIsDoubleAndEqualTo(Math.Round(-123.456, 0, MidpointRounding.Up), -124.0, "Bridge584 Up 6");
 
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(1.45, 1, 4), 1.5, "Bridge584 AwayFromZero 1");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(1.55, 1, 4), 1.6, "Bridge584 AwayFromZero 2");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(123.456789, 4, 4), 123.4568, "Bridge584 AwayFromZero 3");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(123.456789, 6, 4), 123.456789, "Bridge584 AwayFromZero 4");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(123.456789, 8, 4), 123.456789, "Bridge584 AwayFromZero 5");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-123.456, 0, 4), -123.0, "Bridge584 AwayFromZero 6");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(1.45, 1, 4), System.Double, $box_.System.Double.toString), Bridge.box(1.5, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 1");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(1.55, 1, 4), System.Double, $box_.System.Double.toString), Bridge.box(1.6, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 2");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(123.456789, 4, 4), System.Double, $box_.System.Double.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 3");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(123.456789, 6, 4), System.Double, $box_.System.Double.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 4");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(123.456789, 8, 4), System.Double, $box_.System.Double.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 5");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-123.456, 0, 4), System.Double, $box_.System.Double.toString), Bridge.box(-123.0, System.Double, $box_.System.Double.toString), "Bridge584 AwayFromZero 6");
 
             //AssertIsDoubleAndEqualTo(Math.Round(1.45, 1, MidpointRounding.Down), 1.4, "Bridge584 Down 1");
             //AssertIsDoubleAndEqualTo(Math.Round(1.55, 1, MidpointRounding.Down), 1.5, "Bridge584 Down 2");
@@ -18885,12 +18885,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             //AssertIsDoubleAndEqualTo(Math.Round(123.456789, 8, MidpointRounding.TowardsZero), 123.456789, "Bridge584 TowardsZero 5");
             //AssertIsDoubleAndEqualTo(Math.Round(-123.456, 0, MidpointRounding.TowardsZero), -123.0, "Bridge584 TowardsZero 6");
 
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(1.45, 1, 6), 1.4, "Bridge584 ToEven 1");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(1.55, 1, 6), 1.6, "Bridge584 ToEven 2");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(123.456789, 4, 6), 123.4568, "Bridge584 ToEven 3");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(123.456789, 6, 6), 123.456789, "Bridge584 ToEven 4");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(123.456789, 8, 6), 123.456789, "Bridge584 ToEven 5");
-            this.assertIsDoubleAndEqualTo(Bridge.Math.round(-123.456, 0, 6), -123.0, "Bridge584 ToEven 6");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(1.45, 1, 6), System.Double, $box_.System.Double.toString), Bridge.box(1.4, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 1");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(1.55, 1, 6), System.Double, $box_.System.Double.toString), Bridge.box(1.6, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 2");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(123.456789, 4, 6), System.Double, $box_.System.Double.toString), Bridge.box(123.4568, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 3");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(123.456789, 6, 6), System.Double, $box_.System.Double.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 4");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(123.456789, 8, 6), System.Double, $box_.System.Double.toString), Bridge.box(123.456789, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 5");
+            this.assertIsDoubleAndEqualTo(Bridge.box(Bridge.Math.round(-123.456, 0, 6), System.Double, $box_.System.Double.toString), Bridge.box(-123.0, System.Double, $box_.System.Double.toString), "Bridge584 ToEven 6");
 
             //AssertIsDoubleAndEqualTo(Math.Round(1.45, 1, MidpointRounding.Ceil), 1.5, "Bridge584 Ceil 1");
             //AssertIsDoubleAndEqualTo(Math.Round(1.55, 1, MidpointRounding.Ceil), 1.6, "Bridge584 Ceil 2");
@@ -18925,7 +18925,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             this.assertAlmostEqual(Math.sin(0.5), 0.479425538604203);
         },
         sqrtWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).sqrt(), "1.7320508075688772935274463415");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).sqrt(), System.Decimal, $box_.System.Decimal.toString), "1.7320508075688772935274463415");
         },
         tanWorks: function () {
             this.assertAlmostEqual(Math.tan(0.5), 0.54630248984379048);
@@ -18955,7 +18955,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         getValueWorksForUninitializedElement: function () {
             var arr = System.Array.create(0, null, 2, 2);
-            Bridge.Test.Assert.areStrictEqual(0, System.Array.get(arr, 0, 0));
+            Bridge.Test.Assert.areStrictEqual(0, Bridge.unbox(System.Array.get(arr, 0, 0)));
         },
         getValueByIndexWorksForUninitializedElement: function () {
             var arr = System.Array.create(0, null, 2, 2);
@@ -19005,12 +19005,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         getValueWorks: function () {
             var arr = this.setUpArray([[1, 2], [3, 4], [5, 6]]);
-            Bridge.Test.Assert.areEqual(1, System.Array.get(arr, 0, 0));
-            Bridge.Test.Assert.areEqual(2, System.Array.get(arr, 0, 1));
-            Bridge.Test.Assert.areEqual(3, System.Array.get(arr, 1, 0));
-            Bridge.Test.Assert.areEqual(4, System.Array.get(arr, 1, 1));
-            Bridge.Test.Assert.areEqual(5, System.Array.get(arr, 2, 0));
-            Bridge.Test.Assert.areEqual(6, System.Array.get(arr, 2, 1));
+            Bridge.Test.Assert.areEqual(1, Bridge.unbox(System.Array.get(arr, 0, 0)));
+            Bridge.Test.Assert.areEqual(2, Bridge.unbox(System.Array.get(arr, 0, 1)));
+            Bridge.Test.Assert.areEqual(3, Bridge.unbox(System.Array.get(arr, 1, 0)));
+            Bridge.Test.Assert.areEqual(4, Bridge.unbox(System.Array.get(arr, 1, 1)));
+            Bridge.Test.Assert.areEqual(5, Bridge.unbox(System.Array.get(arr, 2, 0)));
+            Bridge.Test.Assert.areEqual(6, Bridge.unbox(System.Array.get(arr, 2, 1)));
         },
         gettingValueByIndexWorks: function () {
             var arr = this.setUpArray([[1, 2], [3, 4], [5, 6]]);
@@ -19194,13 +19194,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var a = 3, b = null;
             Bridge.Test.Assert.areEqual$1("System.Nullable$1[[Boolean]]", Bridge.Reflection.getTypeFullName(System.Nullable$1(Boolean)), "Open FullName");
             Bridge.Test.Assert.areEqual$1("System.Nullable$1[[System.Int32, mscorlib]]", Bridge.Reflection.getTypeFullName(System.Nullable$1(System.Int32)), "Instantiated FullName");
-            Bridge.Test.Assert.true$1(Bridge.is(a, System.Int32), "is int? #1");
-            Bridge.Test.Assert.false$1(Bridge.is(b, System.Int32), "is int? #2");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(a, System.Int32, $box_.System.Nullable$1.toString), System.Int32), "is int? #1");
+            Bridge.Test.Assert.false$1(Bridge.is(Bridge.box(b, System.Int32, $box_.System.Nullable$1.toString), System.Int32), "is int? #2");
 
-            Bridge.Test.Assert.true$1(this.isOfType(System.Nullable$1(System.Int32), 3), "IsOfType #1");
-            Bridge.Test.Assert.false$1(this.isOfType(System.Nullable$1(System.Int32), 3.14), "IsOfType #2");
-            Bridge.Test.Assert.true$1(this.isOfType(System.Nullable$1(System.TimeSpan), new System.TimeSpan(System.Int64(1))), "IsOfType #3");
-            Bridge.Test.Assert.false$1(this.isOfType(System.Nullable$1(System.TimeSpan), 3.14), "IsOfType #4");
+            Bridge.Test.Assert.true$1(this.isOfType(System.Nullable$1(System.Int32), Bridge.box(3, System.Int32)), "IsOfType #1");
+            Bridge.Test.Assert.false$1(this.isOfType(System.Nullable$1(System.Int32), Bridge.box(3.14, System.Double, $box_.System.Double.toString)), "IsOfType #2");
+            Bridge.Test.Assert.true$1(this.isOfType(System.Nullable$1(System.TimeSpan), Bridge.box(new System.TimeSpan(System.Int64(1)), System.TimeSpan)), "IsOfType #3");
+            Bridge.Test.Assert.false$1(this.isOfType(System.Nullable$1(System.TimeSpan), Bridge.box(3.14, System.Double, $box_.System.Double.toString)), "IsOfType #4");
         },
         convertingToNullableWorks: function () {
             var i = 3;
@@ -19216,8 +19216,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         boxingWorks: function () {
             var a = 3, b = null;
-            Bridge.Test.Assert.true(a != null);
-            Bridge.Test.Assert.false(b != null);
+            Bridge.Test.Assert.true(Bridge.box(a, System.Int32, $box_.System.Nullable$1.toString) != null);
+            Bridge.Test.Assert.false(Bridge.box(b, System.Int32, $box_.System.Nullable$1.toString) != null);
         },
         unboxingWorks: function () {
             var a = 3, b = null;
@@ -19421,7 +19421,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.apply($_.Bridge.ClientTest.NullableTests, {
         f1: function () {
             var o = "x";
-            var x = System.Nullable.getValue(Bridge.cast(o, System.Int32));
+            var x = System.Nullable.getValue(Bridge.cast(Bridge.unbox(o), System.Int32));
         }
     });
 
@@ -19434,7 +19434,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1("1: Frank", tempFrank, "Check call works");
 
             var options = { data: { name: c.temp } };
-            Bridge.Test.Assert.areEqual$1("Frank", options.data.name, "External referenced default ObjectLiteral works");
+            Bridge.Test.Assert.areEqual$1("Frank", Bridge.unbox(options.data.name), "External referenced default ObjectLiteral works");
 
             var bs = Bridge.ClientTest.ObjectLiteralTests.Bridge1529.BS.ctor();
             Bridge.Test.Assert.true(Bridge.isPlainObject(bs));
@@ -19900,17 +19900,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
                 for (var i = 0; i < Bridge.ClientTest.RandomTests.ITERATIONS; i = (i + 1) | 0) {
                     var x = r.next$1(20);
-                    Bridge.Test.Assert.true$1(x >= 0 && x < 20, x + " under 20 - Next(maxValue)");
+                    Bridge.Test.Assert.true$1(x >= 0 && x < 20, Bridge.box(x, System.Int32) + " under 20 - Next(maxValue)");
                 }
 
                 for (var i1 = 0; i1 < Bridge.ClientTest.RandomTests.ITERATIONS; i1 = (i1 + 1) | 0) {
                     var x1 = r.next$2(20, 30);
-                    Bridge.Test.Assert.true$1(x1 >= 20 && x1 < 30, x1 + " between 20 and 30 - Next(minValue, maxValue)");
+                    Bridge.Test.Assert.true$1(x1 >= 20 && x1 < 30, Bridge.box(x1, System.Int32) + " between 20 and 30 - Next(minValue, maxValue)");
                 }
 
                 for (var i2 = 0; i2 < Bridge.ClientTest.RandomTests.ITERATIONS; i2 = (i2 + 1) | 0) {
                     var x2 = r.nextDouble();
-                    Bridge.Test.Assert.true$1(x2 >= 0.0 && x2 < 1.0, System.Double.format(x2, 'G') + " between 0.0 and 1.0  - NextDouble()");
+                    Bridge.Test.Assert.true$1(x2 >= 0.0 && x2 < 1.0, System.Double.format(Bridge.box(x2, System.Double, $box_.System.Double.toString), 'G') + " between 0.0 and 1.0  - NextDouble()");
                 }
             },
             seeded: function () {
@@ -19941,7 +19941,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
                 for (var i = 0; i < Bridge.ClientTest.RandomTests.ITERATIONS; i = (i + 1) | 0) {
                     var d = r.exposeSample();
-                    Bridge.Test.Assert.true$1(d >= 0.0 && d < 1.0, System.Double.format(d, 'G') + " between 0.0 and 1.0  - ExposeSample()");
+                    Bridge.Test.Assert.true$1(d >= 0.0 && d < 1.0, System.Double.format(Bridge.box(d, System.Double, $box_.System.Double.toString), 'G') + " between 0.0 and 1.0  - ExposeSample()");
                 }
             }
         }
@@ -20073,7 +20073,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(a6.getH(), 49, "H");
             Bridge.Test.Assert.areEqual$1(a6.getE(), Bridge.ClientTest.Reflection.AttributeTests.E1.V1, "E");
             Bridge.Test.Assert.areEqual$1(a6.getS(), "Test_string", "S");
-            Bridge.Test.Assert.areEqual$1(a6.getO(), null, "O");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(a6.getO()), null, "O");
             Bridge.Test.Assert.areEqual$1(a6.getT(), String, "T");
         },
         arraysCanBeUsedAsAttributeArguments: function () {
@@ -20349,7 +20349,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             V1: "v1",
             V2: "v2"
         },
-        $utype: System.String
+        $utype: String
     });
 
     Bridge.define("Bridge.ClientTest.Reflection.AttributeTests.I1", {
@@ -21085,10 +21085,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Reflection.midel(m);
             }, "Without target without delegate type should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null);
+                Bridge.Reflection.midel(m, Bridge.unbox(null));
             }, "Null target with delegate type should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null);
+                Bridge.Reflection.midel(m, Bridge.unbox(null));
             }, "Null target without delegate type should throw");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, c, [String]);
@@ -21097,7 +21097,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Reflection.midel(m, null, [String]);
             }, "With type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, [String]);
+                Bridge.Reflection.midel(m, Bridge.unbox(null), [String]);
             }, "With type arguments with null target should throw");
         },
         delegateCreateDelegateWorksForNonGenericInstanceMethods: function () {
@@ -21109,8 +21109,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C8, 8, 284, "M2");
             var f1 = Bridge.Reflection.midel(m);
             var f2 = Bridge.Reflection.midel(m);
-            var f3 = Bridge.Reflection.midel(m, null);
-            var f4 = Bridge.Reflection.midel(m, null);
+            var f3 = Bridge.Reflection.midel(m, Bridge.unbox(null));
+            var f4 = Bridge.Reflection.midel(m, Bridge.unbox(null));
             Bridge.Test.Assert.areEqual$1(f1("a", "b"), "a b", "Delegate created with delegate type without target should be correct");
             Bridge.Test.Assert.areEqual$1(f2("c", "d"), "c d", "Delegate created without delegate type without target should be correct");
             Bridge.Test.Assert.areEqual$1(f3("e", "f"), "e f", "Delegate created with delegate type with null target should be correct");
@@ -21128,7 +21128,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Reflection.midel(m, null, [String]);
             }, "With type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, [String]);
+                Bridge.Reflection.midel(m, Bridge.unbox(null), [String]);
             }, "With type arguments with null target should throw");
         },
         createDelegateWorksNonGenericStaticMethodOfGenericType: function () {
@@ -21142,7 +21142,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var f = Bridge.Reflection.midel(m, c, [System.Int32, String]);
             Bridge.Test.Assert.areEqual$1(f("a"), "X System.Int32 String a", "Result of invoking delegate should be correct");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, [System.Int32, String]);
+                Bridge.Reflection.midel(m, Bridge.unbox(null), [System.Int32, String]);
             }, "Null target with correct type arguments should throw");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, c);
@@ -21159,30 +21159,30 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         createDelegateWorksForGenericStaticMethods: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C8, 8, 284, "M4");
-            var f = Bridge.Reflection.midel(m, null, [System.Int32, String]);
+            var f = Bridge.Reflection.midel(m, Bridge.unbox(null), [System.Int32, String]);
             Bridge.Test.Assert.areEqual$1(f("a"), "System.Int32 String a", "Result of invoking delegate should be correct");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, new Bridge.ClientTest.Reflection.ReflectionTests.C8(""), [System.Int32, String]);
             }, "Target with correct type arguments should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null);
+                Bridge.Reflection.midel(m, Bridge.unbox(null));
             }, "No type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, System.Array.init(0, null));
+                Bridge.Reflection.midel(m, Bridge.unbox(null), System.Array.init(0, null));
             }, "0 type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, System.Array.init(1, null));
+                Bridge.Reflection.midel(m, Bridge.unbox(null), System.Array.init(1, null));
             }, "1 type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, System.Array.init(3, null));
+                Bridge.Reflection.midel(m, Bridge.unbox(null), System.Array.init(3, null));
             }, "3 type arguments without target should throw");
         },
         invokeWorksForNonGenericInstanceMethods: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C8, 8, 284, "M1");
             var argsArr = ["c", "d"];
             var c = new Bridge.ClientTest.Reflection.ReflectionTests.C8("X");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(m, c)("a", "b"), "X a b", "Invoke with target should work");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(m, c).apply(null, argsArr), "X c d", "Invoke (non-expanded) with target should work");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(m, c)("a", "b")), "X a b", "Invoke with target should work");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(m, c).apply(null, argsArr)), "X c d", "Invoke (non-expanded) with target should work");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, null)("a", "b");
             }, "Invoke without target should throw");
@@ -21195,7 +21195,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         invokeWorksForNonGenericStaticMethods: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C8, 8, 284, "M2");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(m, null)("a", "b"), "a b", "Invoke without target should work");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(m, null)("a", "b")), "a b", "Invoke without target should work");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, new Bridge.ClientTest.Reflection.ReflectionTests.C8(""))("a", "b");
             }, "Invoke with target should throw");
@@ -21208,24 +21208,24 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         invokeWorksForNonGenericInstanceMethodsOnSerializableTypes: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C7, 8, 284, "M1");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(m, Bridge.merge(new Bridge.ClientTest.Reflection.ReflectionTests.C7(), {
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(m, Bridge.merge(new Bridge.ClientTest.Reflection.ReflectionTests.C7(), {
                     x: 13
-                } ))(14), 27, "Invoke should work");
+                } ))(14)), 27, "Invoke should work");
         },
         invokeWorksForNonGenericInlineCodeMethods: function () {
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C21, 8, 284, "M1"), new Bridge.ClientTest.Reflection.ReflectionTests.C21(14))(15, 16), 45, "Instance invoke should work");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C21, 8, 284, "M2"), null)(15, 16), 31, "Static invoke should work");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C21, 8, 284, "M1"), new Bridge.ClientTest.Reflection.ReflectionTests.C21(14))(15, 16)), 45, "Instance invoke should work");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C21, 8, 284, "M2"), null)(15, 16)), 31, "Static invoke should work");
         },
         invokeWorksForGenericInlineCodeMethods: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C21, 8, 284, "M3");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(m, new Bridge.ClientTest.Reflection.ReflectionTests.C21(42), [String])("World"), "42StringWorld", "Invoke should work");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(m, new Bridge.ClientTest.Reflection.ReflectionTests.C21(42), [String])("World")), "42StringWorld", "Invoke should work");
         },
         invokeWorksForGenericInstanceMethod: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C8, 8, 284, "M3");
             var argsArr = ["x"];
             var c = new Bridge.ClientTest.Reflection.ReflectionTests.C8("X");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(m, c, [System.Int32, String])("a"), "X System.Int32 String a", "Result of invoking delegate should be correct");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(m, c, [System.Int32, String]).apply(null, argsArr), "X System.Int32 String x", "Result of invoking delegate should be correct");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(m, c, [System.Int32, String])("a")), "X System.Int32 String a", "Result of invoking delegate should be correct");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(m, c, [System.Int32, String]).apply(null, argsArr)), "X System.Int32 String x", "Result of invoking delegate should be correct");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, null, [System.Int32, String])("a");
             }, "Null target with correct type arguments should throw");
@@ -21244,7 +21244,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         invokeWorksForGenericStaticMethod: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C8, 8, 284, "M4");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(m, null, [System.Int32, String])("a"), "System.Int32 String a", "Result of invoking delegate should be correct");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(m, null, [System.Int32, String])("a")), "System.Int32 String a", "Result of invoking delegate should be correct");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, new Bridge.ClientTest.Reflection.ReflectionTests.C8(""), [System.Int32, String])("a");
             }, "Target with correct type arguments should throw");
@@ -21263,18 +21263,18 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         invokeWorksForGenericInstanceMethodsOnSerializableTypes: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C7, 8, 284, "M3");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(m, Bridge.merge(new Bridge.ClientTest.Reflection.ReflectionTests.C7(), {
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(m, Bridge.merge(new Bridge.ClientTest.Reflection.ReflectionTests.C7(), {
                     x: 13
-                } ), [System.Int32, String])("Suffix"), "13 System.Int32 String Suffix", "Invoke should work");
+                } ), [System.Int32, String])("Suffix")), "13 System.Int32 String Suffix", "Invoke should work");
         },
         invokeWorksForExpandParamsMethods: function () {
             var m1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C22, 8, 284, "M2");
-            var r1 = Bridge.cast(Bridge.Reflection.midel(m1, new Bridge.ClientTest.Reflection.ReflectionTests.C22.ctor(0, null)).apply(null, [2, [17, 31]]), Array);
-            Bridge.Test.Assert.areEqual(r1, [2, [17, 31]]);
+            var r1 = Bridge.cast(Bridge.Reflection.midel(m1, new Bridge.ClientTest.Reflection.ReflectionTests.C22.ctor(0, null)).apply(null, [Bridge.box(2, System.Int32), [17, 31]]), Array);
+            Bridge.Test.Assert.areEqual(r1, [Bridge.box(2, System.Int32), [17, 31]]);
 
             var m2 = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C23, 8, 284, "M2");
-            var r2 = Bridge.cast(Bridge.Reflection.midel(m2, new Bridge.ClientTest.Reflection.ReflectionTests.C23.ctor(0, null)).apply(null, [2, [17, 32]]), Array);
-            Bridge.Test.Assert.areEqual(r2, [2, [17, 32]]);
+            var r2 = Bridge.cast(Bridge.Reflection.midel(m2, new Bridge.ClientTest.Reflection.ReflectionTests.C23.ctor(0, null)).apply(null, [Bridge.box(2, System.Int32), [17, 32]]), Array);
+            Bridge.Test.Assert.areEqual(r2, [Bridge.box(2, System.Int32), [17, 32]]);
         },
         invokeWorksForAllKindsOfConstructors: function () {
             var c1 = Bridge.cast(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C10, 31, 28).filter($_.Bridge.ClientTest.Reflection.ReflectionTests.f2)[0], System.Reflection.ConstructorInfo);
@@ -21297,18 +21297,18 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             var c20 = Bridge.cast(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C20, 31, 28)[0], System.Reflection.ConstructorInfo);
             var o5 = Bridge.Reflection.invokeCI(c20, [42, "Hello"]);
-            Bridge.Test.Assert.areDeepEqual(o5, { a: 42, b: "Hello" });
+            Bridge.Test.Assert.areDeepEqual(Bridge.unbox(o5), { a: 42, b: "Hello" });
         },
         invokeWorksForExpandParamsConstructors: function () {
             var c1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C22, 1, 284, null, [String, Array]);
             var o1 = Bridge.cast(Bridge.Reflection.invokeCI(c1, ["a", ["b", "c"]]), Bridge.ClientTest.Reflection.ReflectionTests.C22);
-            Bridge.Test.Assert.areEqual$1(o1.a, "a", "o1.a");
-            Bridge.Test.Assert.areEqual$1(o1.b, ["b", "c"], "o1.b");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(o1.a), "a", "o1.a");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(o1.b), ["b", "c"], "o1.b");
 
             var c2 = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C23, 1, 284, null, [String, Array]);
             var o2 = Bridge.cast(Bridge.Reflection.invokeCI(c2, ["a", ["b", "c"]]), Bridge.ClientTest.Reflection.ReflectionTests.C23);
-            Bridge.Test.Assert.areEqual$1(o2.a, "a", "o1.a");
-            Bridge.Test.Assert.areEqual$1(o2.b, ["b", "c"], "o1.b");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(o2.a), "a", "o1.a");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(o2.b), ["b", "c"], "o1.b");
         },
         memberTypeIsFieldForField: function () {
             Bridge.Test.Assert.areEqual$1(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C12, 4, 284, "F1").t, 4, "Instance");
@@ -21340,11 +21340,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var c = Bridge.merge(new Bridge.ClientTest.Reflection.ReflectionTests.C12(), {
                 F1: 42
             } );
-            Bridge.Test.Assert.areEqual(Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C12, 4, 284, "F1"), c), 42);
+            Bridge.Test.Assert.areEqual(Bridge.unbox(Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C12, 4, 284, "F1"), c)), 42);
         },
         getValueWorksForStaticField: function () {
             Bridge.ClientTest.Reflection.ReflectionTests.C12.F3 = "X_Test";
-            Bridge.Test.Assert.areEqual(Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C12, 4, 284, "F3"), null), "X_Test");
+            Bridge.Test.Assert.areEqual(Bridge.unbox(Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C12, 4, 284, "F3"), null)), "X_Test");
         },
         setValueWorksForInstanceField: function () {
             var c = new Bridge.ClientTest.Reflection.ReflectionTests.C12();
@@ -21639,21 +21639,21 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 setP1: 78
             } );
             var p1 = Bridge.Reflection.midel(m1, c)(null);
-            Bridge.Test.Assert.areEqual$1(p1, 78, "m1.Invoke");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(p1), 78, "m1.Invoke");
 
             Bridge.ClientTest.Reflection.ReflectionTests.C14.setP3(new Date(2012, 4 - 1, 2));
             var p2 = Bridge.Reflection.midel(m2, null)(null);
-            Bridge.Test.Assert.areEqual$1(p2, new Date(2012, 4 - 1, 2), "m2.Invoke");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(p2), new Date(2012, 4 - 1, 2), "m2.Invoke");
 
             c = Bridge.merge(new Bridge.ClientTest.Reflection.ReflectionTests.C14(), {
                 p13Field: 13
             } );
             var p3 = Bridge.Reflection.midel(m3, c)(null);
-            Bridge.Test.Assert.areEqual$1(p3, 13, "m3.Invoke");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(p3), 13, "m3.Invoke");
 
             Bridge.ClientTest.Reflection.ReflectionTests.C14.p14Field = 124;
             var p4 = Bridge.Reflection.midel(m4, null)(null);
-            Bridge.Test.Assert.areEqual$1(p4, 124, "m4.Invoke");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(p4), 124, "m4.Invoke");
         },
         propertiesForSetMethodAreCorrectForPropertyImplementedAsGetAndSetMethods: function () {
             var m1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C14, 16, 284, "P1").s;
@@ -21732,11 +21732,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 P2: "Hello, world"
             } );
             var p1 = Bridge.Reflection.midel(m1, c)(null);
-            Bridge.Test.Assert.areEqual$1(p1, "Hello, world", "m1.Invoke");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(p1), "Hello, world", "m1.Invoke");
 
             Bridge.ClientTest.Reflection.ReflectionTests.C14.P4 = 3.5;
             var p2 = Bridge.Reflection.midel(m2, null)(null);
-            Bridge.Test.Assert.areEqual$1(p2, 3.5, "m2.Invoke");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(p2), 3.5, "m2.Invoke");
         },
         propertiesForSetMethodAreCorrectForPropertyImplementedAsFields: function () {
             var m1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C14, 16, 284, "P2").s;
@@ -21796,13 +21796,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 v: "X"
             } );
             var v1 = Bridge.Reflection.midel(m1, c1)(42, "Hello");
-            Bridge.Test.Assert.areEqual$1(v1, "X 42 Hello", "m1.Invoke");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(v1), "X 42 Hello", "m1.Invoke");
 
             var c2 = Bridge.merge(new Bridge.ClientTest.Reflection.ReflectionTests.C24(), {
                 v: "Y"
             } );
             var v2 = Bridge.Reflection.midel(m2, c2)(24, "World");
-            Bridge.Test.Assert.areEqual$1(v2, "Y 24 World", "m2.Invoke");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(v2), "Y 24 World", "m2.Invoke");
         },
         propertiesForSetMethodAreCorrectForIndexer: function () {
             var m1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C15, 16, 284, "Item").s;
@@ -21920,15 +21920,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             } );
             Bridge.ClientTest.Reflection.ReflectionTests.C14.setP3(new Date(2013, 3 - 1, 5));
             Bridge.ClientTest.Reflection.ReflectionTests.C14.P4 = 7.5;
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(p1.g, c14)(), 42, "P1.GetValue");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(p2.g, c14)(), "Hello, world!", "P2.GetValue");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(p3.g, null)(), new Date(2013, 3 - 1, 5), "P3.GetValue");
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(p4.g, null)(), 7.5, "P4.GetValue");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(p1.g, c14)()), 42, "P1.GetValue");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(p2.g, c14)()), "Hello, world!", "P2.GetValue");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(p3.g, null)()), new Date(2013, 3 - 1, 5), "P3.GetValue");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(p4.g, null)()), 7.5, "P4.GetValue");
 
             var c15 = Bridge.merge(new Bridge.ClientTest.Reflection.ReflectionTests.C15(), {
                 v: "X"
             } );
-            Bridge.Test.Assert.areEqual$1(Bridge.Reflection.midel(i.g, c15).apply(null, [42, "Hello"]), "X 42 Hello", "Item.GetValue");
+            Bridge.Test.Assert.areEqual$1(Bridge.unbox(Bridge.Reflection.midel(i.g, c15).apply(null, [Bridge.box(42, System.Int32), "Hello"])), "X 42 Hello", "Item.GetValue");
         },
         propertyInfoSetValueWorks: function () {
             var p1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C14, 16, 284, "P1");
@@ -21951,7 +21951,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var c15 = Bridge.merge(new Bridge.ClientTest.Reflection.ReflectionTests.C15(), {
                 v: "X"
             } );
-            Bridge.Reflection.midel(i.s, c15).apply(null, [378, "X"].concat("The_value"));
+            Bridge.Reflection.midel(i.s, c15).apply(null, [Bridge.box(378, System.Int32), "X"].concat("The_value"));
             Bridge.Test.Assert.areEqual$1(c15.s, "X", "Item.SetValue.s");
             Bridge.Test.Assert.areEqual$1(c15.x, 378, "Item.SetValue.x");
             Bridge.Test.Assert.areEqual$1(c15.v, "The_value", "Item.SetValue.value");
@@ -22255,7 +22255,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         s: null,
         v: null,
         getItem: function (x, s) {
-            return System.String.concat(this.v, " ", x, " ", s);
+            return System.String.concat(this.v, " ", Bridge.box(x, System.Int32), " ", s);
         },
         setItem: function (x, s, value) {
             this.x = x;
@@ -22330,7 +22330,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             if (b === void 0) { b = []; }
 
             this.$initialize();
-            this.a = a;
+            this.a = Bridge.box(a, System.Int32);
             this.b = b;
         },
         $ctor1: function (a, b) {
@@ -22342,11 +22342,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         M1: function (a, b) {
             if (b === void 0) { b = []; }
-            return [a, b];
+            return [Bridge.box(a, System.Int32), b];
         },
         M2: function (a, b) {
             b = Array.prototype.slice.call(arguments, 1);
-            return [a, b];
+            return [Bridge.box(a, System.Int32), b];
         }
     });
 
@@ -22357,7 +22357,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             if (b === void 0) { b = []; }
 
             this.$initialize();
-            this.a = a;
+            this.a = Bridge.box(a, System.Int32);
             this.b = b;
         },
         $ctor1: function (a, b) {
@@ -22369,11 +22369,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         M1: function (a, b) {
             if (b === void 0) { b = []; }
-            return [a, b];
+            return [Bridge.box(a, System.Int32), b];
         },
         M2: function (a, b) {
             b = Array.prototype.slice.call(arguments, 1);
-            return [a, b];
+            return [Bridge.box(a, System.Int32), b];
         }
     });
 
@@ -22590,7 +22590,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         statics: {
             canConvert: function (T, arg) {
                 try {
-                    var x = Bridge.cast(arg, T);
+                    var x = Bridge.cast(Bridge.unbox(arg), T);
                     return x == null || x != null; // return true;
                 }
                 catch ($e1) {
@@ -22619,9 +22619,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(Bridge.is(new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.D4(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I3), "#17");
             Bridge.Test.Assert.true$1(Bridge.is(new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.D4(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I4), "#18");
             Bridge.Test.Assert.true$1(Bridge.is(new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X2(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I1), "#19");
-            Bridge.Test.Assert.true$1(Bridge.is((0), System.Int32), "#20");
-            Bridge.Test.Assert.true$1(Bridge.is((0), System.Int32), "#21");
-            Bridge.Test.Assert.true$1(Bridge.hasValue((0)), "#22");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box((0), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E2, $box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E2.toString), System.Int32), "#20");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box((0), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1.toString), System.Int32), "#21");
+            Bridge.Test.Assert.true$1(Bridge.hasValue(Bridge.box((0), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1.toString)), "#22");
             Bridge.Test.Assert.false$1(Bridge.is(new (Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1))(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I7$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1)), "#23");
             Bridge.Test.Assert.true$1(Bridge.is(new (Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1))(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1)), "#24");
             Bridge.Test.Assert.true$1(Bridge.is(new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.Y1X1(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1)), "#25");
@@ -22759,9 +22759,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1((Bridge.as(new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.D4(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I3)) != null, "#17");
             Bridge.Test.Assert.true$1((Bridge.as(new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.D4(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I4)) != null, "#18");
             Bridge.Test.Assert.true$1((Bridge.as(new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X2(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I1)) != null, "#19");
-            Bridge.Test.Assert.true$1((Bridge.as((0), System.Int32, true)) != null, "#20");
-            Bridge.Test.Assert.true$1((Bridge.as((0), System.Int32, true)) != null, "#21");
-            Bridge.Test.Assert.true$1(((0)) != null, "#22");
+            Bridge.Test.Assert.true$1((Bridge.as(Bridge.box((0), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E2, $box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E2.toString), System.Int32, true)) != null, "#20");
+            Bridge.Test.Assert.true$1((Bridge.as(Bridge.box((0), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1.toString), System.Int32, true)) != null, "#21");
+            Bridge.Test.Assert.true$1((Bridge.box((0), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1.toString)) != null, "#22");
             Bridge.Test.Assert.false$1((Bridge.as(new (Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1))(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I7$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1))) != null, "#23");
             Bridge.Test.Assert.true$1((Bridge.as(new (Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1))(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1))) != null, "#24");
             Bridge.Test.Assert.true$1((Bridge.as(new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.Y1X1(), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1))) != null, "#25");
@@ -22899,9 +22899,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I3, new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.D4()), "#17");
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I4, new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.D4()), "#18");
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I1, new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X2()), "#19");
-            Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, (0)), "#20");
-            Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(System.Int32, (0)), "#21");
-            Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Object, (0)), "#22");
+            Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, Bridge.box((0), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E2, $box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E2.toString)), "#20");
+            Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(System.Int32, Bridge.box((0), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1.toString)), "#21");
+            Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Object, Bridge.box((0), Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1.toString)), "#22");
             Bridge.Test.Assert.false$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I7$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1), new (Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1))()), "#23");
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1), new (Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1))()), "#24");
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.X1), new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.Y1X1()), "#25");
@@ -23034,12 +23034,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.throws($_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.f2);
         },
         cast: function (T, o) {
-            return Bridge.cast(o, T);
+            return Bridge.cast(Bridge.unbox(o), T);
         },
         castOperatorForSerializableTypeWithoutTypeCheckCodeAlwaysSucceedsGeneric: function () {
             var o = {  };
             var b = this.cast(Object, o);
-            Bridge.Test.Assert.true(Bridge.referenceEquals(o, b));
+            Bridge.Test.Assert.true(Bridge.referenceEquals(Bridge.unbox(o), b));
         },
         typeCheckForSubTypeOfGenericType: function () {
             var c12 = new Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.C12();
@@ -23489,9 +23489,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true(Bridge.Reflection.isInterface(Bridge.ClientTest.Reflection.TypeSystemTests.IG$1(System.Int32)));
         },
         isInstanceOfTypeWorksForReferenceTypes: function () {
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType({  }, Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#1");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox({  }), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#1");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1(), Object), "#2");
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType({  }, Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#3");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox({  }), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#3");
             Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1(), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.D1), "#4");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.D1(), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#5");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.D1(), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#6");
@@ -23514,9 +23514,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType((0), Object), "#23");
             Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(null, Object), "#24");
 
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType({  }, Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#25");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox({  }), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#25");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1(), Object), "#26");
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType({  }, Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#27");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox({  }), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#27");
             Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1(), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.D1), "#28");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.D1(), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#29");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.D1(), Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#30");
@@ -23711,7 +23711,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(Bridge.ClientTest.Reflection.TypeSystemTests.BX$1(Object), Bridge.ClientTest.Reflection.TypeSystemTests.BX$1(Object));
         },
         falseIsFunctionShouldReturnFalse: function () {
-            Bridge.Test.Assert.false(Bridge.is(false, Function));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(false, Boolean, $box_.Boolean.toString), Function));
         },
         castingUndefinedToOtherTypeShouldReturnUndefined: function () {
             Bridge.Test.Assert.areEqual(typeof Bridge.cast(undefined, Bridge.ClientTest.Reflection.TypeSystemTests.C), "undefined");
@@ -23730,7 +23730,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         instanceOfWorksForSerializableTypesWithCustomTypeCheckCode: function () {
             var o1 = new $_.$AnonymousType$29(1);
             var o2 = new $_.$AnonymousType$30(1, 2);
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(o1, Bridge.ClientTest.Reflection.TypeSystemTests.DS2), "o1 should not be of type");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox(o1), Bridge.ClientTest.Reflection.TypeSystemTests.DS2), "o1 should not be of type");
             //Assert.True (typeof(DS2).IsInstanceOfType(o2), "o2 should be of type");
         },
         staticGetTypeMethodWorks: function () {
@@ -23766,30 +23766,30 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             return Bridge.getDefaultValue(T);
         },
         castingToNamedValuesEnumCastsToString: function () {
-            Bridge.Test.Assert.true$1(Bridge.is("firstValue", String), "#1");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box("firstValue", Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, $box_.Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum.toString), String), "#1");
             Bridge.Test.Assert.true$1(Bridge.is("firstValue", String), "#2");
-            Bridge.Test.Assert.false$1(Bridge.is(0, String), "#3");
+            Bridge.Test.Assert.false$1(Bridge.is(Bridge.box(0, System.Int32), String), "#3");
             Bridge.Test.Assert.false$1(this.doesItThrow($_.Bridge.ClientTest.Reflection.TypeSystemTests.f2), "#4");
             Bridge.Test.Assert.true$1(this.doesItThrow($_.Bridge.ClientTest.Reflection.TypeSystemTests.f3), "#5");
 
-            Bridge.Test.Assert.notNull$1(Bridge.as("firstValue", String, true), "#6");
+            Bridge.Test.Assert.notNull$1(Bridge.as(Bridge.box("firstValue", Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, $box_.Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum.toString), String, true), "#6");
             Bridge.Test.Assert.notNull$1(Bridge.as("firstValue", String, true), "#7");
-            Bridge.Test.Assert.null$1(Bridge.as(0, String, true), "#8");
+            Bridge.Test.Assert.null$1(Bridge.as(Bridge.box(0, System.Int32), String, true), "#8");
 
-            Bridge.Test.Assert.true$1(this.isOfType(Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, "firstValue"), "#9");
+            Bridge.Test.Assert.true$1(this.isOfType(Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, Bridge.box("firstValue", Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, $box_.Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum.toString)), "#9");
             Bridge.Test.Assert.true$1(this.isOfType(Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, "firstValue"), "#10");
-            Bridge.Test.Assert.false$1(this.isOfType(Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, 0), "#11");
+            Bridge.Test.Assert.false$1(this.isOfType(Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, Bridge.box(0, System.Int32)), "#11");
         },
         castingToImportedNamedValuesEnumCastsToString: function () {
-            Bridge.Test.Assert.true$1(Bridge.is("firstValue", String), "#1");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box("firstValue", Bridge.ClientTest.Reflection.TypeSystemTests.ImportedNamedValuesEnum, $box_.Bridge.ClientTest.Reflection.TypeSystemTests.ImportedNamedValuesEnum.toString), String), "#1");
             Bridge.Test.Assert.true$1(Bridge.is("firstValue", String), "#2");
-            Bridge.Test.Assert.false$1(Bridge.is(0, String), "#3");
+            Bridge.Test.Assert.false$1(Bridge.is(Bridge.box(0, System.Int32), String), "#3");
             Bridge.Test.Assert.false$1(this.doesItThrow($_.Bridge.ClientTest.Reflection.TypeSystemTests.f2), "#4");
             Bridge.Test.Assert.true$1(this.doesItThrow($_.Bridge.ClientTest.Reflection.TypeSystemTests.f3), "#5");
 
-            Bridge.Test.Assert.notNull$1(Bridge.as("firstValue", String, true), "#6");
+            Bridge.Test.Assert.notNull$1(Bridge.as(Bridge.box("firstValue", Bridge.ClientTest.Reflection.TypeSystemTests.ImportedNamedValuesEnum, $box_.Bridge.ClientTest.Reflection.TypeSystemTests.ImportedNamedValuesEnum.toString), String, true), "#6");
             Bridge.Test.Assert.notNull$1(Bridge.as("firstValue", String, true), "#7");
-            Bridge.Test.Assert.null$1(Bridge.as(0, String, true), "#8");
+            Bridge.Test.Assert.null$1(Bridge.as(Bridge.box(0, System.Int32), String, true), "#8");
         },
         defaultValueOfNamedValuesEnumIsNull: function () {
             Bridge.Test.Assert.null$1(null, "#1");
@@ -23866,10 +23866,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             return _o5;
         },
         f2: function () {
-            var x = Bridge.cast("firstValue", String);
+            var x = Bridge.cast(Bridge.unbox("firstValue"), String);
         },
         f3: function () {
-            var x = Bridge.cast(0, String);
+            var x = Bridge.cast(Bridge.unbox(Bridge.box(0, System.Int32)), String);
         }
     });
 
@@ -23894,7 +23894,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         messageB: null,
         ctor: function (x, y) {
             this.$initialize();
-            this.messageB = x + " " + y;
+            this.messageB = Bridge.box(x, System.Int32) + " " + Bridge.box(y, System.Int32);
         }
     });
 
@@ -23914,7 +23914,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         messageB: null,
         ctor: function (x, y) {
             this.$initialize();
-            this.messageB = x + " " + y;
+            this.messageB = Bridge.box(x, System.Int32) + " " + Bridge.box(y, System.Int32);
         }
     });
 
@@ -23990,7 +23990,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             firstValue: "firstValue",
             secondValue: "secondValue"
         },
-        $utype: System.String
+        $utype: String
     });
 
     Bridge.define("Bridge.ClientTest.Reflection.TypeSystemTests.IsAssignableFromTypes");
@@ -24048,7 +24048,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             return ((((x + y) | 0) + this.m) | 0);
         },
         g: function (T, x, y) {
-            return System.String.concat(((((x + y) | 0) + this.m) | 0), Bridge.Reflection.getTypeName(T));
+            return System.String.concat(Bridge.box(((((x + y) | 0) + this.m) | 0), System.Int32), Bridge.Reflection.getTypeName(T));
         }
     });
 
@@ -24062,7 +24062,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             return ((((x + y) | 0) + this.m) | 0);
         },
         g: function (T, x, y) {
-            return System.String.concat(((((x + y) | 0) + this.m) | 0), Bridge.Reflection.getTypeName(T));
+            return System.String.concat(Bridge.box(((((x + y) | 0) + this.m) | 0), System.Int32), Bridge.Reflection.getTypeName(T));
         },
         getF: function () {
             return Bridge.fn.bind(this, this.f);
@@ -24078,12 +24078,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             firstValue: "firstValue",
             secondValue: "secondValue"
         },
-        $utype: System.String
+        $utype: String
     });
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.BooleanTests", {
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(true, Boolean));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(true, Boolean, $box_.Boolean.toString), Boolean));
             Bridge.Test.Assert.areEqual("Boolean", Bridge.Reflection.getTypeFullName(Boolean));
         },
         getDefaultValue: function (T) {
@@ -24104,10 +24104,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((true)), Bridge.getHashCode((false)));
         },
         objectEqualsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((true), true));
-            Bridge.Test.Assert.false(Bridge.equals((true), false));
-            Bridge.Test.Assert.false(Bridge.equals((false), true));
-            Bridge.Test.Assert.true(Bridge.equals((false), false));
+            Bridge.Test.Assert.true(Bridge.equals((true), Bridge.unbox(Bridge.box(true, Boolean, $box_.Boolean.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((true), Bridge.unbox(Bridge.box(false, Boolean, $box_.Boolean.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((false), Bridge.unbox(Bridge.box(true, Boolean, $box_.Boolean.toString))));
+            Bridge.Test.Assert.true(Bridge.equals((false), Bridge.unbox(Bridge.box(false, Boolean, $box_.Boolean.toString))));
         },
         boolEqualsWorks: function () {
             Bridge.Test.Assert.true((true) === true);
@@ -24314,8 +24314,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var result = { };
 
             var returnValue = System.Boolean.tryParse(value, result);
-            Bridge.Test.Assert.areEqual$1(expectedReturn, returnValue, System.String.concat(i + " Return value: ", value));
-            Bridge.Test.Assert.areEqual$1(expectedResult, result.v, System.String.concat(i + " Result: ", value));
+            Bridge.Test.Assert.areEqual$1(expectedReturn, returnValue, System.String.concat(Bridge.box(i, System.Int32) + " Return value: ", value));
+            Bridge.Test.Assert.areEqual$1(expectedResult, result.v, System.String.concat(Bridge.box(i, System.Int32) + " Result: ", value));
         }
     });
 
@@ -24379,12 +24379,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.ByteTests", {
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.Byte));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Byte));
-            Bridge.Test.Assert.false(Bridge.is(-1, System.Byte));
-            Bridge.Test.Assert.false(Bridge.is(256, System.Byte));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.Byte), System.Byte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Byte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-1, System.Int32), System.Byte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(256, System.Int32), System.Byte));
             Bridge.Test.Assert.areEqual("System.Byte", Bridge.Reflection.getTypeFullName(System.Byte));
-            var b = 0;
+            var b = Bridge.box(0, System.Byte);
             Bridge.Test.Assert.true(Bridge.is(b, System.Byte));
             Bridge.Test.Assert.true(Bridge.is(b, System.IComparable$1(System.Byte)));
             Bridge.Test.Assert.true(Bridge.is(b, System.IEquatable$1(System.Byte)));
@@ -24502,10 +24502,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.Byte))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.Byte))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.Byte))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.Byte))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -24558,10 +24558,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.CharTests", {
         typePropertiesAreInt32: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.Char));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Char));
-            Bridge.Test.Assert.false(Bridge.is(-1, System.Char));
-            Bridge.Test.Assert.false(Bridge.is(65536, System.Char));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0, System.Int32), System.Char));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Char));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-1, System.Int32), System.Char));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(65536, System.Int32), System.Char));
             Bridge.Test.Assert.areEqual("System.Char", Bridge.Reflection.getTypeFullName(System.Char));
         },
         castsWork: function () {
@@ -24739,9 +24739,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areStrictEqual$1(System.Double.format(d, 'G'), v.toString(), message);
         },
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(System.Decimal(0.5), System.Decimal));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(System.Decimal(0.5), System.Decimal, $box_.System.Decimal.toString), System.Decimal));
             Bridge.Test.Assert.areEqual("System.Decimal", Bridge.Reflection.getTypeFullName(System.Decimal));
-            var d = System.Decimal(0.0);
+            var d = Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString);
             Bridge.Test.Assert.true(Bridge.is(d, System.Decimal));
             Bridge.Test.Assert.true(Bridge.is(d, System.IFormattable));
         },
@@ -24749,26 +24749,26 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             return Bridge.getDefaultValue(T);
         },
         defaultValueIs0: function () {
-            this.assertIsDecimalAndEqualTo(this.getDefaultValue(System.Decimal), 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(this.getDefaultValue(System.Decimal), System.Decimal, $box_.System.Decimal.toString), 0);
         },
         creatingInstanceReturnsZero: function () {
-            this.assertIsDecimalAndEqualTo(Bridge.createInstance(System.Decimal), 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(Bridge.createInstance(System.Decimal), System.Decimal, $box_.System.Decimal.toString), 0);
         },
         constantsWork: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.One, 1);
-            this.assertIsDecimalAndEqualTo(System.Decimal.Zero, 0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.MinusOne, -1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.One, System.Decimal, $box_.System.Decimal.toString), 1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.Zero, System.Decimal, $box_.System.Decimal.toString), 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), -1);
         },
         defaultConstructorReturnsZero: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(0), 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(0), System.Decimal, $box_.System.Decimal.toString), 0);
         },
         convertingConstructorsWork: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(0.5), 0.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal(1.5), 1.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal(2), 2);
-            this.assertIsDecimalAndEqualTo(System.Decimal(System.Int64(3)), 3);
-            this.assertIsDecimalAndEqualTo(System.Decimal(4), 4);
-            this.assertIsDecimalAndEqualTo(System.Decimal(System.UInt64(5)), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(0.5), System.Decimal, $box_.System.Decimal.toString), 0.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(1.5), System.Decimal, $box_.System.Decimal.toString), 1.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(2), System.Decimal, $box_.System.Decimal.toString), 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(System.Int64(3)), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4), System.Decimal, $box_.System.Decimal.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(System.UInt64(5)), System.Decimal, $box_.System.Decimal.toString), 5);
         },
         formatWorks: function () {
             Bridge.Test.Assert.areEqual("123", Bridge.Int.format(System.Decimal(291.0), "x"));
@@ -24781,12 +24781,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         addWithStringWorks: function () {
             var d1 = System.Decimal(1.0);
-            var s1 = System.Nullable.toString(d1) + "#";
+            var s1 = System.Nullable.toString(Bridge.box(d1, System.Decimal, $box_.System.Nullable$1.toString)) + "#";
 
             Bridge.Test.Assert.areEqual$1("1#", s1, "decimal?");
 
             var d2 = System.Decimal(2.0);
-            var s2 = Bridge.Int.format(d2, 'G') + "!";
+            var s2 = Bridge.Int.format(Bridge.box(d2, System.Decimal, $box_.System.Decimal.toString), 'G') + "!";
 
             Bridge.Test.Assert.areEqual$1("2!", s2, "decimal");
         },
@@ -24821,17 +24821,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         operatorsWork: function () {
             var $t;
             var x = System.Decimal(3);
-            this.assertIsDecimalAndEqualTo(x.clone(), 3);
-            this.assertIsDecimalAndEqualTo(x.neg(), -3);
-            this.assertIsDecimalAndEqualTo(x.add(System.Decimal(4.0)), 7);
-            this.assertIsDecimalAndEqualTo(x.sub(System.Decimal(2.0)), 1);
-            this.assertIsDecimalAndEqualTo(($t = x, x = x.inc(), $t), 3);
-            this.assertIsDecimalAndEqualTo((x = x.inc()), 5);
-            this.assertIsDecimalAndEqualTo(($t = x, x = x.dec(), $t), 5);
-            this.assertIsDecimalAndEqualTo((x = x.dec()), 3);
-            this.assertIsDecimalAndEqualTo(x.mul(System.Decimal(3.0)), 9);
-            this.assertIsDecimalAndEqualTo(x.div(System.Decimal(2.0)), 1.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal(14.0).mod(x), 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.clone(), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.neg(), System.Decimal, $box_.System.Decimal.toString), -3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.add(System.Decimal(4.0)), System.Decimal, $box_.System.Decimal.toString), 7);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.sub(System.Decimal(2.0)), System.Decimal, $box_.System.Decimal.toString), 1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(($t = x, x = x.inc(), $t), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box((x = x.inc()), System.Decimal, $box_.System.Decimal.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(($t = x, x = x.dec(), $t), System.Decimal, $box_.System.Decimal.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box((x = x.dec()), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.mul(System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), 9);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.div(System.Decimal(2.0)), System.Decimal, $box_.System.Decimal.toString), 1.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(14.0).mod(x), System.Decimal, $box_.System.Decimal.toString), 2);
             Bridge.Test.Assert.true(x.equalsT(System.Decimal(3.0)));
             Bridge.Test.Assert.false(x.equalsT(System.Decimal(4.0)));
             Bridge.Test.Assert.false(x.ne(System.Decimal(3.0)));
@@ -24849,92 +24849,92 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areDeepEqual(System.Decimal(7.0), System.Decimal(3.0).add(System.Decimal(4.0)));
         },
         ceilingWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.4).ceil(), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.4).ceil(), System.Decimal, $box_.System.Decimal.toString), 4);
         },
         divideWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).div(System.Decimal(4.0)), 0.75);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).div(System.Decimal(4.0)), System.Decimal, $box_.System.Decimal.toString), 0.75);
         },
         floorWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.2).floor(), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.2).floor(), System.Decimal, $box_.System.Decimal.toString), 3);
         },
         remainderWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(14.0).mod(System.Decimal(3.0)), 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(14.0).mod(System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), 2);
         },
         multiplyWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).mul(System.Decimal(2.0)), 6);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).mul(System.Decimal(2.0)), System.Decimal, $box_.System.Decimal.toString), 6);
         },
         negateWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(0).sub(System.Decimal(3.0)), -3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(0).sub(System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), -3);
         },
         roundWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 6), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 6), System.Decimal, $box_.System.Decimal.toString), 3);
         },
         roundWithModeWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 0), 4, "Up 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 0), 4, "Up 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 0), 4, "Up 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 0), -4, "Up -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 0), -4, "Up -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 0), -4, "Up -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 0), System.Decimal, $box_.System.Decimal.toString), 4, "Up 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 0), System.Decimal, $box_.System.Decimal.toString), 4, "Up 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 0), System.Decimal, $box_.System.Decimal.toString), 4, "Up 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 0), System.Decimal, $box_.System.Decimal.toString), -4, "Up -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 0), System.Decimal, $box_.System.Decimal.toString), -4, "Up -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 0), System.Decimal, $box_.System.Decimal.toString), -4, "Up -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 1), 3, "Down 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 1), 3, "Down 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 1), 3, "Down 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 1), -3, "Down -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 1), -3, "Down -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 1), -3, "Down -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 1), System.Decimal, $box_.System.Decimal.toString), 3, "Down 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 1), System.Decimal, $box_.System.Decimal.toString), 3, "Down 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 1), System.Decimal, $box_.System.Decimal.toString), 3, "Down 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 1), System.Decimal, $box_.System.Decimal.toString), -3, "Down -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 1), System.Decimal, $box_.System.Decimal.toString), -3, "Down -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 1), System.Decimal, $box_.System.Decimal.toString), -3, "Down -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 2), 4, "InfinityPos 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 2), 4, "InfinityPos 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 2), 4, "InfinityPos 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 2), -3, "InfinityPos -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 2), -3, "InfinityPos -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 2), -3, "InfinityPos -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 2), System.Decimal, $box_.System.Decimal.toString), 4, "InfinityPos 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 2), System.Decimal, $box_.System.Decimal.toString), 4, "InfinityPos 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 2), System.Decimal, $box_.System.Decimal.toString), 4, "InfinityPos 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 2), System.Decimal, $box_.System.Decimal.toString), -3, "InfinityPos -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 2), System.Decimal, $box_.System.Decimal.toString), -3, "InfinityPos -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 2), System.Decimal, $box_.System.Decimal.toString), -3, "InfinityPos -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 3), 3, "InfinityNeg 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 3), 3, "InfinityNeg 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 3), 3, "InfinityNeg 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 3), -4, "InfinityNeg -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 3), -4, "InfinityNeg -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 3), -4, "InfinityNeg -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 3), System.Decimal, $box_.System.Decimal.toString), 3, "InfinityNeg 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 3), System.Decimal, $box_.System.Decimal.toString), 3, "InfinityNeg 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 3), System.Decimal, $box_.System.Decimal.toString), 3, "InfinityNeg 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 3), System.Decimal, $box_.System.Decimal.toString), -4, "InfinityNeg -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 3), System.Decimal, $box_.System.Decimal.toString), -4, "InfinityNeg -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 3), System.Decimal, $box_.System.Decimal.toString), -4, "InfinityNeg -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 5), 4, "TowardsZero 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 5), 3, "TowardsZero 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 5), 3, "TowardsZero 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 5), -3, "TowardsZero -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 5), -3, "TowardsZero -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 5), -4, "TowardsZero -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 5), System.Decimal, $box_.System.Decimal.toString), 4, "TowardsZero 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 5), System.Decimal, $box_.System.Decimal.toString), 3, "TowardsZero 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 5), System.Decimal, $box_.System.Decimal.toString), 3, "TowardsZero 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 5), System.Decimal, $box_.System.Decimal.toString), -3, "TowardsZero -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 5), System.Decimal, $box_.System.Decimal.toString), -3, "TowardsZero -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 5), System.Decimal, $box_.System.Decimal.toString), -4, "TowardsZero -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 4), 4, "AwayFromZero 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 4), 4, "AwayFromZero 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 4), 3, "AwayFromZero 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 4), -3, "AwayFromZero -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 4), -4, "AwayFromZero -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 4), -4, "AwayFromZero -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 4), System.Decimal, $box_.System.Decimal.toString), 4, "AwayFromZero 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 4), System.Decimal, $box_.System.Decimal.toString), 4, "AwayFromZero 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 4), System.Decimal, $box_.System.Decimal.toString), 3, "AwayFromZero 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 4), System.Decimal, $box_.System.Decimal.toString), -3, "AwayFromZero -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 4), System.Decimal, $box_.System.Decimal.toString), -4, "AwayFromZero -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 4), System.Decimal, $box_.System.Decimal.toString), -4, "AwayFromZero -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 7), 4, "Ceil 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 7), 4, "Ceil 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 7), 3, "Ceil 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 7), -3, "Ceil -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 7), -3, "Ceil -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 7), -4, "Ceil -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 7), System.Decimal, $box_.System.Decimal.toString), 4, "Ceil 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 7), System.Decimal, $box_.System.Decimal.toString), 4, "Ceil 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 7), System.Decimal, $box_.System.Decimal.toString), 3, "Ceil 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 7), System.Decimal, $box_.System.Decimal.toString), -3, "Ceil -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 7), System.Decimal, $box_.System.Decimal.toString), -3, "Ceil -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 7), System.Decimal, $box_.System.Decimal.toString), -4, "Ceil -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 8), 4, "Floor 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 8), 3, "Floor 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 8), 3, "Floor 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 8), -3, "Floor -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 8), -4, "Floor -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 8), -4, "Floor -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 8), System.Decimal, $box_.System.Decimal.toString), 4, "Floor 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 8), System.Decimal, $box_.System.Decimal.toString), 3, "Floor 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 8), System.Decimal, $box_.System.Decimal.toString), 3, "Floor 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 8), System.Decimal, $box_.System.Decimal.toString), -3, "Floor -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 8), System.Decimal, $box_.System.Decimal.toString), -4, "Floor -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 8), System.Decimal, $box_.System.Decimal.toString), -4, "Floor -3.8m");
 
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.8), 6), 4, "ToEven 3.8m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 6), 4, "ToEven 3.5m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 6), 3, "ToEven 3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.2), 6), -3, "ToEven -3.2m");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 6), -4, "ToEven -3.5");
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.8), 6), -4, "ToEven -3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.8), 6), System.Decimal, $box_.System.Decimal.toString), 4, "ToEven 3.8m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 6), System.Decimal, $box_.System.Decimal.toString), 4, "ToEven 3.5m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 6), System.Decimal, $box_.System.Decimal.toString), 3, "ToEven 3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.2), 6), System.Decimal, $box_.System.Decimal.toString), -3, "ToEven -3.2m");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 6), System.Decimal, $box_.System.Decimal.toString), -4, "ToEven -3.5");
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.8), 6), System.Decimal, $box_.System.Decimal.toString), -4, "ToEven -3.8m");
         },
         subtractWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(7.0).sub(System.Decimal(3.0)), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(7.0).sub(System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), 4);
         },
         getHashCodeWorks: function () {
             Bridge.Test.Assert.areDeepEqual(Bridge.getHashCode((System.Decimal(0.0))), Bridge.getHashCode((System.Decimal(0.0))));
@@ -24943,11 +24943,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((System.Decimal(0.5))), Bridge.getHashCode((System.Decimal(0.0))));
         },
         objectEqualsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((System.Decimal(0.0)), System.Decimal(0.0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(1.0)), System.Decimal(0.0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(0.0)), System.Decimal(0.5)));
-            Bridge.Test.Assert.true(Bridge.equals((System.Decimal(1.0)), System.Decimal(1.0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(0.0)), System.Decimal.MaxValue));
+            Bridge.Test.Assert.true(Bridge.equals((System.Decimal(0.0)), Bridge.unbox(Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(1.0)), Bridge.unbox(Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(0.0)), Bridge.unbox(Bridge.box(System.Decimal(0.5), System.Decimal, $box_.System.Decimal.toString))));
+            Bridge.Test.Assert.true(Bridge.equals((System.Decimal(1.0)), Bridge.unbox(Bridge.box(System.Decimal(1.0), System.Decimal, $box_.System.Decimal.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(0.0)), Bridge.unbox(Bridge.box(System.Decimal.MaxValue, System.Decimal, $box_.System.Decimal.toString))));
         },
         decimalEqualsWorks: function () {
             Bridge.Test.Assert.true((System.Decimal(0.0)).equalsT(System.Decimal(0.0)));
@@ -24972,27 +24972,27 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var a = System.Decimal(1.0);
             var b = a.equalsT(System.Decimal(1.0)) ? System.Decimal(2.0) : System.Decimal(3.0);
 
-            this.assertIsDecimalAndEqualTo(b, 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(b, System.Decimal, $box_.System.Decimal.toString), 2);
         },
         shortCoalesceWorks: function () {
             var $t, $t1;
-            var c = System.Decimal(1.0);
-            var d = ($t = c, $t != null ? $t : System.Decimal(2.0));
+            var c = Bridge.box(System.Decimal(1.0), System.Decimal, $box_.System.Decimal.toString);
+            var d = ($t = c, $t != null ? $t : Bridge.box(System.Decimal(2.0), System.Decimal, $box_.System.Decimal.toString));
 
             this.assertIsDecimalAndEqualTo(d, 1);
 
             var e = System.Decimal(3);
             var f = ($t1 = e, $t1 != null ? $t1 : System.Decimal(0));
 
-            this.assertIsDecimalAndEqualTo(f, 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(f, System.Decimal, $box_.System.Decimal.toString), 3);
         }
     });
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.DoubleTests", {
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(0.5, System.Double));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Double));
             Bridge.Test.Assert.areEqual("System.Double", Bridge.Reflection.getTypeFullName(System.Double));
-            var d = 0.0;
+            var d = Bridge.box(0.0, System.Double, $box_.System.Double.toString);
             Bridge.Test.Assert.true(Bridge.is(d, System.Double));
             Bridge.Test.Assert.true(Bridge.is(d, System.IFormattable));
         },
@@ -25007,7 +25007,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         constantsWork: function () {
             var zero = 0;
-            Bridge.Test.Assert.true$1(System.Double.max > System.Nullable.getValue(Bridge.cast(1.7E+308, System.Double)), "MaxValue should be correct");
+            Bridge.Test.Assert.true$1(System.Double.max > System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(1.7E+308, System.Double, $box_.System.Double.toString)), System.Double)), "MaxValue should be correct");
             Bridge.Test.Assert.areEqual$1(4.94065645841247E-324, 4.94065645841247E-324, "MinValue should be correct");
             Bridge.Test.Assert.true$1(isNaN(Number.NaN), "NaN should be correct");
             Bridge.Test.Assert.areStrictEqual$1(1 / zero, Number.POSITIVE_INFINITY, "PositiveInfinity should be correct");
@@ -25082,10 +25082,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((0.5)), Bridge.getHashCode((0.0)));
         },
         objectEqualsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0.0), 0.0));
-            Bridge.Test.Assert.false(Bridge.equals((1.0), 0.0));
-            Bridge.Test.Assert.false(Bridge.equals((0.0), 0.5));
-            Bridge.Test.Assert.true(Bridge.equals((1.0), 1.0));
+            Bridge.Test.Assert.true(Bridge.equals((0.0), Bridge.unbox(Bridge.box(0.0, System.Double, $box_.System.Double.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((1.0), Bridge.unbox(Bridge.box(0.0, System.Double, $box_.System.Double.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((0.0), Bridge.unbox(Bridge.box(0.5, System.Double, $box_.System.Double.toString))));
+            Bridge.Test.Assert.true(Bridge.equals((1.0), Bridge.unbox(Bridge.box(1.0, System.Double, $box_.System.Double.toString))));
         },
         doubleEqualsWorks: function () {
             Bridge.Test.Assert.true((0.0) === 0.0);
@@ -25111,7 +25111,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         typePropertiesAreCorrect: function () {
             //Assert.AreEqual("System.Enum", typeof(Enum).FullName);
             Bridge.Test.Assert.areEqual("Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum", Bridge.Reflection.getTypeFullName(Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum));
-            Bridge.Test.Assert.true(Bridge.is(Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum.FirstValue, System.Int32));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum.FirstValue, Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum, $box_.Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum.toString), System.Int32));
         },
         getDefaultValue: function (T) {
             return Bridge.getDefaultValue(T);
@@ -25123,7 +25123,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areStrictEqual(Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum.FirstValue, this.getDefaultValue(Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum));
         },
         defaultConstructorOfEnumTypeReturnsZero: function () {
-            Bridge.Test.Assert.areStrictEqual(0, (0).valueOf());
+            Bridge.Test.Assert.areStrictEqual(0, Bridge.unbox((0).valueOf()));
         },
         firstValueOfEnumIsZero: function () {
             Bridge.Test.Assert.areStrictEqual(Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum.FirstValue, Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum.FirstValue);
@@ -25166,13 +25166,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.Int16Tests", {
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.Int16));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Int16));
-            Bridge.Test.Assert.false(Bridge.is(-32769, System.Int16));
-            Bridge.Test.Assert.false(Bridge.is(32768, System.Int16));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.Int16), System.Int16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Int16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-32769, System.Int32), System.Int16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(32768, System.Int32), System.Int16));
             Bridge.Test.Assert.areEqual("System.Int16", Bridge.Reflection.getTypeFullName(System.Int16));
 
-            var s = 0;
+            var s = Bridge.box(0, System.Int16);
             Bridge.Test.Assert.true(Bridge.is(s, System.Int16));
             Bridge.Test.Assert.true(Bridge.is(s, System.IComparable$1(System.Int16)));
             Bridge.Test.Assert.true(Bridge.is(s, System.IEquatable$1(System.Int16)));
@@ -25290,10 +25290,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.Int16))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.Int16))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.Int16))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.Int16))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -25346,13 +25346,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.Int32Tests", {
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.Int32));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Int32));
-            Bridge.Test.Assert.false(Bridge.is(System.Int64([2147483647,-1]), System.Int32));
-            Bridge.Test.Assert.false(Bridge.is(2147483648, System.Int32));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.Int32), System.Int32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Int32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(System.Int64([2147483647,-1]), System.Int64), System.Int32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(2147483648, System.UInt32), System.Int32));
             Bridge.Test.Assert.areEqual("System.Int32", Bridge.Reflection.getTypeFullName(System.Int32));
 
-            var i = 0;
+            var i = Bridge.box(0, System.Int32);
             Bridge.Test.Assert.true(Bridge.is(i, System.Int32));
             Bridge.Test.Assert.true(Bridge.is(i, System.IComparable$1(System.Int32)));
             Bridge.Test.Assert.true(Bridge.is(i, System.IEquatable$1(System.Int32)));
@@ -25398,29 +25398,29 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         typeIsWorksForInt32: function () {
             Bridge.Test.Assert.false(Bridge.is(null, System.Int32));
-            Bridge.Test.Assert.false(Bridge.is(1.5, System.Int32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(1.5, System.Double, $box_.System.Double.toString), System.Int32));
             Bridge.Test.Assert.false(Bridge.is({  }, System.Int32));
-            Bridge.Test.Assert.true(Bridge.is(1, System.Int32));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(1, System.Int32), System.Int32));
         },
         typeAsWorksForInt32: function () {
             Bridge.Test.Assert.false((null) != null);
             Bridge.Test.Assert.false((Bridge.as({  }, System.Int32, true)) != null);
-            Bridge.Test.Assert.false((Bridge.as(1.5, System.Int32, true)) != null);
+            Bridge.Test.Assert.false((Bridge.as(Bridge.box(1.5, System.Double, $box_.System.Double.toString), System.Int32, true)) != null);
             Bridge.Test.Assert.true((Bridge.as(1, System.Int32, true)) != null);
         },
         unboxingWorksForInt32: function () {
             var _null = null;
             var o = {  };
-            var d = 1.5;
-            var i = 1;
-            Bridge.Test.Assert.areEqual(null, Bridge.cast(_null, System.Int32, true));
+            var d = Bridge.box(1.5, System.Double, $box_.System.Double.toString);
+            var i = Bridge.box(1, System.Int32);
+            Bridge.Test.Assert.areEqual(null, Bridge.cast(Bridge.unbox(_null), System.Int32, true));
             Bridge.Test.Assert.throws$5(function () {
-                var _ = Bridge.cast(o, System.Int32, true);
+                var _ = Bridge.cast(Bridge.unbox(o), System.Int32, true);
             }, "Cannot cast object to int?");
             Bridge.Test.Assert.throws$5(function () {
-                var _ = Bridge.cast(d, System.Int32, true);
+                var _ = Bridge.cast(Bridge.unbox(d), System.Int32, true);
             }, "Cannot cast decimal to int?");
-            Bridge.Test.Assert.areEqual(1, Bridge.cast(i, System.Int32, true));
+            Bridge.Test.Assert.areEqual(1, Bridge.cast(Bridge.unbox(i), System.Int32, true));
         },
         getDefaultValue: function (T) {
             return Bridge.getDefaultValue(T);
@@ -25494,10 +25494,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.Int32))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.Int32))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.Int32))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.Int32))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -25598,20 +25598,20 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(expected.toString(), actual.toString(), message);
         },
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(System.Int64(0), System.Int64));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Int64));
-            Bridge.Test.Assert.false(Bridge.is(1E+100, System.Int64));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(System.Int64(0), System.Int64), System.Int64));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Int64));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(1E+100, System.Double, $box_.System.Double.toString), System.Int64));
             Bridge.Test.Assert.areEqual("System.Int64", Bridge.Reflection.getTypeFullName(System.Int64));
 
-            var l = System.Int64(0);
+            var l = Bridge.box(System.Int64(0), System.Int64);
             Bridge.Test.Assert.true(Bridge.is(l, System.Int64));
             Bridge.Test.Assert.true(Bridge.is(l, System.IComparable$1(System.Int64)));
             Bridge.Test.Assert.true(Bridge.is(l, System.IEquatable$1(System.Int64)));
             Bridge.Test.Assert.true(Bridge.is(l, System.IFormattable));
         },
         minMaxValuesAreCorrect: function () {
-            this.assertLong("-9223372036854775808", System.Int64.MinValue);
-            this.assertLong("9223372036854775807", System.Int64.MaxValue);
+            this.assertLong("-9223372036854775808", Bridge.box(System.Int64.MinValue, System.Int64));
+            this.assertLong("9223372036854775807", Bridge.box(System.Int64.MaxValue, System.Int64));
         },
         castsWork: function () {
             var i3 = System.UInt64(5754), i4 = System.UInt64(System.Int64([-808,2147483647])), i5 = System.UInt64([-1816395584,-517669143]);
@@ -25677,13 +25677,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var l6 = System.Int64([-2147483648,0]);
             var l7 = System.Int64(1);
 
-            this.assertLong("257", System.Int64(ub).add(l1));
-            this.assertLong("130", System.Int64(sb).add(l2));
-            this.assertLong("65539", System.Int64(us).add(l3));
-            this.assertLong("32772", System.Int64(ss).add(l4));
-            this.assertLong("4294967301", System.Int64(ui).add(l5));
-            this.assertLong("2147483654", System.Int64(si).add(l6));
-            this.assertLong("8", System.Int64.clip64(ul).add(l7));
+            this.assertLong("257", Bridge.box(System.Int64(ub).add(l1), System.Int64));
+            this.assertLong("130", Bridge.box(System.Int64(sb).add(l2), System.Int64));
+            this.assertLong("65539", Bridge.box(System.Int64(us).add(l3), System.Int64));
+            this.assertLong("32772", Bridge.box(System.Int64(ss).add(l4), System.Int64));
+            this.assertLong("4294967301", Bridge.box(System.Int64(ui).add(l5), System.Int64));
+            this.assertLong("2147483654", Bridge.box(System.Int64(si).add(l6), System.Int64));
+            this.assertLong("8", Bridge.box(System.Int64.clip64(ul).add(l7), System.Int64));
 
             var dcml = System.Decimal(11.0);
             var dbl = 12.0;
@@ -25691,9 +25691,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             var l = System.Int64(100);
 
-            this.assertLong("111", dcml.add(System.Decimal(l)), null, "System.Decimal");
-            this.assertLong("112", dbl + System.Int64.toNumber(l), null, "System.Int32");
-            this.assertLong("113", flt + System.Int64.toNumber(l), null, "System.Int32");
+            this.assertLong("111", Bridge.box(dcml.add(System.Decimal(l)), System.Decimal, $box_.System.Decimal.toString), null, "System.Decimal");
+            this.assertLong("112", Bridge.box(dbl + System.Int64.toNumber(l), System.Double, $box_.System.Double.toString), null, "System.Double");
+            this.assertLong("113", Bridge.box(flt + System.Int64.toNumber(l), System.Single, $box_.System.Single.toString), null, "System.Single");
         },
         getDefaultValue: function (T) {
             return Bridge.getDefaultValue(T);
@@ -25781,10 +25781,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true(System.Int64(Bridge.getHashCode(System.Int64([0,1]))).lte(System.Int64([-1,0])));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((System.Int64(0)), System.Int64(0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.Int64(1)), System.Int64(0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.Int64(0)), System.Int64(1)));
-            Bridge.Test.Assert.true(Bridge.equals((System.Int64(1)), System.Int64(1)));
+            Bridge.Test.Assert.true(Bridge.equals((System.Int64(0)), Bridge.unbox(Bridge.box(System.Int64(0), System.Int64))));
+            Bridge.Test.Assert.false(Bridge.equals((System.Int64(1)), Bridge.unbox(Bridge.box(System.Int64(0), System.Int64))));
+            Bridge.Test.Assert.false(Bridge.equals((System.Int64(0)), Bridge.unbox(Bridge.box(System.Int64(1), System.Int64))));
+            Bridge.Test.Assert.true(Bridge.equals((System.Int64(1)), Bridge.unbox(Bridge.box(System.Int64(1), System.Int64))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((System.Int64(0)).equalsT(System.Int64(0)));
@@ -25898,7 +25898,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         typePropertiesAreCorrect: function () {
             Bridge.Test.Assert.areEqual("Date", Bridge.Reflection.getTypeFullName(Date));
-            var o = new Date();
+            var o = Bridge.box(new Date(), Date, $box_.Date.toString);
             Bridge.Test.Assert.true$1(Bridge.is(o, Date), "o is DateTime");
         },
         defaultConstructorReturnsTodaysDate: function () {
@@ -25907,7 +25907,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         creatingInstanceReturnsDateZero: function () {
             var fullYear = Bridge.createInstance(Date).getFullYear();
-            Bridge.Test.Assert.true$1(1971 >= fullYear, "1971 >= " + fullYear);
+            Bridge.Test.Assert.true$1(1971 >= fullYear, "1971 >= " + Bridge.box(fullYear, System.Int32));
         },
         millisecondSinceEpochConstructorWorks: function () {
             var dt = new Date(System.Int64([250327040,10]).toNumber()/10000);
@@ -26044,11 +26044,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         valueOfWorks: function () {
             var dt = new Date(System.Int64(Date.UTC(1970, 1 - 1, 2)).mul(10000).toNumber()/10000);
-            Bridge.Test.Assert.areEqual(86400000, dt.valueOf());
+            Bridge.Test.Assert.areEqual(86400000, Bridge.unbox(dt.valueOf()));
         },
         getTimezoneOffsetWorks: function () {
             var dt = new Date(System.Int64(0).toNumber()/10000);
-            Bridge.Test.Assert.areEqual(((Bridge.Int.div(System.Nullable.getValue(Bridge.cast((new Date(1970, 1 - 1, 1).valueOf()), System.Int32)), 60000)) | 0), dt.getTimezoneOffset());
+            Bridge.Test.Assert.areEqual(((Bridge.Int.div(System.Nullable.getValue(Bridge.cast(Bridge.unbox((new Date(1970, 1 - 1, 1).valueOf())), System.Int32)), 60000)) | 0), dt.getTimezoneOffset());
         },
         getUTCFullYearWorks: function () {
             var dt = new Date(System.Int64(Date.UTC(2011, 7 - 1, 12, 13, 42, 56, 345)).mul(10000).toNumber()/10000);
@@ -26197,10 +26197,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true(System.Int64(Bridge.getHashCode(new Date(3000, 1 - 1, 1))).lt(System.Int64([-1,0])));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(0).toNumber()/10000)));
-            Bridge.Test.Assert.false(Bridge.equals(new Date(System.Int64(10000).toNumber()/10000), new Date(System.Int64(0).toNumber()/10000)));
-            Bridge.Test.Assert.false(Bridge.equals(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(10000).toNumber()/10000)));
-            Bridge.Test.Assert.true(Bridge.equals(new Date(System.Int64(10000).toNumber()/10000), new Date(System.Int64(10000).toNumber()/10000)));
+            Bridge.Test.Assert.true(Bridge.equals(new Date(System.Int64(0).toNumber()/10000), Bridge.unbox(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString))));
+            Bridge.Test.Assert.false(Bridge.equals(new Date(System.Int64(10000).toNumber()/10000), Bridge.unbox(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString))));
+            Bridge.Test.Assert.false(Bridge.equals(new Date(System.Int64(0).toNumber()/10000), Bridge.unbox(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString))));
+            Bridge.Test.Assert.true(Bridge.equals(new Date(System.Int64(10000).toNumber()/10000), Bridge.unbox(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString))));
         },
         dateTimeEqualsWorks: function () {
             Bridge.Test.Assert.true(Bridge.equalsT(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(0).toNumber()/10000)));
@@ -26209,10 +26209,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true(Bridge.equalsT(new Date(System.Int64(10000).toNumber()/10000), new Date(System.Int64(10000).toNumber()/10000)));
         },
         iEquatableEqualsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(new Date(System.Int64(0).toNumber()/10000), System.IEquatable$1(Date)), new Date(System.Int64(0).toNumber()/10000), Date));
-            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(new Date(System.Int64(10000).toNumber()/10000), System.IEquatable$1(Date)), new Date(System.Int64(0).toNumber()/10000), Date));
-            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(new Date(System.Int64(0).toNumber()/10000), System.IEquatable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), Date));
-            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(new Date(System.Int64(10000).toNumber()/10000), System.IEquatable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), Date));
+            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString), System.IEquatable$1(Date)), new Date(System.Int64(0).toNumber()/10000), Date));
+            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString), System.IEquatable$1(Date)), new Date(System.Int64(0).toNumber()/10000), Date));
+            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString), System.IEquatable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), Date));
+            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString), System.IEquatable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), Date));
         },
         compareToWorks: function () {
             Bridge.Test.Assert.true(Bridge.compare(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(0).toNumber()/10000)) === 0);
@@ -26220,9 +26220,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.true(Bridge.compare(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(10000).toNumber()/10000)) < 0);
         },
         iComparableCompareToWorks: function () {
-            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(new Date(System.Int64(0).toNumber()/10000), System.IComparable$1(Date)), new Date(System.Int64(0).toNumber()/10000), false, Date) === 0);
-            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(new Date(System.Int64(10000).toNumber()/10000), System.IComparable$1(Date)), new Date(System.Int64(0).toNumber()/10000), false, Date) > 0);
-            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(new Date(System.Int64(0).toNumber()/10000), System.IComparable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), false, Date) < 0);
+            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString), System.IComparable$1(Date)), new Date(System.Int64(0).toNumber()/10000), false, Date) === 0);
+            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString), System.IComparable$1(Date)), new Date(System.Int64(0).toNumber()/10000), false, Date) > 0);
+            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString), System.IComparable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), false, Date) < 0);
         },
         createUnixTimestampAndConvertBackToDateTime: function () {
             var now = new Date();
@@ -26257,7 +26257,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         canGetHashCodeForObject: function () {
             var o = {  };
             var c = Bridge.getHashCode(o);
-            Bridge.Test.Assert.true(Bridge.is(c, System.Int32));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(c, System.Int32), System.Int32));
         },
         repeatedCallsToGetHashCodeReturnsSameValue: function () {
             var o = {  };
@@ -26265,27 +26265,27 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         objectIsEqualToItself: function () {
             var o = {  };
-            Bridge.Test.Assert.true(Bridge.equals(o, o));
+            Bridge.Test.Assert.true(Bridge.equals(o, Bridge.unbox(o)));
         },
         objectIsNotEqualToOtherObject: function () {
-            Bridge.Test.Assert.false(Bridge.equals({  }, {  }));
+            Bridge.Test.Assert.false(Bridge.equals({  }, Bridge.unbox({  })));
         },
         staticEqualsWorks: function () {
             var o1 = {  }, o2 = {  };
             Bridge.Test.Assert.true(Bridge.equals(null, null));
-            Bridge.Test.Assert.false(Bridge.equals(null, o1));
-            Bridge.Test.Assert.false(Bridge.equals(o1, null));
-            Bridge.Test.Assert.true(Bridge.equals(o1, o1));
-            Bridge.Test.Assert.false(Bridge.equals(o1, o2));
+            Bridge.Test.Assert.false(Bridge.equals(null, Bridge.unbox(o1)));
+            Bridge.Test.Assert.false(Bridge.equals(Bridge.unbox(o1), null));
+            Bridge.Test.Assert.true(Bridge.equals(Bridge.unbox(o1), Bridge.unbox(o1)));
+            Bridge.Test.Assert.false(Bridge.equals(Bridge.unbox(o1), Bridge.unbox(o2)));
         },
         referenceEqualsWorks: function () {
             var o1 = {  }, o2 = {  }, n = null;
-            Bridge.Test.Assert.true$1(Bridge.referenceEquals(n, n), "n, n");
-            Bridge.Test.Assert.true$1(Bridge.referenceEquals(n, undefined), "n, Script.Undefined");
-            Bridge.Test.Assert.false$1(Bridge.referenceEquals(o1, o2), "o1, o2");
-            Bridge.Test.Assert.false$1(Bridge.referenceEquals(o1, n), "o1, n");
-            Bridge.Test.Assert.false$1(Bridge.referenceEquals(o1, undefined), "o1, Script.Undefined");
-            Bridge.Test.Assert.true$1(Bridge.referenceEquals(o1, o1), "o1, o1");
+            Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(n), Bridge.unbox(n)), "n, n");
+            Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(n), Bridge.unbox(undefined)), "n, Script.Undefined");
+            Bridge.Test.Assert.false$1(Bridge.referenceEquals(Bridge.unbox(o1), Bridge.unbox(o2)), "o1, o2");
+            Bridge.Test.Assert.false$1(Bridge.referenceEquals(Bridge.unbox(o1), Bridge.unbox(n)), "o1, n");
+            Bridge.Test.Assert.false$1(Bridge.referenceEquals(Bridge.unbox(o1), Bridge.unbox(undefined)), "o1, Script.Undefined");
+            Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(o1), Bridge.unbox(o1)), "o1, o1");
         },
         toStringOverride: function () {
             var c1 = new Bridge.ClientTest.SimpleTypes.ObjectTests.C1(), c2 = new Bridge.ClientTest.SimpleTypes.ObjectTests.C2();
@@ -26302,13 +26302,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.SByteTests", {
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.SByte));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.SByte));
-            Bridge.Test.Assert.false(Bridge.is(-129, System.SByte));
-            Bridge.Test.Assert.false(Bridge.is(128, System.SByte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0, System.Byte), System.SByte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.SByte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-129, System.Int32), System.SByte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(128, System.Int32), System.SByte));
             Bridge.Test.Assert.areEqual("System.SByte", Bridge.Reflection.getTypeFullName(System.SByte));
 
-            var b = 0;
+            var b = Bridge.box(0, System.SByte);
             Bridge.Test.Assert.true(Bridge.is(b, System.SByte));
             Bridge.Test.Assert.true(Bridge.is(b, System.IFormattable));
         },
@@ -26424,10 +26424,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.SByte))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.SByte))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.SByte))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.SByte))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -26477,10 +26477,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.SingleTests", {
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(0.5, System.Single));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0.5, System.Single, $box_.System.Single.toString), System.Single));
             Bridge.Test.Assert.areEqual("System.Single", Bridge.Reflection.getTypeFullName(System.Single));
 
-            var f = 0.0;
+            var f = Bridge.box(0.0, System.Single, $box_.System.Single.toString);
             Bridge.Test.Assert.true(Bridge.is(f, System.Single));
             Bridge.Test.Assert.true(Bridge.is(f, System.IFormattable));
         },
@@ -26495,8 +26495,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         constantsWork: function () {
             var zero = 0;
-            Bridge.Test.Assert.true$1(System.Nullable.getValue(Bridge.cast(-3.40282347E+38, System.Single)) < -3.4E+38 && System.Nullable.getValue(Bridge.cast(-3.40282347E+38, System.Single)) > -3.5E+38, "MinValue should be correct");
-            Bridge.Test.Assert.true$1(System.Nullable.getValue(Bridge.cast(3.40282347E+38, System.Single)) > 3.4E+38 && System.Nullable.getValue(Bridge.cast(3.40282347E+38, System.Single)) < 3.5E+38, "MaxValue should be correct");
+            Bridge.Test.Assert.true$1(System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(-3.40282347E+38, System.Single, $box_.System.Single.toString)), System.Single)) < -3.4E+38 && System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(-3.40282347E+38, System.Single, $box_.System.Single.toString)), System.Single)) > -3.5E+38, "MinValue should be correct");
+            Bridge.Test.Assert.true$1(System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(3.40282347E+38, System.Single, $box_.System.Single.toString)), System.Single)) > 3.4E+38 && System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(3.40282347E+38, System.Single, $box_.System.Single.toString)), System.Single)) < 3.5E+38, "MaxValue should be correct");
             Bridge.Test.Assert.areEqual$1(1.401298E-45, 1.401298E-45, "Epsilon should be correct");
             Bridge.Test.Assert.true$1(isNaN(Number.NaN), "NaN should be correct");
             Bridge.Test.Assert.areStrictEqual$1(1 / zero, Number.POSITIVE_INFINITY, "PositiveInfinity should be correct");
@@ -26573,10 +26573,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((0.5)), Bridge.getHashCode((0.0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0.0), 0.0));
-            Bridge.Test.Assert.false(Bridge.equals((1.0), 0.0));
-            Bridge.Test.Assert.false(Bridge.equals((0.0), 0.5));
-            Bridge.Test.Assert.true(Bridge.equals((1.0), 1.0));
+            Bridge.Test.Assert.true(Bridge.equals((0.0), Bridge.unbox(Bridge.box(0.0, System.Single, $box_.System.Single.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((1.0), Bridge.unbox(Bridge.box(0.0, System.Single, $box_.System.Single.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((0.0), Bridge.unbox(Bridge.box(0.5, System.Single, $box_.System.Single.toString))));
+            Bridge.Test.Assert.true(Bridge.equals((1.0), Bridge.unbox(Bridge.box(1.0, System.Single, $box_.System.Single.toString))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0.0) === 0.0);
@@ -26726,13 +26726,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 s = ["1", "2", "3", "4", "5"].toString().split(',').join('');
                 Bridge.Test.Assert.areEqual$1("12345", s, "string.Concat()");
 
-                s = [1, null, 2, null, 3].toString().split(',').join('');
+                s = [Bridge.box(1, System.Int32), null, Bridge.box(2, System.Int32), null, Bridge.box(3, System.Int32)].toString().split(',').join('');
                 Bridge.Test.Assert.areEqual$1("123", s, "string.Concat()");
             },
             test: function (x, y, comparison, testI, expected, expectedIndex) {
                 var cmpValue = 0;
                 cmpValue = System.String.compare(testI[x], testI[y], comparison);
-                Bridge.Test.Assert.areEqual$1(expected[expectedIndex], cmpValue, System.String.concat("String.Compare('", testI[x], "', '", testI[y], "',", System.Enum.toString(Number, comparison), ")"));
+                Bridge.Test.Assert.areEqual$1(expected[expectedIndex], cmpValue, System.String.concat("String.Compare('", testI[x], "', '", testI[y], "',", System.Enum.toString(Number, Bridge.box(comparison, Number, $box_.Number.toString)), ")"));
             },
             enumerable: function () {
                 var $t;
@@ -26865,7 +26865,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual("xabcd", System.String.format.apply(System.String, ["x{0}{1}{2}{3}"].concat(arr4)));
         },
         formatWorksWithIFormattable: function () {
-            Bridge.Test.Assert.areEqual("3.14", System.String.format("{0:F2}", 3.1428571428571428));
+            Bridge.Test.Assert.areEqual("3.14", System.String.format("{0:F2}", Bridge.box(3.1428571428571428, System.Double, $box_.System.Double.toString)));
         },
         formatCanUseEscapedBraces: function () {
             Bridge.Test.Assert.areEqual("{0}", System.String.format("{{0}}", null));
@@ -27284,15 +27284,15 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         instanceEqualsWorks: function () {
             var r = "a";
-            Bridge.Test.Assert.true(Bridge.equals(("a"), r));
-            Bridge.Test.Assert.false(Bridge.equals(("b"), r));
+            Bridge.Test.Assert.true(Bridge.equals(("a"), Bridge.unbox(r)));
+            Bridge.Test.Assert.false(Bridge.equals(("b"), Bridge.unbox(r)));
             r = "b";
-            Bridge.Test.Assert.false(Bridge.equals(("a"), r));
-            Bridge.Test.Assert.true(Bridge.equals(("b"), r));
+            Bridge.Test.Assert.false(Bridge.equals(("a"), Bridge.unbox(r)));
+            Bridge.Test.Assert.true(Bridge.equals(("b"), Bridge.unbox(r)));
             r = "A";
-            Bridge.Test.Assert.false(Bridge.equals(("a"), r));
+            Bridge.Test.Assert.false(Bridge.equals(("a"), Bridge.unbox(r)));
             r = "ab";
-            Bridge.Test.Assert.false(Bridge.equals(("a"), r));
+            Bridge.Test.Assert.false(Bridge.equals(("a"), Bridge.unbox(r)));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true(System.String.equals(("a"), "a"));
@@ -27339,9 +27339,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual("1, 5, 6", Bridge.toArray(intValues).join(", "));
             var stringValues = new (Bridge.ClientTest.SimpleTypes.StringTests.MyEnumerable$1(String))(["a", "ab", "abc", "abcd"]);
             Bridge.Test.Assert.areEqual("a, ab, abc, abcd", Bridge.toArray(stringValues).join(", "));
-
-            // TODO: c# makes it False but js false
-            Bridge.Test.Assert.areEqual("a, 1, abc, false", ["a", 1, "abc", false].join(", ")); // False");
+            Bridge.Test.Assert.areEqual("a, 1, abc, False", ["a", Bridge.box(1, System.Int32), "abc", Bridge.box(false, Boolean, $box_.Boolean.toString)].join(", "));
         },
         containsWorks: function () {
             var text = "Lorem ipsum dolor sit amet";
@@ -27478,7 +27476,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.false$1(v1.equalsT(v3), "v1.Equals(v3)");
                 Bridge.Test.Assert.false$1(v1.equals(o), "v1.Equals(o)");
                 Bridge.Test.Assert.false$1(v1.equalsT(null), "v1.Equals(null)");
-                Bridge.Test.Assert.false$1(v1.equals(100), "v1.Equals(100)");
+                Bridge.Test.Assert.false$1(v1.equals(Bridge.box(100, System.Int32)), "v1.Equals(100)");
                 Bridge.Test.Assert.true$1(v1.equals(o2), "v1.Equals(o2)");
 
                 Bridge.Test.Assert.areEqual$1(1283637748, v1.getHashCode(), "v1.GetHashCode()");
@@ -27601,7 +27599,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.define("Bridge.ClientTest.SimpleTypes.TimeSpanTests", {
         typePropertiesAreCorrect: function () {
             Bridge.Test.Assert.areEqual("System.TimeSpan", Bridge.Reflection.getTypeFullName(System.TimeSpan));
-            var d = new System.TimeSpan();
+            var d = Bridge.box(new System.TimeSpan(), System.TimeSpan);
             Bridge.Test.Assert.true$1(Bridge.is(d, System.TimeSpan), "d is TimeSpan");
             Bridge.Test.Assert.true$1(Bridge.is(d, System.IComparable$1(System.TimeSpan)), "d is IComparable<TimeSpan>");
             Bridge.Test.Assert.true$1(Bridge.is(d, System.IEquatable$1(System.TimeSpan)), "d is IEquatable<TimeSpan>");
@@ -27624,44 +27622,44 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         parameterConstructorsWorks: function () {
             var time = new System.TimeSpan(System.Int64(34567));
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "ticks type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "ticks type");
             Bridge.Test.Assert.true$1(System.Int64(34567).equals(time.getTicks()), "ticks value");
 
             time = new System.TimeSpan(10, 20, 5);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "h, m, s type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "h, m, s type");
             Bridge.Test.Assert.true$1(System.Int64([-1612154752,86]).equals(time.getTicks()), "h, m, s value");
 
             time = new System.TimeSpan(15, 10, 20, 5);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "d, h, m, s type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "d, h, m, s type");
             Bridge.Test.Assert.true$1(System.Int64([471513216,3104]).equals(time.getTicks()), "d, h, m, s value");
 
             time = new System.TimeSpan(15, 10, 20, 5, 14);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "full type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "full type");
             Bridge.Test.Assert.true$1(System.Int64([471653216,3104]).equals(time.getTicks()), "full value");
         },
         factoryMethodsWork: function () {
             var time = System.TimeSpan.fromDays(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromDays type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromDays type");
             Bridge.Test.Assert.true$1(System.Int64([2134720512,603]).equals(time.getTicks()), "FromDays value");
 
             time = System.TimeSpan.fromHours(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromHours type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromHours type");
             Bridge.Test.Assert.true$1(System.Int64([625817600,25]).equals(time.getTicks()), "FromHours value");
 
             time = System.TimeSpan.fromMinutes(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromMinutes type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromMinutes type");
             Bridge.Test.Assert.true$1(System.Int64(1800000000).equals(time.getTicks()), "FromMinutes value");
 
             time = System.TimeSpan.fromSeconds(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromSeconds type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromSeconds type");
             Bridge.Test.Assert.true$1(System.Int64(30000000).equals(time.getTicks()), "FromSeconds value");
 
             time = System.TimeSpan.fromMilliseconds(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromMilliseconds type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromMilliseconds type");
             Bridge.Test.Assert.true$1(System.Int64(30000).equals(time.getTicks()), "FromMilliseconds value");
 
             time = System.TimeSpan.fromTicks(System.Int64(3));
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromTicks type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromTicks type");
             Bridge.Test.Assert.true$1(System.Int64(3).equals(time.getTicks()), "FromTicks value");
         },
         propertiesWork: function () {
@@ -27719,8 +27717,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var time2 = new System.TimeSpan(14, 10, 20, 5, 14);
             var time3 = new System.TimeSpan(15, 10, 20, 5, 14);
 
-            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(time1, System.IEquatable$1(System.TimeSpan)), time2, System.TimeSpan));
-            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(time1, System.IEquatable$1(System.TimeSpan)), time3, System.TimeSpan));
+            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(Bridge.box(time1, System.TimeSpan), System.IEquatable$1(System.TimeSpan)), time2, System.TimeSpan));
+            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(Bridge.box(time1, System.TimeSpan), System.IEquatable$1(System.TimeSpan)), time3, System.TimeSpan));
         },
         toStringWorks: function () {
             var time1 = new System.TimeSpan(15, 10, 20, 5, 14);
@@ -27736,14 +27734,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var time1 = new System.TimeSpan(2, 3, 4, 5, 6);
             var time2 = new System.TimeSpan(3, 4, 5, 6, 7);
             var actual = time1.add(time2);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(457751013, actual.getTotalMilliseconds(), "TotalMilliseconds should be correct");
         },
         subtractWorks: function () {
             var time1 = new System.TimeSpan(4, 3, 7, 2, 6);
             var time2 = new System.TimeSpan(3, 4, 5, 6, 7);
             var actual = time1.subtract(time2);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(82915999, actual.getTotalMilliseconds(), "TotalMilliseconds should be correct");
         },
         durationWorks: function () {
@@ -27751,14 +27749,14 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var time2 = new System.TimeSpan(2, 1, 5, 4, 3);
             var actual1 = time1.duration();
             var actual2 = time2.duration();
-            Bridge.Test.Assert.true$1(Bridge.is(time1, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time1, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(266465004, actual1.getTotalMilliseconds(), "Negative should be negated");
             Bridge.Test.Assert.areEqual$1(176704003, actual2.getTotalMilliseconds(), "Positive should be preserved");
         },
         negateWorks: function () {
             var time = new System.TimeSpan(-3, 2, -1, 5, -4);
             var actual = time.negate();
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(252055004, actual.getTotalMilliseconds(), "Ticks should be correct");
         },
         assertAlmostEqual: function (d1, d2) {
@@ -27804,26 +27802,26 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var time1 = new System.TimeSpan(2, 3, 4, 5, 6);
             var time2 = new System.TimeSpan(3, 4, 5, 6, 7);
             var actual = System.TimeSpan.add(time1, time2);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(457751013, actual.getTotalMilliseconds(), "TotalMilliseconds should be correct");
         },
         subtractionOperatorWorks: function () {
             var time1 = new System.TimeSpan(4, 3, 7, 2, 6);
             var time2 = new System.TimeSpan(3, 4, 5, 6, 7);
             var actual = System.TimeSpan.sub(time1, time2);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(82915999, actual.getTotalMilliseconds(), "TotalMilliseconds should be correct");
         },
         unaryPlusWorks: function () {
             var time = new System.TimeSpan(-3, 2, -1, 5, -4);
             var actual = System.TimeSpan.plus(time);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(-252055004, actual.getTotalMilliseconds(), "Ticks should be correct");
         },
         unaryMinusWorks: function () {
             var time = new System.TimeSpan(-3, 2, -1, 5, -4);
             var actual = System.TimeSpan.neg(time);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(252055004, actual.getTotalMilliseconds(), "Ticks should be correct");
         }
     });
@@ -27909,13 +27907,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.UInt16Tests", {
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.UInt16));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.UInt16));
-            Bridge.Test.Assert.false(Bridge.is(-1, System.UInt16));
-            Bridge.Test.Assert.false(Bridge.is(65536, System.UInt16));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.UInt16), System.UInt16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.UInt16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-1, System.Int32), System.UInt16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(65536, System.Int32), System.UInt16));
             Bridge.Test.Assert.areEqual("System.UInt16", Bridge.Reflection.getTypeFullName(System.UInt16));
 
-            var s = 0;
+            var s = Bridge.box(0, System.UInt16);
             Bridge.Test.Assert.true(Bridge.is(s, System.UInt16));
             Bridge.Test.Assert.true(Bridge.is(s, System.IComparable$1(System.UInt16)));
             Bridge.Test.Assert.true(Bridge.is(s, System.IEquatable$1(System.UInt16)));
@@ -28033,10 +28031,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.UInt16))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.UInt16))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.UInt16))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.UInt16))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -28089,12 +28087,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.define("Bridge.ClientTest.SimpleTypes.UInt32Tests", {
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.UInt32));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.UInt32));
-            Bridge.Test.Assert.false(Bridge.is(-1, System.UInt32));
-            Bridge.Test.Assert.false(Bridge.is(System.Int64([0,1]), System.UInt32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0, System.Int32), System.UInt32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.UInt32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-1, System.Int32), System.UInt32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(System.Int64([0,1]), System.Int64), System.UInt32));
             Bridge.Test.Assert.areEqual("System.UInt32", Bridge.Reflection.getTypeFullName(System.UInt32));
-            var i = 0;
+            var i = Bridge.box(0, System.UInt32);
             Bridge.Test.Assert.true(Bridge.is(i, System.UInt32));
             Bridge.Test.Assert.true(Bridge.is(i, System.IComparable$1(System.UInt32)));
             Bridge.Test.Assert.true(Bridge.is(i, System.IEquatable$1(System.UInt32)));
@@ -28208,10 +28206,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.UInt32))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.UInt32))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.UInt32))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.UInt32))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -28276,18 +28274,18 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(expected.toString(), actual.toString(), message);
         },
         typePropertiesAreCorrect: function () {
-            Bridge.Test.Assert.true(Bridge.is(System.UInt64(0), System.UInt64));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.UInt64));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(System.UInt64(0), System.UInt64), System.UInt64));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.UInt64));
             Bridge.Test.Assert.areEqual("System.UInt64", Bridge.Reflection.getTypeFullName(System.UInt64));
-            var l = System.UInt64(0);
+            var l = Bridge.box(System.UInt64(0), System.UInt64);
             Bridge.Test.Assert.true(Bridge.is(l, System.UInt64));
             Bridge.Test.Assert.true(Bridge.is(l, System.IComparable$1(System.UInt64)));
             Bridge.Test.Assert.true(Bridge.is(l, System.IEquatable$1(System.UInt64)));
             Bridge.Test.Assert.true(Bridge.is(l, System.IFormattable));
         },
         minMaxValuesAreCorrect: function () {
-            this.assertULong("0", System.UInt64.MinValue);
-            this.assertULong("18446744073709551615", System.UInt64.MaxValue);
+            this.assertULong("0", Bridge.box(System.UInt64.MinValue, System.UInt64));
+            this.assertULong("18446744073709551615", Bridge.box(System.UInt64.MaxValue, System.UInt64));
         },
         castsWork: function () {
             var i2 = System.Int64(0), i3 = System.Int64(234), i4 = System.Int64([-808,2147483647]);
@@ -28345,13 +28343,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var l6 = System.UInt64(2147483648);
             var l7 = System.UInt64(1);
 
-            this.assertULong("257", System.UInt64(ub).add(l1));
-            this.assertULong("130", Bridge.Int.clipu64(sb).add(l2));
-            this.assertULong("65539", System.UInt64(us).add(l3));
-            this.assertULong("32772", Bridge.Int.clipu64(ss).add(l4));
-            this.assertULong("4294967301", System.UInt64(ui).add(l5));
-            this.assertULong("2147483654", Bridge.Int.clipu64(si).add(l6));
-            this.assertULong("8", System.Int64.clipu64(sl).add(l7));
+            this.assertULong("257", Bridge.box(System.UInt64(ub).add(l1), System.UInt64));
+            this.assertULong("130", Bridge.box(Bridge.Int.clipu64(sb).add(l2), System.UInt64));
+            this.assertULong("65539", Bridge.box(System.UInt64(us).add(l3), System.UInt64));
+            this.assertULong("32772", Bridge.box(Bridge.Int.clipu64(ss).add(l4), System.UInt64));
+            this.assertULong("4294967301", Bridge.box(System.UInt64(ui).add(l5), System.UInt64));
+            this.assertULong("2147483654", Bridge.box(Bridge.Int.clipu64(si).add(l6), System.UInt64));
+            this.assertULong("8", Bridge.box(System.Int64.clipu64(sl).add(l7), System.UInt64));
 
             var dcml = System.Decimal(11.0);
             var dbl = 12.0;
@@ -28359,9 +28357,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             var l = System.Int64(100);
 
-            this.assertULong("111", dcml.add(System.Decimal(l)), null, "System.Decimal");
-            this.assertULong("112", dbl + System.Int64.toNumber(l), null, "System.Int32");
-            this.assertULong("113", flt + System.Int64.toNumber(l), null, "System.Int32");
+            this.assertULong("111", Bridge.box(dcml.add(System.Decimal(l)), System.Decimal, $box_.System.Decimal.toString), null, "System.Decimal");
+            this.assertULong("112", Bridge.box(dbl + System.Int64.toNumber(l), System.Double, $box_.System.Double.toString), null, "System.Double");
+            this.assertULong("113", Bridge.box(flt + System.Int64.toNumber(l), System.Single, $box_.System.Single.toString), null, "System.Single");
         },
         getDefaultValue: function (T) {
             return Bridge.getDefaultValue(T);
@@ -28445,10 +28443,10 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((System.UInt64(1))), Bridge.getHashCode((System.UInt64(0))));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((System.UInt64(0)), System.UInt64(0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.UInt64(1)), System.UInt64(0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.UInt64(0)), System.UInt64(1)));
-            Bridge.Test.Assert.true(Bridge.equals((System.UInt64(1)), System.UInt64(1)));
+            Bridge.Test.Assert.true(Bridge.equals((System.UInt64(0)), Bridge.unbox(Bridge.box(System.UInt64(0), System.UInt64))));
+            Bridge.Test.Assert.false(Bridge.equals((System.UInt64(1)), Bridge.unbox(Bridge.box(System.UInt64(0), System.UInt64))));
+            Bridge.Test.Assert.false(Bridge.equals((System.UInt64(0)), Bridge.unbox(Bridge.box(System.UInt64(1), System.UInt64))));
+            Bridge.Test.Assert.true(Bridge.equals((System.UInt64(1)), Bridge.unbox(Bridge.box(System.UInt64(1), System.UInt64))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((System.UInt64(0)).equalsT(System.UInt64(0)));
@@ -28522,7 +28520,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         validateGroup: function (match, groupIndex, index, length, success, value, captureCount) {
             var group = match.getGroups().get(groupIndex);
-            this.validateGroupImpl(group, index, length, success, value, captureCount, "ValidateGroup: Group" + groupIndex);
+            this.validateGroupImpl(group, index, length, success, value, captureCount, "ValidateGroup: Group" + Bridge.box(groupIndex, System.Int32));
         },
         validateGroupImpl: function (group, index, length, success, value, captureCount, descr) {
             this.validateCaptureImpl(group, index, length, value, descr);
@@ -28536,11 +28534,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.notNull$1(match.getGroups(), "ValidateCapture: Match.Groups is not NULL");
             var group = match.getGroups().get(groupIndex);
 
-            Bridge.Test.Assert.notNull$1(group, "ValidateCapture: Group" + groupIndex + " is not NULL");
-            Bridge.Test.Assert.notNull$1(group.getCaptures(), "ValidateCapture: Group" + groupIndex + ".Captures is not NULL");
+            Bridge.Test.Assert.notNull$1(group, "ValidateCapture: Group" + Bridge.box(groupIndex, System.Int32) + " is not NULL");
+            Bridge.Test.Assert.notNull$1(group.getCaptures(), "ValidateCapture: Group" + Bridge.box(groupIndex, System.Int32) + ".Captures is not NULL");
             var capture = group.getCaptures().get(captureIndex);
 
-            this.validateCaptureImpl(capture, index, length, value, "ValidateCapture: Group" + groupIndex + ".Capture" + captureIndex);
+            this.validateCaptureImpl(capture, index, length, value, "ValidateCapture: Group" + Bridge.box(groupIndex, System.Int32) + ".Capture" + Bridge.box(captureIndex, System.Int32));
         },
         validateCaptureImpl: function (capture, index, length, value, descr) {
             Bridge.Test.Assert.notNull$1(capture, System.String.concat(descr, " is not NULL"));
@@ -28577,7 +28575,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                     Bridge.Test.Assert.notNull$1(actual.getCaptures(), System.String.concat(descr, ".Captures is not NULL"));
                     Bridge.Test.Assert.areEqual$1(expected.getCaptures().getCount(), actual.getCaptures().getCount(), System.String.concat(descr, ".Captures.Count"));
                     for (var i = 0; i < expected.getCaptures().getCount(); i = (i + 1) | 0) {
-                        this.capturesAreEqual(expected.getCaptures().get(i), actual.getCaptures().get(i), System.String.concat(descr, ".Captures[", i, "]"));
+                        this.capturesAreEqual(expected.getCaptures().get(i), actual.getCaptures().get(i), System.String.concat(descr, ".Captures[", Bridge.box(i, System.Int32), "]"));
                     }
                 }
             }
@@ -28595,7 +28593,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                     Bridge.Test.Assert.notNull$1(actual.getGroups(), System.String.concat(descr, ".Groups is not NULL"));
                     Bridge.Test.Assert.areEqual$1(expected.getGroups().getCount(), actual.getGroups().getCount(), System.String.concat(descr, ".Groups.Count"));
                     for (var i = 0; i < expected.getGroups().getCount(); i = (i + 1) | 0) {
-                        this.capturesAreEqual(expected.getGroups().get(i), actual.getGroups().get(i), System.String.concat(descr, ".Groups[", i, "]"));
+                        this.capturesAreEqual(expected.getGroups().get(i), actual.getGroups().get(i), System.String.concat(descr, ".Groups[", Bridge.box(i, System.Int32), "]"));
                     }
                 }
             }
@@ -28609,7 +28607,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
                 var minLength = Math.min(expected.length, actual.length);
                 for (var i = 0; i < minLength; i = (i + 1) | 0) {
-                    Bridge.Test.Assert.areEqual$1(expected[i], actual[i], System.String.concat(msg, "[", i, "]"));
+                    Bridge.Test.Assert.areEqual$1(expected[i], actual[i], System.String.concat(msg, "[", Bridge.box(i, System.Int32), "]"));
                 }
             }
         },
@@ -28776,7 +28774,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 // If the first char is lower case...
                 if (Bridge.isLower(x.charCodeAt(0))) {
                     // Capitalize it.
-                    return System.String.concat(String.fromCharCode(String.fromCharCode(x.charCodeAt(0)).toUpperCase().charCodeAt(0)), x.substr(1, ((x.length - 1) | 0)));
+                    return System.String.concat(String.fromCharCode(Bridge.box(String.fromCharCode(x.charCodeAt(0)).toUpperCase().charCodeAt(0), System.Char, $box_.System.Char.toString)), x.substr(1, ((x.length - 1) | 0)));
                 }
                 return x;
             },
@@ -28876,7 +28874,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             for (var i = 0; i < uncPaths.length; i = (i + 1) | 0) {
                 var uncPath = uncPaths[i];
                 var result = System.Text.RegularExpressions.Regex.replace(uncPath, pattern, replacement);
-                Bridge.Test.Assert.areEqual$1(expected[i], result, "Result at #" + i);
+                Bridge.Test.Assert.areEqual$1(expected[i], result, "Result at #" + Bridge.box(i, System.Int32));
             }
         },
         replaceStaticWithOptionsTest: function () {
@@ -28888,7 +28886,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             for (var i = 0; i < uncPaths.length; i = (i + 1) | 0) {
                 var uncPath = uncPaths[i];
                 var result = System.Text.RegularExpressions.Regex.replace$1(uncPath, pattern, replacement, 1);
-                Bridge.Test.Assert.areEqual$1(expected[i], result, "Result at #" + i);
+                Bridge.Test.Assert.areEqual$1(expected[i], result, "Result at #" + Bridge.box(i, System.Int32));
             }
         },
         replaceStaticWithOptionsAndTimeoutTest: function () {
@@ -28900,7 +28898,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             for (var i = 0; i < uncPaths.length; i = (i + 1) | 0) {
                 var uncPath = uncPaths[i];
                 var result = System.Text.RegularExpressions.Regex.replace$2(uncPath, pattern, replacement, 1, System.TimeSpan.fromSeconds(1));
-                Bridge.Test.Assert.areEqual$1(expected[i], result, "Result at #" + i);
+                Bridge.Test.Assert.areEqual$1(expected[i], result, "Result at #" + Bridge.box(i, System.Int32));
             }
         },
         replaceStaticWithEvaluatorTest: function () {
@@ -28943,7 +28941,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         validateResult: function (expected, actual) {
             Bridge.Test.Assert.areEqual$1(expected.length, actual.length, "Length");
             for (var i = 0; i < actual.length; i = (i + 1) | 0) {
-                Bridge.Test.Assert.areEqual$1(expected[i], actual[i], "Result at " + i);
+                Bridge.Test.Assert.areEqual$1(expected[i], actual[i], "Result at " + Bridge.box(i, System.Int32));
             }
         },
         splitTest1: function () {
@@ -29728,7 +29726,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         typePropertiesForCancellationTokenRegistrationAreCorrect: function () {
             Bridge.Test.Assert.areEqual$1("System.Threading.CancellationTokenRegistration", Bridge.Reflection.getTypeFullName(System.Threading.CancellationTokenRegistration), "FullName");
 
-            var ctr = new System.Threading.CancellationTokenRegistration();
+            var ctr = Bridge.box(new System.Threading.CancellationTokenRegistration(), System.Threading.CancellationTokenRegistration);
             Bridge.Test.Assert.true$1(Bridge.is(ctr, System.Threading.CancellationTokenRegistration), "CancellationTokenRegistration");
             Bridge.Test.Assert.true$1(Bridge.is(ctr, System.IDisposable), "IDisposable");
             Bridge.Test.Assert.true$1(Bridge.is(ctr, System.IEquatable$1(System.Threading.CancellationTokenRegistration)), "IEquatable<CancellationTokenRegistration>");
@@ -29925,9 +29923,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             cts.cancel();
             var state = 0;
             cts.token.register(function (c) {
-                Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                 state = 1;
-            }, context);
+            }, Bridge.unbox(context));
             Bridge.Test.Assert.areEqual(1, state);
         },
         registerOnACancelledSourceWithoutContextRethrowsAThrownException: function () {
@@ -29952,9 +29950,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             cts.cancel();
             try {
                 cts.token.register(function (c) {
-                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                     throw ex1;
-                }, context);
+                }, Bridge.unbox(context));
                 Bridge.Test.Assert.fail$1("Should have thrown");
             }
             catch (ex) {
@@ -29974,13 +29972,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.identity(numCalled, (numCalled = (numCalled + 1) | 0));
             }, false);
             cts.token.register(function (c) {
-                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                     numCalled = (numCalled + 1) | 0;
-                }, context);
+                }, Bridge.unbox(context));
             cts.token.register(function (c) {
-                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                     numCalled = (numCalled + 1) | 0;
-                }, context);
+                }, Bridge.unbox(context));
             Bridge.Test.Assert.areEqual(4, numCalled);
         },
         cancellationTokenSourceCanBeDisposed: function () {
@@ -30009,9 +30007,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             });
             Bridge.Test.Assert.areEqual$1(1, state, "state 1");
             ct.register(function (c) {
-                Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                 state = 2;
-            }, context);
+            }, Bridge.unbox(context));
             Bridge.Test.Assert.areEqual$1(2, state, "state 2");
         },
         duplicateCancelDoesNotCauseCallbacksToBeCalledTwice: function () {
@@ -30032,8 +30030,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             Bridge.Test.Assert.true$1(ctr1.equalsT(ctr1), "#1");
             Bridge.Test.Assert.false$1(ctr1.equalsT(ctr2), "#2");
-            Bridge.Test.Assert.true$1(Bridge.equals(ctr1, ctr1), "#3");
-            Bridge.Test.Assert.false$1(Bridge.equals(ctr1, ctr2), "#4");
+            Bridge.Test.Assert.true$1(Bridge.equals(ctr1, Bridge.unbox(Bridge.box(ctr1, System.Threading.CancellationTokenRegistration))), "#3");
+            Bridge.Test.Assert.false$1(Bridge.equals(ctr1, Bridge.unbox(Bridge.box(ctr2, System.Threading.CancellationTokenRegistration))), "#4");
 
             Bridge.Test.Assert.true$1(Bridge.equals(ctr1, ctr1), "#5");
             Bridge.Test.Assert.false$1(Bridge.equals(ctr1, ctr2), "#6");
@@ -30158,12 +30156,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early.");
             Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, task.status, "Task should be running before promise is completed.");
-            promise.resolve([42, "result 123", 101]);
+            promise.resolve([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
 
             task1.continueWith(function (x) {
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.ranToCompletion, task.status, "Task should be completed after promise");
                 Bridge.Test.Assert.true$1(continuationRun, "Continuation should have been run after promise was completed.");
-                Bridge.Test.Assert.areDeepEqual$1([42, "result 123", 101], task.getResult(), "The result should be correct");
+                Bridge.Test.Assert.areDeepEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], task.getResult(), "The result should be correct");
 
                 completeAsync();
             });
@@ -30187,7 +30185,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early.");
             Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, task.status, "Task should be running before promise is completed.");
-            promise.resolve([42, "result 123", 101]);
+            promise.resolve([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
 
             task1.continueWith(function (x) {
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.ranToCompletion, task.status, "Task should be completed after promise");
@@ -30218,7 +30216,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early.");
             Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, task.status, "Task should be running before promise is completed.");
-            promise.reject([42, "result 123", 101]);
+            promise.reject([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
 
             task1.continueWith(function (x) {
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.faulted, task.status, "Task should have faulted after the promise was rejected.");
@@ -30226,7 +30224,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.true$1(Bridge.is(task.exception, System.AggregateException), "Exception should be an AggregateException");
                 Bridge.Test.Assert.areEqual$1(1, task.exception.innerExceptions.getCount(), "Exception should have one inner exception");
                 Bridge.Test.Assert.true$1(Bridge.is(task.exception.innerExceptions.get(0), Bridge.PromiseException), "Inner exception should be a PromiseException");
-                Bridge.Test.Assert.areDeepEqual$1([42, "result 123", 101], Bridge.cast(task.exception.innerExceptions.get(0), Bridge.PromiseException).arguments, "The PromiseException arguments should be correct");
+                Bridge.Test.Assert.areDeepEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], Bridge.cast(task.exception.innerExceptions.get(0), Bridge.PromiseException).arguments, "The PromiseException arguments should be correct");
 
                 completeAsync();
             });
@@ -30252,7 +30250,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
                                     task = System.Threading.Tasks.Task.run(function () {
                                         Bridge.Test.Assert.true$1(result == null, "Await should not finish too early (a).");
-                                        promise.resolve([42, "result 123", 101]);
+                                        promise.resolve([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
                                     });
 
                                     Bridge.Test.Assert.true$1(result == null, "Await should not finish too early (b).");
@@ -30266,7 +30264,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                                 $taskResult1 = $task1.getAwaitedResult();
                                 result = $taskResult1;
 
-                                    Bridge.Test.Assert.areEqual$1([42, "result 123", 101], result, "The result should be correct");
+                                    Bridge.Test.Assert.areEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], result, "The result should be correct");
                                     completeAsync();
                                 return;
                             }
@@ -30307,7 +30305,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
                                         task = System.Threading.Tasks.Task.run(function () {
                                             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early (a).");
-                                            promise.reject([42, "result 123", 101]);
+                                            promise.reject([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
                                         });
                                     $step = 1;
                                     continue;
@@ -30328,7 +30326,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                                 }
                                 case 3: {
                                     continuationRun = true;
-                                        Bridge.Test.Assert.areEqual$1([42, "result 123", 101], ex.arguments, "The PromiseException arguments should be correct");
+                                        Bridge.Test.Assert.areEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], ex.arguments, "The PromiseException arguments should be correct");
                                         $async_e = null;
                                     $step = 5;
                                     continue;
@@ -30374,7 +30372,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         handleProgress: function (args) {
             if (args === void 0) { args = []; }
-            var i = System.Nullable.getValue(Bridge.cast(args[0], System.Int32));
+            var i = System.Nullable.getValue(Bridge.cast(Bridge.unbox(args[0]), System.Int32));
             this.setPromiseProgress(i);
         },
         taskFromPromiseWithProgressWithoutResultFactoryWorksWhenPromiseProgressesAndCompletes: function () {
@@ -30397,17 +30395,17 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early.");
             Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, task.status, "Task should be running before promise is completed.");
 
-            promise.progress([20]);
+            promise.progress([Bridge.box(20, System.Int32)]);
             Bridge.Test.Assert.areEqual$1(20, this.getPromiseProgress(), "Progress 20");
 
             // Resolve will set Progress to 100%
-            promise.resolve([42, "result 123", 101]);
+            promise.resolve([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
             Bridge.Test.Assert.areEqual$1(100, this.getPromiseProgress(), "Progress 100");
 
             task1.continueWith(function (x) {
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.ranToCompletion, task.status, "Task should be completed after promise");
                 Bridge.Test.Assert.true$1(continuationRun, "Continuation should have been run after promise was completed.");
-                Bridge.Test.Assert.areDeepEqual$1([42, "result 123", 101], task.getResult(), "The result should be correct");
+                Bridge.Test.Assert.areDeepEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], task.getResult(), "The result should be correct");
 
                 completeAsync();
             });
@@ -30419,9 +30417,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     Bridge.apply($_.Bridge.ClientTest.Threading.PromiseTests, {
         f1: function (i, s, j) {
             return Bridge.merge(new Bridge.ClientTest.Threading.PromiseTests.TaskResult(), {
-                setI: i,
-                setS: s,
-                setJ: j
+                setI: System.Nullable.getValue(Bridge.cast(Bridge.unbox(i), System.Int32)),
+                setS: Bridge.cast(s, String),
+                setJ: System.Nullable.getValue(Bridge.cast(Bridge.unbox(j), System.Int32))
             } );
         }
     });
@@ -30496,7 +30494,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 }
 
                 if (!Bridge.staticEquals(aThen.getProgress(), null)) {
-                    aThen.getProgress()([100]);
+                    aThen.getProgress()([Bridge.box(100, System.Int32)]);
                 }
 
                 i = (i + 1) | 0;
@@ -31071,7 +31069,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.areEqual$1(null, task.exception, "task should not have an exception");
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, continuedTask.status, "continuedTask should be running at point 2");
 
-                return t.getResult() + "_";
+                return Bridge.box(t.getResult(), System.Int32) + "_";
             });
 
             Bridge.Test.Assert.false$1(Bridge.referenceEquals(task, continuedTask), "task and continuedTask should not be the same");
@@ -31983,8 +31981,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                                         Bridge.Test.Assert.throws$7(System.InvalidOperationException, function () {
                                             timer.change(1, 1);
                                         }, "No change after Dispose allowed");
-                                        Bridge.Test.Assert.true$1(count > 0, "Ticks: " + count);
-                                        Bridge.Test.Assert.areEqual$1("SomeState", Bridge.ClientTest.Threading.TimerTests.getStaticData(), "State works");
+                                        Bridge.Test.Assert.true$1(count > 0, "Ticks: " + Bridge.box(count, System.Int32));
+                                        Bridge.Test.Assert.areEqual$1("SomeState", Bridge.unbox(Bridge.ClientTest.Threading.TimerTests.getStaticData()), "State works");
 
                                         $task2 = System.Threading.Tasks.Task.delay(200);
                                         $step = 2;
@@ -32041,8 +32039,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                                         Bridge.Test.Assert.throws$7(System.InvalidOperationException, function () {
                                             timer.change(1, 1);
                                         }, "No change after Dispose allowed");
-                                        Bridge.Test.Assert.true$1(count > 0, "Ticks: " + count);
-                                        Bridge.Test.Assert.areEqual$1("SomeState", ts.getData(), "State works");
+                                        Bridge.Test.Assert.true$1(count > 0, "Ticks: " + Bridge.box(count, System.Int32));
+                                        Bridge.Test.Assert.areEqual$1("SomeState", Bridge.unbox(ts.getData()), "State works");
 
                                         $task2 = System.Threading.Tasks.Task.delay(200);
                                         $step = 2;
@@ -32149,8 +32147,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                                     count = Bridge.ClientTest.Threading.TimerTests.getStaticCounter();
                                     timer.change(-1, 0);
 
-                                    Bridge.Test.Assert.true$1(count > 0, "Ticks: " + count);
-                                    Bridge.Test.Assert.areEqual$1("SomeState", Bridge.ClientTest.Threading.TimerTests.getStaticData(), "State works");
+                                    Bridge.Test.Assert.true$1(count > 0, "Ticks: " + Bridge.box(count, System.Int32));
+                                    Bridge.Test.Assert.areEqual$1("SomeState", Bridge.unbox(Bridge.ClientTest.Threading.TimerTests.getStaticData()), "State works");
 
                                     $task2 = System.Threading.Tasks.Task.delay(200);
                                     $step = 2;
@@ -32216,8 +32214,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                                     count = ts.getCounter();
                                     timer.change(-1, 0);
 
-                                    Bridge.Test.Assert.true$1(count > 0, "Ticks: " + count);
-                                    Bridge.Test.Assert.areEqual$1("SomeState", ts.getData(), "State works");
+                                    Bridge.Test.Assert.true$1(count > 0, "Ticks: " + Bridge.box(count, System.Int32));
+                                    Bridge.Test.Assert.areEqual$1("SomeState", Bridge.unbox(ts.getData()), "State works");
 
                                     $task2 = System.Threading.Tasks.Task.delay(200);
                                     $step = 2;
@@ -32730,7 +32728,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [false];
             this.verifyFromObject(function (value) { return System.Convert.toBoolean(value); }, function (value, provider) { return System.Convert.toBoolean(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toBoolean(value); }, function (value, provider) { return System.Convert.toBoolean(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -32820,7 +32818,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [0];
             this.verifyFromObject(function (value) { return System.Convert.toByte(value); }, function (value, provider) { return System.Convert.toByte(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toByte(value); }, function (value, provider) { return System.Convert.toByte(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -32916,7 +32914,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             this.verifyThrows(System.InvalidCastException, System.Decimal, function (value) { return System.Convert.toChar(value, null, 15); }, invalidValues);
         },
         fromDecimalViaObject: function () {
-            var invalidValues = [System.Decimal(0.0), System.Decimal.MinValue, System.Decimal.MaxValue];
+            var invalidValues = [Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MinValue, System.Decimal, $box_.System.Decimal.toString), Bridge.box(System.Decimal.MaxValue, System.Decimal, $box_.System.Decimal.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toChar(value, null, 1); }, function (value, provider) { return System.Convert.toChar(value, provider, 1); }, invalidValues);
         },
         fromDouble: function () {
@@ -32924,7 +32922,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             this.verifyThrows(System.InvalidCastException, System.Double, function (value) { return System.Convert.toChar(value, null, 14); }, invalidValues);
         },
         fromDoubleViaObject: function () {
-            var invalidValues = [0.0, System.Double.min, System.Double.max];
+            var invalidValues = [Bridge.box(0.0, System.Double, $box_.System.Double.toString), Bridge.box(System.Double.min, System.Double, $box_.System.Double.toString), Bridge.box(System.Double.max, System.Double, $box_.System.Double.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toChar(value, null, 1); }, function (value, provider) { return System.Convert.toChar(value, provider, 1); }, invalidValues);
         },
         fromInt16: function () {
@@ -32956,7 +32954,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [0];
             this.verify(Object, function (value) { return System.Convert.toChar(value, null, 1); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyThrows(System.InvalidCastException, Object, function (value) { return System.Convert.toChar(value, null, 1); }, invalidValues);
         },
         fromSByte: function () {
@@ -32972,7 +32970,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             this.verifyThrows(System.InvalidCastException, System.Single, function (value) { return System.Convert.toChar(value, null, 13); }, invalidValues);
         },
         fromSingleViaObject: function () {
-            var invalidValues = [0.0, -3.40282347E+38, 3.40282347E+38];
+            var invalidValues = [Bridge.box(0.0, System.Single, $box_.System.Single.toString), Bridge.box(-3.40282347E+38, System.Single, $box_.System.Single.toString), Bridge.box(3.40282347E+38, System.Single, $box_.System.Single.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toChar(value, null, 1); }, function (value, provider) { return System.Convert.toChar(value, provider, 1); }, invalidValues);
         },
         fromString: function () {
@@ -33026,7 +33024,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             }
 
             var dateTimeFormat = System.Globalization.CultureInfo.getCurrentCulture().dateTimeFormat;
-            var pattern = System.String.concat(dateTimeFormat.longDatePattern, String.fromCharCode(32), dateTimeFormat.longTimePattern);
+            var pattern = System.String.concat(dateTimeFormat.longDatePattern, String.fromCharCode(Bridge.box(32, System.Char, $box_.System.Char.toString)), dateTimeFormat.longTimePattern);
             var testValues = System.Array.init(expectedValues.length, null);
             for (var i = 0; i < expectedValues.length; i = (i + 1) | 0) {
                 testValues[i] = Bridge.Date.format(expectedValues[i], pattern, dateTimeFormat);
@@ -33047,7 +33045,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             for (var i = 0; i < testValues.length; i = (i + 1) | 0) {
                 var result = System.Convert.toDateTime(testValues[i], Bridge.ClientTest.ConvertTests.ConvertToDateTimeTests.s_dateTimeFormatInfo);
                 Bridge.Test.Assert.areEqual(expectedValues[i], result);
-                result = System.Convert.toDateTime(testValues[i], Bridge.ClientTest.ConvertTests.ConvertToDateTimeTests.s_dateTimeFormatInfo);
+                result = System.Convert.toDateTime(Bridge.unbox(testValues[i]), Bridge.ClientTest.ConvertTests.ConvertToDateTimeTests.s_dateTimeFormatInfo);
                 Bridge.Test.Assert.areEqual(expectedValues[i], result);
             }
 
@@ -33115,13 +33113,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.apply($_.Bridge.ClientTest.ConvertTests.ConvertToDateTimeTests, {
         f1: function () {
-            System.Convert.toDateTime({  });
+            System.Convert.toDateTime(Bridge.unbox({  }));
         },
         f2: function (err) {
             return Bridge.is(err, System.InvalidCastException);
         },
         f3: function () {
-            System.Convert.toDateTime({  }, Bridge.ClientTest.ConvertTests.ConvertToDateTimeTests.s_dateTimeFormatInfo);
+            System.Convert.toDateTime(Bridge.unbox({  }), Bridge.ClientTest.ConvertTests.ConvertToDateTimeTests.s_dateTimeFormatInfo);
         },
         f4: function () {
             System.Convert.toDateTime(false);
@@ -33197,7 +33195,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [System.Decimal(0)];
             this.verifyFromObject(function (value) { return System.Convert.toDecimal(value); }, function (value, provider) { return System.Convert.toDecimal(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toDecimal(value); }, function (value, provider) { return System.Convert.toDecimal(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -33291,7 +33289,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [0.0];
             this.verifyFromObject(function (value) { return System.Convert.toDouble(value); }, function (value, provider) { return System.Convert.toDouble(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toDouble(value); }, function (value, provider) { return System.Convert.toDouble(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -33394,7 +33392,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [0];
             this.verifyFromObject(function (value) { return System.Convert.toInt16(value); }, function (value, provider) { return System.Convert.toInt16(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toInt16(value); }, function (value, provider) { return System.Convert.toInt16(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -33652,7 +33650,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [System.Int64(0)];
             this.verifyFromObject(function (value) { return System.Convert.toInt64(value); }, function (value, provider) { return System.Convert.toInt64(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toInt64(value); }, function (value, provider) { return System.Convert.toInt64(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -33788,7 +33786,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [0];
             this.verifyFromObject(function (value) { return System.Convert.toSByte(value); }, function (value, provider) { return System.Convert.toSByte(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toSByte(value); }, function (value, provider) { return System.Convert.toSByte(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -33919,7 +33917,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [0.0];
             this.verifyFromObject(function (value) { return System.Convert.toSingle(value); }, function (value, provider) { return System.Convert.toSingle(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toSingle(value); }, function (value, provider) { return System.Convert.toSingle(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -34024,7 +34022,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [0];
             this.verifyFromObject(function (value) { return System.Convert.toUInt16(value); }, function (value, provider) { return System.Convert.toUInt16(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toUInt16(value); }, function (value, provider) { return System.Convert.toUInt16(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -34159,7 +34157,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [0];
             this.verifyFromObject(function (value) { return System.Convert.toUInt32(value); }, function (value, provider) { return System.Convert.toUInt32(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toUInt32(value); }, function (value, provider) { return System.Convert.toUInt32(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -34293,7 +34291,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var expectedValues = [System.UInt64(0)];
             this.verifyFromObject(function (value) { return System.Convert.toUInt64(value); }, function (value, provider) { return System.Convert.toUInt64(value, provider); }, testValues, expectedValues);
 
-            var invalidValues = [{  }, new Date()];
+            var invalidValues = [{  }, Bridge.box(new Date(), Date, $box_.Date.toString)];
             this.verifyFromObjectThrows(System.InvalidCastException, function (value) { return System.Convert.toUInt64(value); }, function (value, provider) { return System.Convert.toUInt64(value, provider); }, invalidValues);
         },
         fromSByte: function () {
@@ -34679,7 +34677,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         ctor: function (x, y) {
             this.$initialize();
             Bridge.ClientTest.Reflection.TypeSystemTests.BaseNamedConstructorWithArgumentsTypes.B.ctor.call(this, ((x + 1) | 0), ((y + 1) | 0));
-            this.messageD = x + " " + y;
+            this.messageD = Bridge.box(x, System.Int32) + " " + Bridge.box(y, System.Int32);
         }
     });
 
@@ -34699,7 +34697,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         ctor: function (x, y) {
             this.$initialize();
             Bridge.ClientTest.Reflection.TypeSystemTests.BaseUnnamedConstructorWithArgumentsTypes.B.ctor.call(this, ((x + 1) | 0), ((y + 1) | 0));
-            this.messageD = x + " " + y;
+            this.messageD = Bridge.box(x, System.Int32) + " " + Bridge.box(y, System.Int32);
         }
     });
 
@@ -34826,7 +34824,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             return ((((x - y) | 0) - this.m) | 0);
         },
         g: function (T, x, y) {
-            return System.String.concat(((((x - y) | 0) - this.m) | 0), Bridge.Reflection.getTypeName(T));
+            return System.String.concat(Bridge.box(((((x - y) | 0) - this.m) | 0), System.Int32), Bridge.Reflection.getTypeName(T));
         },
         getF: function () {
             return Bridge.fn.bind(this, Bridge.ClientTest.Reflection.TypeSystemTests.MethodGroupConversionTypes.B.prototype.f);
@@ -34891,7 +34889,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(4, captures.getCount(), "Captures.Count");
             Bridge.Test.Assert.areEqual$1(true, captures.getIsReadOnly(), "Captures.IsReadOnly");
             Bridge.Test.Assert.areEqual$1(false, captures.getIsSynchronized(), "Captures.IsSynchronized");
-            Bridge.Test.Assert.areEqual$1(group, captures.getSyncRoot(), "Captures.SyncRoot");
+            Bridge.Test.Assert.areEqual$1(group, Bridge.unbox(captures.getSyncRoot()), "Captures.SyncRoot");
         },
         captureCollectionForeachTest: function () {
             var $t;
@@ -34904,7 +34902,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             while ($t.moveNext()) {
                 var captureObj = $t.getCurrent();
                 var capture = Bridge.as(captureObj, System.Text.RegularExpressions.Capture);
-                this.capturesAreEqual(captures.get(i), capture, "Captures[" + i + "]");
+                this.capturesAreEqual(captures.get(i), capture, "Captures[" + Bridge.box(i, System.Int32) + "]");
                 i = (i + 1) | 0;
             }
         },
@@ -34920,7 +34918,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var i = 0;
             do {
                 var capture = Bridge.as(en.System$Collections$IEnumerator$getCurrent(), System.Text.RegularExpressions.Capture);
-                this.capturesAreEqual(captures.get(i), capture, "Captures[" + i + "]");
+                this.capturesAreEqual(captures.get(i), capture, "Captures[" + Bridge.box(i, System.Int32) + "]");
                 i = (i + 1) | 0;
             } while (en.System$Collections$IEnumerator$moveNext());
 
@@ -34935,7 +34933,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             captures.copyTo(dstArray, 0);
 
             for (var i = 0; i < captures.getCount(); i = (i + 1) | 0) {
-                this.capturesAreEqual(captures.get(i), dstArray[i], "Captures[" + i + "]");
+                this.capturesAreEqual(captures.get(i), dstArray[i], "Captures[" + Bridge.box(i, System.Int32) + "]");
             }
 
             Bridge.Test.Assert.throws$2(function () {
@@ -35287,7 +35285,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             $t = Bridge.getEnumerator(m.getGroups());
             while ($t.moveNext()) {
                 var group = Bridge.cast($t.getCurrent(), System.Text.RegularExpressions.Group);
-                Bridge.Test.Assert.areEqual$1(expected.getItem(i), group.getValue(), "Group[" + i + "].Value is correct");
+                Bridge.Test.Assert.areEqual$1(expected.getItem(i), group.getValue(), "Group[" + Bridge.box(i, System.Int32) + "].Value is correct");
                 i = (i + 1) | 0;
             }
         },
@@ -35447,7 +35445,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(2, groups.getCount(), "Groups.Count");
             Bridge.Test.Assert.areEqual$1(true, groups.getIsReadOnly(), "Groups.IsReadOnly");
             Bridge.Test.Assert.areEqual$1(false, groups.getIsSynchronized(), "Groups.IsSynchronized");
-            Bridge.Test.Assert.areEqual$1(m, groups.getSyncRoot(), "Groups.SyncRoot");
+            Bridge.Test.Assert.areEqual$1(m, Bridge.unbox(groups.getSyncRoot()), "Groups.SyncRoot");
         },
         groupCollectionForeachTest: function () {
             var $t;
@@ -35459,7 +35457,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             while ($t.moveNext()) {
                 var groupObj = $t.getCurrent();
                 var group = Bridge.as(groupObj, System.Text.RegularExpressions.Group);
-                this.groupsAreEqual(groups.get(i), group, "Groups[" + i + "]");
+                this.groupsAreEqual(groups.get(i), group, "Groups[" + Bridge.box(i, System.Int32) + "]");
                 i = (i + 1) | 0;
             }
         },
@@ -35474,7 +35472,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var i = 0;
             do {
                 var group = Bridge.as(en.System$Collections$IEnumerator$getCurrent(), System.Text.RegularExpressions.Group);
-                this.groupsAreEqual(groups.get(i), group, "Groups[" + i + "]");
+                this.groupsAreEqual(groups.get(i), group, "Groups[" + Bridge.box(i, System.Int32) + "]");
                 i = (i + 1) | 0;
             } while (en.System$Collections$IEnumerator$moveNext());
 
@@ -35488,7 +35486,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             groups.copyTo(dstArray, 0);
 
             for (var i = 0; i < groups.getCount(); i = (i + 1) | 0) {
-                this.groupsAreEqual(groups.get(i), dstArray[i], "Groups[" + i + "]");
+                this.groupsAreEqual(groups.get(i), dstArray[i], "Groups[" + Bridge.box(i, System.Int32) + "]");
             }
 
             Bridge.Test.Assert.throws$2(function () {
@@ -35565,7 +35563,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(2, matches.getCount(), "Matches.Count");
             Bridge.Test.Assert.areEqual$1(true, matches.getIsReadOnly(), "Matches.IsReadOnly");
             Bridge.Test.Assert.areEqual$1(false, matches.getIsSynchronized(), "Matches.IsSynchronized");
-            Bridge.Test.Assert.areEqual$1(matches, matches.getSyncRoot(), "Matches.SyncRoot");
+            Bridge.Test.Assert.areEqual$1(matches, Bridge.unbox(matches.getSyncRoot()), "Matches.SyncRoot");
         },
         matchCollectionItemsTest: function () {
             var match1 = Bridge.ClientTest.Text.RegularExpressions.Entities.RegexMatchCollectionTests.getTestDataMatch();
@@ -35576,7 +35574,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             Bridge.Test.Assert.areEqual(expected.length, matches.getCount());
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
-                this.matchesAreEqual(expected[i], matches.get(i), "Matches[" + i + "]");
+                this.matchesAreEqual(expected[i], matches.get(i), "Matches[" + Bridge.box(i, System.Int32) + "]");
             }
         },
         matchCollectionForeachTest: function () {
@@ -35591,7 +35589,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             while ($t.moveNext()) {
                 var matchObj = $t.getCurrent();
                 var match = Bridge.as(matchObj, System.Text.RegularExpressions.Match);
-                this.matchesAreEqual(expected[i], match, "Matches[" + i + "]");
+                this.matchesAreEqual(expected[i], match, "Matches[" + Bridge.box(i, System.Int32) + "]");
                 i = (i + 1) | 0;
             }
         },
@@ -35609,7 +35607,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var i = 0;
             do {
                 var match = Bridge.as(en.System$Collections$IEnumerator$getCurrent(), System.Text.RegularExpressions.Match);
-                this.matchesAreEqual(expected[i], match, "Matches[" + i + "]");
+                this.matchesAreEqual(expected[i], match, "Matches[" + Bridge.box(i, System.Int32) + "]");
                 i = (i + 1) | 0;
             } while (en.System$Collections$IEnumerator$moveNext());
 
@@ -35621,7 +35619,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             matches.copyTo(dstArray, 0);
 
             for (var i = 0; i < matches.getCount(); i = (i + 1) | 0) {
-                this.matchesAreEqual(matches.get(i), dstArray[i], "Matches[" + i + "]");
+                this.matchesAreEqual(matches.get(i), dstArray[i], "Matches[" + Bridge.box(i, System.Int32) + "]");
             }
 
             Bridge.Test.Assert.throws$2(function () {
@@ -35640,8 +35638,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
             Bridge.Test.Assert.areEqual(((tstText.length + 1) | 0), matches.getCount());
             for (var i = 0; i < matches.getCount(); i = (i + 1) | 0) {
-                Bridge.Test.Assert.areEqual$1(i, matches.get(i).getIndex(), "Matches[" + i + "].Index");
-                Bridge.Test.Assert.areEqual$1(0, matches.get(i).getLength(), "Matches[" + i + "].Length");
+                Bridge.Test.Assert.areEqual$1(i, matches.get(i).getIndex(), "Matches[" + Bridge.box(i, System.Int32) + "].Index");
+                Bridge.Test.Assert.areEqual$1(0, matches.get(i).getLength(), "Matches[" + Bridge.box(i, System.Int32) + "].Length");
             }
         }
     });
@@ -35956,12 +35954,12 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             while ($t.moveNext()) {
                 var ch = $t.getCurrent();
                 try {
-                    var rgx = new System.Text.RegularExpressions.Regex.ctor("\\" + String.fromCharCode(ch));
-                    rgx.match("" + String.fromCharCode(ch));
+                    var rgx = new System.Text.RegularExpressions.Regex.ctor("\\" + String.fromCharCode(Bridge.box(ch, System.Char, $box_.System.Char.toString)));
+                    rgx.match("" + String.fromCharCode(Bridge.box(ch, System.Char, $box_.System.Char.toString)));
                 }
                 catch ($e1) {
                     $e1 = System.Exception.create($e1);
-                    Bridge.Test.Assert.false$1(true, "Char must be escapable: " + String.fromCharCode(ch));
+                    Bridge.Test.Assert.false$1(true, "Char must be escapable: " + String.fromCharCode(Bridge.box(ch, System.Char, $box_.System.Char.toString)));
                 }
             }
         },
@@ -35973,9 +35971,9 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 (function () {
                     var ch = $t.getCurrent();
                     Bridge.Test.Assert.throws$7(System.ArgumentException, function () {
-                        var rgx = new System.Text.RegularExpressions.Regex.ctor("\\" + String.fromCharCode(ch));
-                        rgx.match("" + String.fromCharCode(ch));
-                    }, "Char must not be escapable: " + String.fromCharCode(ch));
+                        var rgx = new System.Text.RegularExpressions.Regex.ctor("\\" + String.fromCharCode(Bridge.box(ch, System.Char, $box_.System.Char.toString)));
+                        rgx.match("" + String.fromCharCode(Bridge.box(ch, System.Char, $box_.System.Char.toString)));
+                    }, "Char must not be escapable: " + String.fromCharCode(Bridge.box(ch, System.Char, $box_.System.Char.toString)));
                 }).call(this);
             }
         }
@@ -37375,7 +37373,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             $t = Bridge.getEnumerator(System.Text.RegularExpressions.Regex.matches(input, pattern));
             while ($t.moveNext()) {
                 var match = Bridge.cast($t.getCurrent(), System.Text.RegularExpressions.Match);
-                actuals.add(System.String.format("{0}_{1}", match.getValue(), match.getIndex()));
+                actuals.add(System.String.format("{0}_{1}", match.getValue(), Bridge.box(match.getIndex(), System.Int32)));
             }
 
             this.validateCollection(String, expecteds, actuals.toArray(), "Result");
@@ -37391,7 +37389,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             $t = Bridge.getEnumerator(System.Text.RegularExpressions.Regex.matches(input, pattern));
             while ($t.moveNext()) {
                 var match = Bridge.cast($t.getCurrent(), System.Text.RegularExpressions.Match);
-                actuals.add(System.String.format("{0}_{1}", match.getValue(), match.getIndex()));
+                actuals.add(System.String.format("{0}_{1}", match.getValue(), Bridge.box(match.getIndex(), System.Int32)));
             }
 
             this.validateCollection(String, expecteds, actuals.toArray(), "Result");
@@ -43259,6 +43257,105 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
 
     Bridge.define("Bridge.ClientTest.TypeSystemTests.C", {
         inherits: [Bridge.ClientTest.TypeSystemTests.B,Bridge.ClientTest.TypeSystemTests.I4]
+    });
+
+    var $box_ = {};
+
+    Bridge.ns("Boolean", $box_);
+
+    Bridge.apply($box_.Boolean, {
+        toString: function(obj) {return System.Boolean.toString(obj);}
+    });
+
+
+    Bridge.ns("System.Double", $box_);
+
+    Bridge.apply($box_.System.Double, {
+        toString: function(obj) {return System.Double.format(obj, 'G');}
+    });
+
+
+    Bridge.ns("System.Decimal", $box_);
+
+    Bridge.apply($box_.System.Decimal, {
+        toString: function(obj) {return Bridge.Int.format(obj, 'G');}
+    });
+
+
+    Bridge.ns("System.Char", $box_);
+
+    Bridge.apply($box_.System.Char, {
+        toString: function(obj) {return String.fromCharCode(obj);}
+    });
+
+
+    Bridge.ns("System.Single", $box_);
+
+    Bridge.apply($box_.System.Single, {
+        toString: function(obj) {return System.Single.format(obj, 'G');}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("Date", $box_);
+
+    Bridge.apply($box_.Date, {
+        toString: function(obj) {return Bridge.Date.format(obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E2", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E2, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E2, obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests.E1, obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Reflection.TypeSystemTests.NamedValuesEnum, obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Reflection.TypeSystemTests.ImportedNamedValuesEnum", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Reflection.TypeSystemTests.ImportedNamedValuesEnum, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Reflection.TypeSystemTests.ImportedNamedValuesEnum, obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.SimpleTypes.EnumTests.TestEnum, obj);}
+    });
+
+
+    Bridge.ns("Number", $box_);
+
+    Bridge.apply($box_.Number, {
+        toString: function(obj) {return System.Enum.toString(Number, obj);}
     });
 
     var $m = Bridge.setMetadata,

--- a/Tests/Runner/Batch2/code.js
+++ b/Tests/Runner/Batch2/code.js
@@ -20,28 +20,28 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
     Bridge.define("Bridge.ClientTest.Batch2.BridgeIssues.Bridge1499", {
         testObjectStringCoalesceWorks: function () {
             var $t, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10, $t11, $t12, $t13, $t14, $t15, $t16, $t17, $t18, $t19;
-            var def = 1;
+            var def = Bridge.box(1, System.Int32);
             var app = null;
             var o1 = "";
             var o2 = "test";
             var o3 = null;
 
-            Bridge.Test.Assert.areStrictEqual(1, ($t = app, $t !== null ? $t : def));
-            Bridge.Test.Assert.areStrictEqual("", ($t1 = o1, $t1 !== null ? $t1 : o2));
-            Bridge.Test.Assert.areStrictEqual("", ($t2 = o1, $t2 !== null ? $t2 : "test"));
-            Bridge.Test.Assert.areStrictEqual("test", ($t3 = o3, $t3 !== null ? $t3 : o2));
-            Bridge.Test.Assert.areStrictEqual("test", ($t4 = o3, $t4 !== null ? $t4 : "test"));
+            Bridge.Test.Assert.areStrictEqual(1, Bridge.unbox(($t = app, $t !== null ? $t : def)));
+            Bridge.Test.Assert.areStrictEqual("", Bridge.unbox(($t1 = o1, $t1 !== null ? $t1 : o2)));
+            Bridge.Test.Assert.areStrictEqual("", Bridge.unbox(($t2 = o1, $t2 !== null ? $t2 : "test")));
+            Bridge.Test.Assert.areStrictEqual("test", Bridge.unbox(($t3 = o3, $t3 !== null ? $t3 : o2)));
+            Bridge.Test.Assert.areStrictEqual("test", Bridge.unbox(($t4 = o3, $t4 !== null ? $t4 : "test")));
 
             var s1 = "";
             var s2 = "test";
             var s3 = null;
 
             Bridge.Test.Assert.areStrictEqual("", ($t5 = s1, $t5 !== null ? $t5 : s2));
-            Bridge.Test.Assert.areStrictEqual("", ($t6 = s1, $t6 !== null ? $t6 : o2));
+            Bridge.Test.Assert.areStrictEqual("", Bridge.unbox(($t6 = s1, $t6 !== null ? $t6 : o2)));
             Bridge.Test.Assert.areStrictEqual("", ($t7 = s1, $t7 !== null ? $t7 : "test"));
             Bridge.Test.Assert.areStrictEqual("", ($t8 = "", $t8 !== null ? $t8 : "test"));
             Bridge.Test.Assert.areStrictEqual("test", ($t9 = s3, $t9 !== null ? $t9 : s2));
-            Bridge.Test.Assert.areStrictEqual("test", ($t10 = s3, $t10 !== null ? $t10 : o2));
+            Bridge.Test.Assert.areStrictEqual("test", Bridge.unbox(($t10 = s3, $t10 !== null ? $t10 : o2)));
             Bridge.Test.Assert.areStrictEqual("test", ($t11 = s3, $t11 !== null ? $t11 : "test"));
             Bridge.Test.Assert.areStrictEqual("test", ($t12 = null, $t12 !== null ? $t12 : "test"));
 
@@ -50,10 +50,10 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
             var i3 = null;
 
             Bridge.Test.Assert.areStrictEqual(0, ($t13 = i1, $t13 !== null ? $t13 : i2));
-            Bridge.Test.Assert.areStrictEqual(0, ($t14 = i1, $t14 !== null ? $t14 : o2));
+            Bridge.Test.Assert.areStrictEqual(0, Bridge.unbox(($t14 = i1, $t14 !== null ? Bridge.box($t14, System.Int32, $box_.System.Nullable$1.toString) : o2)));
             Bridge.Test.Assert.areStrictEqual(0, ($t15 = i1, $t15 !== null ? $t15 : 1));
             Bridge.Test.Assert.areStrictEqual(1, ($t16 = i3, $t16 !== null ? $t16 : i2));
-            Bridge.Test.Assert.areStrictEqual("test", ($t17 = i3, $t17 !== null ? $t17 : o2));
+            Bridge.Test.Assert.areStrictEqual("test", Bridge.unbox(($t17 = i3, $t17 !== null ? Bridge.box($t17, System.Int32, $box_.System.Nullable$1.toString) : o2)));
             Bridge.Test.Assert.areStrictEqual(1, ($t18 = i3, $t18 !== null ? $t18 : 1));
             Bridge.Test.Assert.areStrictEqual(1, ($t19 = null, $t19 !== null ? $t19 : i2));
         }
@@ -101,8 +101,8 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var temp1 = temp;
                 var temp2 = {  };
                 var l = System.Int64(5);
-                var ol = System.Int64(5);
-                var oi = 5;
+                var ol = Bridge.box(System.Int64(5), System.Int64);
+                var oi = Bridge.box(5, System.Int32);
                 var varNull = null;
                 var varUndefined = temp["this-prop-undefined"];
 
@@ -208,8 +208,8 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
             Bridge.Test.Assert.areEqual("y", ["x", "y"][1]);
         },
         getValueWorks: function () {
-            Bridge.Test.Assert.areEqual("x", System.Array.get(["x", "y"], 0));
-            Bridge.Test.Assert.areEqual("y", System.Array.get(["x", "y"], 1));
+            Bridge.Test.Assert.areEqual("x", Bridge.unbox(System.Array.get(["x", "y"], 0)));
+            Bridge.Test.Assert.areEqual("y", Bridge.unbox(System.Array.get(["x", "y"], 1)));
         },
         settingValueByIndexWorks: function () {
             var arr = System.Array.init(2, null);
@@ -239,7 +239,7 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
             var arr = ["x", "y"];
             var arr2 = System.Array.clone(arr);
             Bridge.Test.Assert.false(arr === arr2);
-            Bridge.Test.Assert.areDeepEqual(arr2, arr);
+            Bridge.Test.Assert.areDeepEqual(Bridge.unbox(arr2), arr);
         },
         concatWorks: function () {
             var arr = ["a", "b"];
@@ -275,7 +275,7 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
         foreachWithArrayCallbackWorks: function () {
             var result = "";
             Bridge.Linq.Enumerable.from(["a", "b", "c"]).forEach(function (s, i) {
-                    result = System.String.concat(result, (System.String.concat(s, i)));
+                    result = System.String.concat(result, (System.String.concat(s, Bridge.box(i, System.Int32))));
                 });
             Bridge.Test.Assert.areEqual("a0b1c2", result);
         },
@@ -532,16 +532,16 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(max + 1, System.Int32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(max + 1, System.Int32), System.Int32));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.Int32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.Int32))), System.Int32));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = Bridge.Int.check(max4 + 1, System.Int32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = Bridge.Int.check(max4 + 1, System.Int32))), System.Int32));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(2 * max, System.Int32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(2 * max, System.Int32), System.Int32));
                 }, "Through parameter *");
 
                 var min = -2147483648;
@@ -565,16 +565,16 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier unary -");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(min - 1, System.Int32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(min - 1, System.Int32), System.Int32));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.Int32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.Int32))), System.Int32));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = Bridge.Int.check(min4 - 1, System.Int32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = Bridge.Int.check(min4 - 1, System.Int32))), System.Int32));
                 }, "Through parameter --pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(-min, System.Int32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(-min, System.Int32), System.Int32));
                 }, "Through parameter unary -");
             },
             testUInt32: function () {
@@ -599,16 +599,16 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(max + 1, System.UInt32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(max + 1, System.UInt32), System.UInt32));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.UInt32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.UInt32))), System.UInt32));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = Bridge.Int.check(max4 + 1, System.UInt32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = Bridge.Int.check(max4 + 1, System.UInt32))), System.UInt32));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(2 * max, System.UInt32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(2 * max, System.UInt32), System.UInt32));
                 }, "Through parameter *");
 
                 var min = 0;
@@ -629,13 +629,13 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier pre--");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(min - 1, System.UInt32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(min - 1, System.UInt32), System.UInt32));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.UInt32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.UInt32))), System.UInt32));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = Bridge.Int.check(min4 - 1, System.UInt32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = Bridge.Int.check(min4 - 1, System.UInt32))), System.UInt32));
                 }, "Through parameter --pre");
             },
             testLong: function () {
@@ -661,17 +661,17 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.Int64(1), 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1), 1), System.Int64));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(1), $t));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(1), $t), System.Int64));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc(1)));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc(1)), System.Int64));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.Int64(2).mul(max, 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max, 1), System.Int64));
                 }, "Through parameter *");
 
                 var min = System.Int64.MinValue;
@@ -696,17 +696,17 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier unary -");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.Int64(1), 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1), 1), System.Int64));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(1), $t));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(1), $t), System.Int64));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec(1)));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec(1)), System.Int64));
                 }, "Through parameter --pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.neg(1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.neg(1), System.Int64));
                 }, "Through parameter unary -");
             },
             testULong: function () {
@@ -732,17 +732,17 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.UInt64(1), 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1), 1), System.UInt64));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(1), $t));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(1), $t), System.UInt64));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc(1)));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc(1)), System.UInt64));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max, 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max, 1), System.UInt64));
                 }, "Through parameter *");
 
                 var min = System.UInt64.MinValue;
@@ -764,14 +764,14 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier pre--");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1), 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1), 1), System.UInt64));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(1), $t));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(1), $t), System.UInt64));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec(1)));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec(1)), System.UInt64));
                 }, "Through parameter --pre");
             }
         }
@@ -801,16 +801,16 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(max + 1, System.Int32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(max + 1, System.Int32), System.Int32));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.Int32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.Int32))), System.Int32));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = Bridge.Int.check(max4 + 1, System.Int32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = Bridge.Int.check(max4 + 1, System.Int32))), System.Int32));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(2 * max, System.Int32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(2 * max, System.Int32), System.Int32));
                 }, "Through parameter *");
 
                 var min = -2147483648;
@@ -834,16 +834,16 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier unary -");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(min - 1, System.Int32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(min - 1, System.Int32), System.Int32));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.Int32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.Int32))), System.Int32));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = Bridge.Int.check(min4 - 1, System.Int32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = Bridge.Int.check(min4 - 1, System.Int32))), System.Int32));
                 }, "Through parameter --pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(-min, System.Int32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(-min, System.Int32), System.Int32));
                 }, "Through parameter unary -");
             },
             testUInt32: function () {
@@ -868,16 +868,16 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(max + 1, System.UInt32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(max + 1, System.UInt32), System.UInt32));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.UInt32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = Bridge.Int.check(max3 + 1, System.UInt32))), System.UInt32));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = Bridge.Int.check(max4 + 1, System.UInt32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = Bridge.Int.check(max4 + 1, System.UInt32))), System.UInt32));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(2 * max, System.UInt32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(2 * max, System.UInt32), System.UInt32));
                 }, "Through parameter *");
 
                 var min = 0;
@@ -898,13 +898,13 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier pre--");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.Int.check(min - 1, System.UInt32));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.Int.check(min - 1, System.UInt32), System.UInt32));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.UInt32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = Bridge.Int.check(min3 - 1, System.UInt32))), System.UInt32));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = Bridge.Int.check(min4 - 1, System.UInt32))));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = Bridge.Int.check(min4 - 1, System.UInt32))), System.UInt32));
                 }, "Through parameter --pre");
             },
             testLong: function () {
@@ -930,17 +930,17 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.Int64(1), 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1), 1), System.Int64));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(1), $t));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(1), $t), System.Int64));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc(1)));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc(1)), System.Int64));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.Int64(2).mul(max, 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max, 1), System.Int64));
                 }, "Through parameter *");
 
                 var min = System.Int64.MinValue;
@@ -965,17 +965,17 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier unary -");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.Int64(1), 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1), 1), System.Int64));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(1), $t));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(1), $t), System.Int64));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec(1)));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec(1)), System.Int64));
                 }, "Through parameter --pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.neg(1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.neg(1), System.Int64));
                 }, "Through parameter unary -");
             },
             testULong: function () {
@@ -1001,17 +1001,17 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier *");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.UInt64(1), 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1), 1), System.UInt64));
                 }, "Through parameter +");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(1), $t));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(1), $t), System.UInt64));
                 }, "Through parameter post++");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc(1)));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc(1)), System.UInt64));
                 }, "Through parameter ++pre");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max, 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max, 1), System.UInt64));
                 }, "Through parameter *");
 
                 var min = System.UInt64.MinValue;
@@ -1033,14 +1033,14 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 }, "Through identifier pre--");
 
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1), 1));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1), 1), System.UInt64));
                 }, "Through parameter -");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
                     var $t;
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(1), $t));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(1), $t), System.UInt64));
                 }, "Through parameter post--");
                 Bridge.Test.Assert.throws$7(System.OverflowException, function () {
-                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec(1)));
+                    Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec(1)), System.UInt64));
                 }, "Through parameter --pre");
             }
         }
@@ -1060,15 +1060,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) | 0));
                 var rMax3 = ((max2 = (max2 + 1) | 0));
                 var rMax4 = (2 * max) | 0;
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax1, System.Int32), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMax2, System.Int32), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax3, System.Int32), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int32), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max + 1) | 0)), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) | 0))), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) | 0))), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((2 * max) | 0)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) | 0), System.Int32)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) | 0)), System.Int32)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) | 0)), System.Int32)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) | 0), System.Int32)), "Through parameter *");
 
                 var min = -2147483648;
 
@@ -1081,15 +1081,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) | 0));
                 var rMin3 = ((min2 = (min2 - 1) | 0));
                 var rMin4 = (-min) | 0;
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin1, System.Int32), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin2, System.Int32), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin3, System.Int32), "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin4, System.Int32), "Through identifier unary -");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min - 1) | 0)), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) | 0))), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) | 0))), "Through parameter --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((-min) | 0)), "Through parameter unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) | 0), System.Int32)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) | 0)), System.Int32)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) | 0)), System.Int32)), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((-min) | 0), System.Int32)), "Through parameter unary -");
             },
             testUInt32: function () {
                 var max = 4294967295;
@@ -1103,15 +1103,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) >>> 0));
                 var rMax3 = ((max2 = (max2 + 1) >>> 0));
                 var rMax4 = (2 * max) >>> 0;
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt32), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMax2, System.UInt32), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt32), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", Bridge.box(rMax4, System.UInt32), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max + 1) >>> 0)), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0))), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) >>> 0))), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((2 * max) >>> 0)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) >>> 0), System.UInt32)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0)), System.UInt32)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) >>> 0)), System.UInt32)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) >>> 0), System.UInt32)), "Through parameter *");
 
                 var min = 0;
 
@@ -1124,15 +1124,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) >>> 0));
                 var rMin3 = ((min2 = (min2 - 1) >>> 0));
                 var rMin4 = System.Int64(min).neg();
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin1, System.UInt32), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt32), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin3, System.UInt32), "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min - 1) >>> 0)), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0))), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) >>> 0))), "Through parameter --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.Int64(min).neg()), "Through parameter unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) >>> 0), System.UInt32)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0)), System.UInt32)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) >>> 0)), System.UInt32)), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(min).neg(), System.Int64)), "Through parameter unary -");
             },
             testLong: function () {
                 var $t;
@@ -1147,15 +1147,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.Int64(2).mul(max);
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax1, System.Int64), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMax2, System.Int64), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax3, System.Int64), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int64), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.Int64(1))), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.Int64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1)), System.Int64)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.Int64)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.Int64)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max), System.Int64)), "Through parameter *");
 
                 var min = System.Int64.MinValue;
 
@@ -1168,15 +1168,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
                 var rMin4 = min.neg();
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin1, System.Int64), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin2, System.Int64), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin3, System.Int64), "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.Int64(1))), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.neg()), "Through parameter unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1)), System.Int64)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.Int64)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.Int64)), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.neg(), System.Int64)), "Through parameter unary -");
             },
             testULong: function () {
                 var $t;
@@ -1191,15 +1191,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.UInt64(2).mul(max);
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt64), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMax2, System.UInt64), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt64), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.box(rMax4, System.UInt64), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.UInt64(1))), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1)), System.UInt64)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.UInt64)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.UInt64)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max), System.UInt64)), "Through parameter *");
 
                 var min = System.UInt64.MinValue;
 
@@ -1211,13 +1211,13 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin1 = min.sub(System.UInt64(1));
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin3, "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin1, System.UInt64), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt64), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin3, System.UInt64), "Through identifier --pre");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1))), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1)), System.UInt64)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.UInt64)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.UInt64)), "Through parameter --pre");
             }
         }
     });
@@ -1236,15 +1236,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) | 0));
                 var rMax3 = ((max2 = (max2 + 1) | 0));
                 var rMax4 = (2 * max) | 0;
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax1, System.Int32), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMax2, System.Int32), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMax3, System.Int32), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int32), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max + 1) | 0)), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) | 0))), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) | 0))), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((2 * max) | 0)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) | 0), System.Int32)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) | 0)), System.Int32)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) | 0)), System.Int32)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) | 0), System.Int32)), "Through parameter *");
 
                 var min = -2147483648;
 
@@ -1257,15 +1257,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) | 0));
                 var rMin3 = ((min2 = (min2 - 1) | 0));
                 var rMin4 = (-min) | 0;
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin1, System.Int32), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin2, System.Int32), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMin3, System.Int32), "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin4, System.Int32), "Through identifier unary -");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min - 1) | 0)), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) | 0))), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) | 0))), "Through parameter --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((-min) | 0)), "Through parameter unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) | 0), System.Int32)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) | 0)), System.Int32)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) | 0)), System.Int32)), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((-min) | 0), System.Int32)), "Through parameter unary -");
             },
             testUInt32: function () {
                 var max = 4294967295;
@@ -1279,15 +1279,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = Bridge.identity(max1, (max1 = (max1 + 1) >>> 0));
                 var rMax3 = ((max2 = (max2 + 1) >>> 0));
                 var rMax4 = (2 * max) >>> 0;
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt32), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMax2, System.UInt32), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt32), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", Bridge.box(rMax4, System.UInt32), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max + 1) >>> 0)), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0))), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = (max4 + 1) >>> 0))), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((2 * max) >>> 0)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max + 1) >>> 0), System.UInt32)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = (max3 + 1) >>> 0)), System.UInt32)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = (max4 + 1) >>> 0)), System.UInt32)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((2 * max) >>> 0), System.UInt32)), "Through parameter *");
 
                 var min = 0;
 
@@ -1300,15 +1300,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin2 = Bridge.identity(min1, (min1 = (min1 - 1) >>> 0));
                 var rMin3 = ((min2 = (min2 - 1) >>> 0));
                 var rMin4 = System.Int64(min).neg();
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin1, System.UInt32), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt32), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMin3, System.UInt32), "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min - 1) >>> 0)), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0))), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = (min4 - 1) >>> 0))), "Through parameter --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.Int64(min).neg()), "Through parameter unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min - 1) >>> 0), System.UInt32)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = (min3 - 1) >>> 0)), System.UInt32)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = (min4 - 1) >>> 0)), System.UInt32)), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(min).neg(), System.Int64)), "Through parameter unary -");
             },
             testLong: function () {
                 var $t;
@@ -1323,15 +1323,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.Int64(2).mul(max);
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax1, System.Int64), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMax2, System.Int64), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax3, System.Int64), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int64), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.Int64(1))), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.Int64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1)), System.Int64)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.Int64)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.Int64)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max), System.Int64)), "Through parameter *");
 
                 var min = System.Int64.MinValue;
 
@@ -1344,15 +1344,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
                 var rMin4 = min.neg();
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin1, System.Int64), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin2, System.Int64), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin3, System.Int64), "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.Int64(1))), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.neg()), "Through parameter unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1)), System.Int64)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.Int64)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.Int64)), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.neg(), System.Int64)), "Through parameter unary -");
             },
             testULong: function () {
                 var $t;
@@ -1367,15 +1367,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.UInt64(2).mul(max);
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt64), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMax2, System.UInt64), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt64), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.box(rMax4, System.UInt64), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.UInt64(1))), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1)), System.UInt64)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.UInt64)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.UInt64)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max), System.UInt64)), "Through parameter *");
 
                 var min = System.UInt64.MinValue;
 
@@ -1387,13 +1387,13 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin1 = min.sub(System.UInt64(1));
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin3, "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin1, System.UInt64), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt64), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin3, System.UInt64), "Through identifier --pre");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1))), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1)), System.UInt64)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.UInt64)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.UInt64)), "Through parameter --pre");
             }
         }
     });
@@ -1412,15 +1412,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = Bridge.identity(max1, (max1 = max1 + 1));
                 var rMax3 = ((max2 = max2 + 1));
                 var rMax4 = 2 * max;
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", Bridge.box(rMax1, System.Int32), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.box(rMax2, System.Int32), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", Bridge.box(rMax3, System.Int32), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", Bridge.box(rMax4, System.Int32), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max + 1), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = max3 + 1))), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = max4 + 1))), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(2 * max), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max + 1, System.Int32)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483647", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = max3 + 1)), System.Int32)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = max4 + 1)), System.Int32)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967294", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(2 * max, System.Int32)), "Through parameter *");
 
                 var min = -2147483648;
 
@@ -1433,15 +1433,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin2 = Bridge.identity(min1, (min1 = min1 - 1));
                 var rMin3 = ((min2 = min2 - 1));
                 var rMin4 = -min;
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483649", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483649", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483649", Bridge.box(rMin1, System.Int32), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.box(rMin2, System.Int32), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483649", Bridge.box(rMin3, System.Int32), "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", Bridge.box(rMin4, System.Int32), "Through identifier unary -");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483649", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min - 1), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = min3 - 1))), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483649", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = min4 - 1))), "Through parameter --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(-min), "Through parameter unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483649", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min - 1, System.Int32)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = min3 - 1)), System.Int32)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2147483649", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = min4 - 1)), System.Int32)), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("2147483648", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(-min, System.Int32)), "Through parameter unary -");
             },
             testUInt32: function () {
                 var max = 4294967295;
@@ -1455,15 +1455,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = Bridge.identity(max1, (max1 = max1 + 1));
                 var rMax3 = ((max2 = max2 + 1));
                 var rMax4 = 2 * max;
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967296", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967296", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("8589934590", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967296", Bridge.box(rMax1, System.UInt32), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.box(rMax2, System.UInt32), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967296", Bridge.box(rMax3, System.UInt32), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("8589934590", Bridge.box(rMax4, System.UInt32), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967296", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max + 1), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(max3, (max3 = max3 + 1))), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967296", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((max4 = max4 + 1))), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("8589934590", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(2 * max), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967296", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max + 1, System.UInt32)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967295", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(max3, (max3 = max3 + 1)), System.UInt32)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("4294967296", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((max4 = max4 + 1)), System.UInt32)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("8589934590", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(2 * max, System.UInt32)), "Through parameter *");
 
                 var min = 0;
 
@@ -1476,15 +1476,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin2 = Bridge.identity(min1, (min1 = min1 - 1));
                 var rMin3 = ((min2 = min2 - 1));
                 var rMin4 = System.Int64(min).neg();
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-1", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-1", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-1", Bridge.box(rMin1, System.UInt32), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt32), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-1", Bridge.box(rMin3, System.UInt32), "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-1", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min - 1), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.identity(min3, (min3 = min3 - 1))), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-1", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(((min4 = min4 - 1))), "Through parameter --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.Int64(min).neg()), "Through parameter unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-1", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min - 1, System.UInt32)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(Bridge.identity(min3, (min3 = min3 - 1)), System.UInt32)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-1", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(((min4 = min4 - 1)), System.UInt32)), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(min).neg(), System.Int64)), "Through parameter unary -");
             },
             testLong: function () {
                 var $t;
@@ -1499,15 +1499,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.Int64(2).mul(max);
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax1, System.Int64), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMax2, System.Int64), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMax3, System.Int64), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.box(rMax4, System.Int64), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.Int64(1))), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.Int64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.Int64(1)), System.Int64)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.Int64)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.Int64)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-2", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.Int64(2).mul(max), System.Int64)), "Through parameter *");
 
                 var min = System.Int64.MinValue;
 
@@ -1520,15 +1520,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
                 var rMin4 = min.neg();
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", rMin3, "Through identifier --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", rMin4, "Through identifier unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin1, System.Int64), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin2, System.Int64), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.box(rMin3, System.Int64), "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.box(rMin4, System.Int64), "Through identifier unary -");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.Int64(1))), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.neg()), "Through parameter unary -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.Int64(1)), System.Int64)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.Int64)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("9223372036854775807", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.Int64)), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("-9223372036854775808", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.neg(), System.Int64)), "Through parameter unary -");
             },
             testULong: function () {
                 var $t;
@@ -1543,15 +1543,15 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMax2 = ($t = max1, max1 = max1.inc(), $t);
                 var rMax3 = (max2 = max2.inc());
                 var rMax4 = System.UInt64(2).mul(max);
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax1, "Through identifier +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", rMax2, "Through identifier post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMax3, "Through identifier ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", rMax4, "Through identifier *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax1, System.UInt64), "Through identifier +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMax2, System.UInt64), "Through identifier post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMax3, System.UInt64), "Through identifier ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.box(rMax4, System.UInt64), "Through identifier *");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(max.add(System.UInt64(1))), "Through parameter +");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = max3, max3 = max3.inc(), $t)), "Through parameter post++");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((max4 = max4.inc())), "Through parameter ++pre");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(System.UInt64(2).mul(max)), "Through parameter *");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(max.add(System.UInt64(1)), System.UInt64)), "Through parameter +");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = max3, max3 = max3.inc(), $t), System.UInt64)), "Through parameter post++");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((max4 = max4.inc()), System.UInt64)), "Through parameter ++pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551614", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(System.UInt64(2).mul(max), System.UInt64)), "Through parameter *");
 
                 var min = System.UInt64.MinValue;
 
@@ -1563,13 +1563,13 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
                 var rMin1 = min.sub(System.UInt64(1));
                 var rMin2 = ($t = min1, min1 = min1.dec(), $t);
                 var rMin3 = (min2 = min2.dec());
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin1, "Through identifier -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", rMin2, "Through identifier post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", rMin3, "Through identifier --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin1, System.UInt64), "Through identifier -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.box(rMin2, System.UInt64), "Through identifier post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.box(rMin3, System.UInt64), "Through identifier --pre");
 
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(min.sub(System.UInt64(1))), "Through parameter -");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(($t = min3, min3 = min3.dec(), $t)), "Through parameter post--");
-                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass((min4 = min4.dec())), "Through parameter --pre");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(min.sub(System.UInt64(1)), System.UInt64)), "Through parameter -");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("0", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box(($t = min3, min3 = min3.dec(), $t), System.UInt64)), "Through parameter post--");
+                Bridge.ClientTest.Batch2.CheckedUncheckedTests.assertEqual("18446744073709551615", Bridge.ClientTest.Batch2.CheckedUncheckedTests.bypass(Bridge.box((min4 = min4.dec()), System.UInt64)), "Through parameter --pre");
             }
         }
     });
@@ -1580,5 +1580,13 @@ Bridge.assembly("Bridge.ClientTest.Batch2", function ($asm, globals) {
             MODULE_ISSUES: "Issues2",
             MODULE_CHECKED_UNCKECKED: "Checked/Unckecked"
         }
+    });
+
+    var $box_ = {};
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
     });
 });

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -157,8 +157,8 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
 
                 stopwatch.stop();
 
-                Bridge.Test.Assert.true$1(stopwatch.milliseconds().gte(System.Int64(delay - Bridge.ClientTest.Batch3.BridgeIssues.Bridge1012.DELTA)), ">= " + delay + ", elapsed " + stopwatch.milliseconds());
-                Bridge.Test.Assert.true$1(stopwatch.milliseconds().lt(System.Int64(maxDelay)), "< " + maxDelay + ", elapsed " + stopwatch.milliseconds());
+                Bridge.Test.Assert.true$1(stopwatch.milliseconds().gte(System.Int64(delay - Bridge.ClientTest.Batch3.BridgeIssues.Bridge1012.DELTA)), ">= " + Bridge.box(delay, System.Int32) + ", elapsed " + Bridge.box(stopwatch.milliseconds(), System.Int64));
+                Bridge.Test.Assert.true$1(stopwatch.milliseconds().lt(System.Int64(maxDelay)), "< " + Bridge.box(maxDelay, System.Int32) + ", elapsed " + Bridge.box(stopwatch.milliseconds(), System.Int64));
             },
             testSleepInt: function () {
                 var delay = 100;
@@ -171,8 +171,8 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
 
                 stopwatch.stop();
 
-                Bridge.Test.Assert.true$1(stopwatch.milliseconds().gte(System.Int64(delay - Bridge.ClientTest.Batch3.BridgeIssues.Bridge1012.DELTA)), ">= " + delay + ", elapsed " + stopwatch.milliseconds());
-                Bridge.Test.Assert.true$1(stopwatch.milliseconds().lt(System.Int64(maxDelay)), "< " + maxDelay + ", elapsed " + stopwatch.milliseconds());
+                Bridge.Test.Assert.true$1(stopwatch.milliseconds().gte(System.Int64(delay - Bridge.ClientTest.Batch3.BridgeIssues.Bridge1012.DELTA)), ">= " + Bridge.box(delay, System.Int32) + ", elapsed " + Bridge.box(stopwatch.milliseconds(), System.Int64));
+                Bridge.Test.Assert.true$1(stopwatch.milliseconds().lt(System.Int64(maxDelay)), "< " + Bridge.box(maxDelay, System.Int32) + ", elapsed " + Bridge.box(stopwatch.milliseconds(), System.Int64));
             },
             testSleepTimeSpan: function () {
                 var delay = 100;
@@ -185,8 +185,8 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
 
                 stopwatch.stop();
 
-                Bridge.Test.Assert.true$1(stopwatch.milliseconds().gte(System.Int64(delay - Bridge.ClientTest.Batch3.BridgeIssues.Bridge1012.DELTA)), ">= " + delay + ", elapsed " + stopwatch.milliseconds());
-                Bridge.Test.Assert.true$1(stopwatch.milliseconds().lt(System.Int64(maxDelay)), "< " + maxDelay + ", elapsed " + stopwatch.milliseconds());
+                Bridge.Test.Assert.true$1(stopwatch.milliseconds().gte(System.Int64(delay - Bridge.ClientTest.Batch3.BridgeIssues.Bridge1012.DELTA)), ">= " + Bridge.box(delay, System.Int32) + ", elapsed " + Bridge.box(stopwatch.milliseconds(), System.Int64));
+                Bridge.Test.Assert.true$1(stopwatch.milliseconds().lt(System.Int64(maxDelay)), "< " + Bridge.box(maxDelay, System.Int32) + ", elapsed " + Bridge.box(stopwatch.milliseconds(), System.Int64));
             },
             testSleepThrows: function () {
                 Bridge.Test.Assert.throws$7(System.ArgumentOutOfRangeException, $_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge1012.f1, "-2");
@@ -650,28 +650,28 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1(System.Decimal(5.0));
 
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1().div(System.Decimal(2)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(2.5), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1());
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(2.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), System.Decimal, $box_.System.Decimal.toString));
 
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1().add(System.Decimal(2)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.5), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1());
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), System.Decimal, $box_.System.Decimal.toString));
 
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1().inc());
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(5.5), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1());
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(5.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), System.Decimal, $box_.System.Decimal.toString));
 
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1().inc());
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.5), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1());
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(3.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1().div(System.Decimal(2)), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1($t), $t)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(3.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1());
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1().div(System.Decimal(2)), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1($t), $t)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t1 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1().add(System.Decimal(1)), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1($t1), $t1)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1());
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t1 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1().add(System.Decimal(1)), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1($t1), $t1)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1($t2.inc()), $t2)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(5.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1());
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1($t2.inc()), $t2)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(5.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1($t2.inc()), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1())));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1());
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.setProp1($t2.inc()), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1())), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.getProp1(), System.Decimal, $box_.System.Decimal.toString));
             },
             testIndexerOps: function () {
                 var $t, $t1, $t2;
@@ -679,84 +679,84 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 app.setItem(0, System.Decimal(5.0));
 
                 app.setItem(0, app.getItem(0).div(System.Decimal(2)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(2.5), app.getItem(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(2.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(app.getItem(0), System.Decimal, $box_.System.Decimal.toString));
 
                 app.setItem(0, app.getItem(0).add(System.Decimal(2)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.5), app.getItem(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(app.getItem(0), System.Decimal, $box_.System.Decimal.toString));
 
                 app.setItem(0, app.getItem(0).inc());
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(5.5), app.getItem(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(5.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(app.getItem(0), System.Decimal, $box_.System.Decimal.toString));
 
                 app.setItem(0, app.getItem(0).inc());
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.5), app.getItem(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(app.getItem(0), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(3.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t = app.getItem(0).div(System.Decimal(2)), app.setItem(0, $t), $t)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(3.25), app.getItem(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t = app.getItem(0).div(System.Decimal(2)), app.setItem(0, $t), $t)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(app.getItem(0), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t1 = app.getItem(0).add(System.Decimal(1)), app.setItem(0, $t1), $t1)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), app.getItem(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t1 = app.getItem(0).add(System.Decimal(1)), app.setItem(0, $t1), $t1)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(app.getItem(0), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = app.getItem(0), app.setItem(0, $t2.inc()), $t2)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(5.25), app.getItem(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = app.getItem(0), app.setItem(0, $t2.inc()), $t2)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(5.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(app.getItem(0), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = app.getItem(0), app.setItem(0, $t2.inc()), app.getItem(0))));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.25), app.getItem(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = app.getItem(0), app.setItem(0, $t2.inc()), app.getItem(0))), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(app.getItem(0), System.Decimal, $box_.System.Decimal.toString));
             },
             testDictOps: function () {
                 var $t, $t1, $t2;
                 var dict = $_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.f1(new (System.Collections.Generic.Dictionary$2(System.Int32,System.Decimal))());
 
                 dict.set(0, dict.get(0).div(System.Decimal(2)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(2.5), dict.get(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(2.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(dict.get(0), System.Decimal, $box_.System.Decimal.toString));
 
                 dict.set(0, dict.get(0).add(System.Decimal(2)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.5), dict.get(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(dict.get(0), System.Decimal, $box_.System.Decimal.toString));
 
                 dict.set(0, dict.get(0).inc());
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(5.5), dict.get(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(5.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(dict.get(0), System.Decimal, $box_.System.Decimal.toString));
 
                 dict.set(0, dict.get(0).inc());
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.5), dict.get(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(dict.get(0), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(3.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t = dict.get(0).div(System.Decimal(2)), dict.set(0, $t), $t)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(3.25), dict.get(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t = dict.get(0).div(System.Decimal(2)), dict.set(0, $t), $t)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(dict.get(0), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t1 = dict.get(0).add(System.Decimal(1)), dict.set(0, $t1), $t1)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), dict.get(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t1 = dict.get(0).add(System.Decimal(1)), dict.set(0, $t1), $t1)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(dict.get(0), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = dict.get(0), dict.set(0, $t2.inc()), $t2)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(5.25), dict.get(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = dict.get(0), dict.set(0, $t2.inc()), $t2)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(5.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(dict.get(0), System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = dict.get(0), dict.set(0, $t2.inc()), dict.get(0))));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.25), dict.get(0));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t2 = dict.get(0), dict.set(0, $t2.inc()), dict.get(0))), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(dict.get(0), System.Decimal, $box_.System.Decimal.toString));
             },
             testVariableOps: function () {
                 var $t;
                 var i1 = System.Decimal(5);
 
                 i1 = i1.div(System.Decimal(2));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(2.5), i1);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(2.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(i1, System.Decimal, $box_.System.Decimal.toString));
 
                 i1 = i1.add(System.Decimal(2));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.5), i1);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(i1, System.Decimal, $box_.System.Decimal.toString));
 
                 i1 = i1.inc();
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(5.5), i1);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(5.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(i1, System.Decimal, $box_.System.Decimal.toString));
 
                 i1 = i1.inc();
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.5), i1);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.5), System.Decimal, $box_.System.Decimal.toString), Bridge.box(i1, System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(3.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method((i1 = i1.div(System.Decimal(2)))));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(3.25), i1);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method((i1 = i1.div(System.Decimal(2)))), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(i1, System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method((i1 = i1.add(System.Decimal(1)))));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), i1);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method((i1 = i1.add(System.Decimal(1)))), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(i1, System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(4.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t = i1, i1 = i1.inc(), $t)));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(5.25), i1);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method(($t = i1, i1 = i1.inc(), $t)), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(5.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(i1, System.Decimal, $box_.System.Decimal.toString));
 
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.25), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method((i1 = i1.inc())));
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(System.Decimal(6.25), i1);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.method((i1 = i1.inc())), System.Decimal, $box_.System.Decimal.toString));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(6.25), System.Decimal, $box_.System.Decimal.toString), Bridge.box(i1, System.Decimal, $box_.System.Decimal.toString));
             },
             method: function (i) {
                 return i;
@@ -957,9 +957,9 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 var car = foo;
                 foo.bar = "1";
                 Bridge.Test.Assert.areEqual("1", foo.bar);
-                Bridge.Test.Assert.areEqual("1", foo.bar);
+                Bridge.Test.Assert.areEqual("1", Bridge.unbox(foo.bar));
                 Bridge.Test.Assert.areEqual("1", car.bar);
-                Bridge.Test.Assert.areEqual("1", car.bar);
+                Bridge.Test.Assert.areEqual("1", Bridge.unbox(car.bar));
             }
         }
     });
@@ -1007,20 +1007,20 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
         statics: {
             testEnumNameModes: function () {
                 var t1 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType1;
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType1.CIRCLE, t1.CIRCLE);
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType1.marker, t1.marker);
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType1.CIRCLE, Bridge.unbox(t1.CIRCLE));
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType1.marker, Bridge.unbox(t1.marker));
 
                 var t2 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType2;
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType2.CIRCLE, t2.CIRCLE);
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType2.marker, t2.marker);
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType2.CIRCLE, Bridge.unbox(t2.CIRCLE));
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType2.marker, Bridge.unbox(t2.marker));
 
                 var t3 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType3;
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType3.circle, t3.circle);
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType3.marker, t3.marker);
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType3.circle, Bridge.unbox(t3.circle));
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType3.marker, Bridge.unbox(t3.marker));
 
                 var t4 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType4;
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType4.CIRCLE, t4.CIRCLE);
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType4.MARKER, t4.MARKER);
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType4.CIRCLE, Bridge.unbox(t4.CIRCLE));
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059.OverlayType4.MARKER, Bridge.unbox(t4.MARKER));
             }
         }
     });
@@ -1111,8 +1111,8 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
         statics: {
             testInlinePopertyWithValue: function () {
                 var dict = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1066.MyDictionary();
-                Bridge.Test.Assert.notNull(dict.getAccessor);
-                Bridge.Test.Assert.notNull(dict.setAccessor);
+                Bridge.Test.Assert.notNull(Bridge.unbox(dict.getAccessor));
+                Bridge.Test.Assert.notNull(Bridge.unbox(dict.setAccessor));
                 Bridge.Test.Assert.areEqual(1, dict.getAccessor(0));
             }
         }
@@ -1132,10 +1132,10 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
             testInlinePopertyWithValue: function () {
                 var dict1 = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1067.MyDictionary1();
                 var dict2 = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1067.MyDictionary2();
-                Bridge.Test.Assert.null(dict1.getAccessor);
-                Bridge.Test.Assert.null(dict1.setAccessor);
-                Bridge.Test.Assert.null(dict2.getAccessor);
-                Bridge.Test.Assert.null(dict2.setAccessor);
+                Bridge.Test.Assert.null(Bridge.unbox(dict1.getAccessor));
+                Bridge.Test.Assert.null(Bridge.unbox(dict1.setAccessor));
+                Bridge.Test.Assert.null(Bridge.unbox(dict2.getAccessor));
+                Bridge.Test.Assert.null(Bridge.unbox(dict2.setAccessor));
             }
         }
     });
@@ -1184,8 +1184,8 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
             testNameForProperty: function () {
                 var c = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1072.Class1();
 
-                Bridge.Test.Assert.notNull(c.getAccessor);
-                Bridge.Test.Assert.notNull(c.setAccessor);
+                Bridge.Test.Assert.notNull(Bridge.unbox(c.getAccessor));
+                Bridge.Test.Assert.notNull(Bridge.unbox(c.setAccessor));
 
                 c.setAccessor(7);
                 Bridge.Test.Assert.areEqual(7, c.getAccessor());
@@ -2286,11 +2286,11 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 var f = 1.1;
                 Bridge.Test.Assert.areEqual(System.Single, System.Single);
 
-                var o = b;
-                Bridge.Test.Assert.areEqual(System.Int32, Bridge.getType(o));
+                var o = Bridge.box(b, System.Byte);
+                Bridge.Test.Assert.areEqual(System.Byte, Bridge.getType(o));
 
-                o = f;
-                Bridge.Test.Assert.areEqual(System.Double, Bridge.getType(o));
+                o = Bridge.box(f, System.Single, $box_.System.Single.toString);
+                Bridge.Test.Assert.areEqual(System.Single, Bridge.getType(o));
             }
         }
     });
@@ -2806,7 +2806,7 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 if (diff > delta || diff < -delta) {
                     Bridge.Test.Assert.areEqual$1(e, a, message);
                 } else {
-                    var m = ($t = message, $t != null ? $t : System.String.concat(" ", (diff !== 0 ? System.String.concat("Diff: " + System.Double.format(diff, 'G') + "; Expected: ", e, "; Actual: ", a) : "")));
+                    var m = ($t = message, $t != null ? $t : System.String.concat(" ", (diff !== 0 ? System.String.concat("Diff: " + System.Double.format(Bridge.box(diff, System.Double, $box_.System.Double.toString), 'G') + "; Expected: ", e, "; Actual: ", a) : "")));
                     Bridge.Test.Assert.true$1(true, m);
                 }
             },
@@ -3035,8 +3035,8 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
         statics: {
             testDefaultEnumMode: function () {
                 var numbers = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1253.Numbers;
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1253.Numbers.ONE, numbers.ONE);
-                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1253.Numbers.TWO, numbers.TWO);
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1253.Numbers.ONE, Bridge.unbox(numbers.ONE));
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1253.Numbers.TWO, Bridge.unbox(numbers.TWO));
             }
         }
     });
@@ -3074,7 +3074,7 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 $t = Bridge.getEnumerator(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1256.reservedWords);
                 while ($t.moveNext()) {
                     var name = $t.getCurrent();
-                    Bridge.Test.Assert.areEqual$1(true, o[name], System.String.concat("Expected true for property ", name));
+                    Bridge.Test.Assert.areEqual$1(true, Bridge.unbox(o[name]), System.String.concat("Expected true for property ", name));
                 }
             },
             testMethods: function (o) {
@@ -3087,7 +3087,7 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 $t = Bridge.getEnumerator(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1256.reservedWords);
                 while ($t.moveNext()) {
                     var name = $t.getCurrent();
-                    Bridge.Test.Assert.notNull$1(o[name], System.String.concat("Member ", name, " exists"));
+                    Bridge.Test.Assert.notNull$1(Bridge.unbox(o[name]), System.String.concat("Member ", name, " exists"));
                 }
             },
             let: function () {
@@ -3464,8 +3464,26 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 $t = Bridge.getEnumerator(x);
                 while ($t.moveNext()) {
                     var i = $t.getCurrent();
-                    Bridge.Test.Assert.areEqual(arr[Bridge.identity(index, (index = (index + 1) | 0))], i);
+                    Bridge.Test.Assert.areEqual(arr[Bridge.identity(index, (index = (index + 1) | 0))], Bridge.unbox(i));
                 }
+            }
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1290", {
+        statics: {
+            testBoxedChar: function () {
+                var v = Bridge.box(97, System.Char, $box_.System.Char.toString);
+                Bridge.Test.Assert.areEqual("a", v.toString());
+            }
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1292", {
+        statics: {
+            testBoxedChar: function () {
+                var v = Bridge.box(97, System.Char, $box_.System.Char.toString);
+                Bridge.Test.Assert.areEqual("System.Char", Bridge.Reflection.getTypeFullName(Bridge.getType(v)));
             }
         }
     });
@@ -3618,6 +3636,25 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1301", {
+        statics: {
+            testBoxedNumbers: function () {
+                var v = Bridge.box(3, System.Byte);
+                Bridge.Test.Assert.areEqual("System.Byte", Bridge.Reflection.getTypeFullName(Bridge.getType(v)));
+                v = Bridge.box(3, System.UInt32);
+                Bridge.Test.Assert.areEqual("System.UInt32", Bridge.Reflection.getTypeFullName(Bridge.getType(v)));
+                v = Bridge.box(3, System.UInt16);
+                Bridge.Test.Assert.areEqual("System.UInt16", Bridge.Reflection.getTypeFullName(Bridge.getType(v)));
+                v = Bridge.box(3, System.Int16);
+                Bridge.Test.Assert.areEqual("System.Int16", Bridge.Reflection.getTypeFullName(Bridge.getType(v)));
+                v = Bridge.box(1.0, System.Double, $box_.System.Double.toString);
+                Bridge.Test.Assert.areEqual("System.Double", Bridge.Reflection.getTypeFullName(Bridge.getType(v)));
+                v = Bridge.box(1.0, System.Single, $box_.System.Single.toString);
+                Bridge.Test.Assert.areEqual("System.Single", Bridge.Reflection.getTypeFullName(Bridge.getType(v)));
+            }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304", {
         statics: {
             getOutput: function () {
@@ -3633,43 +3670,43 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.setOutput(null);
             },
             testWriteFormatString: function () {
-                Bridge.Console.log(System.String.format("{0}", 1));
+                Bridge.Console.log(System.String.format("{0}", Bridge.box(1, System.Int32)));
                 Bridge.Test.Assert.areEqual("1", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.clearOutput();
 
-                Bridge.Console.log(System.String.format("{0} {1}", 1, 2));
+                Bridge.Console.log(System.String.format("{0} {1}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32)));
                 Bridge.Test.Assert.areEqual("1 2", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.clearOutput();
 
-                Bridge.Console.log(System.String.format("{0} {1} {2}", 1, 2, 3));
+                Bridge.Console.log(System.String.format("{0} {1} {2}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32), Bridge.box(3, System.Int32)));
                 Bridge.Test.Assert.areEqual("1 2 3", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.clearOutput();
 
-                Bridge.Console.log(System.String.format("{0} {1} {2} {3}", 1, 2, 3, 4));
+                Bridge.Console.log(System.String.format("{0} {1} {2} {3}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32), Bridge.box(3, System.Int32), Bridge.box(4, System.Int32)));
                 Bridge.Test.Assert.areEqual("1 2 3 4", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.clearOutput();
 
-                Bridge.Console.log(System.String.format("{0} {1} {2} {3} {4}", 1, 2, 3, 4, "5"));
+                Bridge.Console.log(System.String.format("{0} {1} {2} {3} {4}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32), Bridge.box(3, System.Int32), Bridge.box(4, System.Int32), "5"));
                 Bridge.Test.Assert.areEqual("1 2 3 4 5", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
             },
             testWriteLineFormatString: function () {
-                Bridge.Console.log(System.String.format("{0}", 1));
+                Bridge.Console.log(System.String.format("{0}", Bridge.box(1, System.Int32)));
                 Bridge.Test.Assert.areEqual("1", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.clearOutput();
 
-                Bridge.Console.log(System.String.format("{0} {1}", 1, 2));
+                Bridge.Console.log(System.String.format("{0} {1}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32)));
                 Bridge.Test.Assert.areEqual("1 2", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.clearOutput();
 
-                Bridge.Console.log(System.String.format("{0} {1} {2}", 1, 2, 3));
+                Bridge.Console.log(System.String.format("{0} {1} {2}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32), Bridge.box(3, System.Int32)));
                 Bridge.Test.Assert.areEqual("1 2 3", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.clearOutput();
 
-                Bridge.Console.log(System.String.format("{0} {1} {2} {3}", 1, 2, 3, 4));
+                Bridge.Console.log(System.String.format("{0} {1} {2} {3}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32), Bridge.box(3, System.Int32), Bridge.box(4, System.Int32)));
                 Bridge.Test.Assert.areEqual("1 2 3 4", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.clearOutput();
 
-                Bridge.Console.log(System.String.format("{0} {1} {2} {3} {4}", 1, 2, 3, 4, "5"));
+                Bridge.Console.log(System.String.format("{0} {1} {2} {3} {4}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32), Bridge.box(3, System.Int32), Bridge.box(4, System.Int32), "5"));
                 Bridge.Test.Assert.areEqual("1 2 3 4 5", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304.getOutput());
             }
         }
@@ -3981,18 +4018,18 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
         statics: {
             testUseCase: function () {
                 var v = 0;
-                var s = v + "";
+                var s = Bridge.box(v, System.Int32) + "";
 
                 Bridge.Test.Assert.areEqual("0", s);
             },
             testStringConcatObject: function () {
-                var o1 = 3;
-                var s1 = [o1].join('');
+                var o1 = Bridge.box(3, System.Int32);
+                var s1 = [Bridge.unbox(o1)].join('');
 
                 Bridge.Test.Assert.areEqual("3", s1);
 
                 var o2 = null;
-                var s2 = [o2].join('');
+                var s2 = [Bridge.unbox(o2)].join('');
 
                 Bridge.Test.Assert.areEqual("", s2);
             },
@@ -4013,12 +4050,12 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 Bridge.Test.Assert.areEqual$1("", s3, "Empty");
             },
             testStringConcatEnumerableGeneric: function () {
-                var e1 = [1, "2"];
+                var e1 = [Bridge.box(1, System.Int32), "2"];
                 var s1 = Bridge.toArray(e1).join('');
 
                 Bridge.Test.Assert.areEqual$1("12", s1, "All not null");
 
-                var e2 = ["3", null, 4];
+                var e2 = ["3", null, Bridge.box(4, System.Int32)];
                 var s2 = Bridge.toArray(e2).join('');
 
                 Bridge.Test.Assert.areEqual$1("34", s2, "One is null");
@@ -4670,11 +4707,11 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 Bridge.Test.Assert.notNull$1(o1, "o1 not null");
                 Bridge.Test.Assert.areEqual$1(1, o1.a, "o1.A == 1");
 
-                Bridge.Test.Assert.null$1(o1.getHashCode, "o1 has no getHashCode");
-                Bridge.Test.Assert.null$1(o1.toJSON, "o1 has no toJSON");
-                Bridge.Test.Assert.null$1(o1.ctor, "o1 has no ctor");
-                Bridge.Test.Assert.null$1(o1.equals, "o1 has no equals");
-                Bridge.Test.Assert.notNull$1(o1.a, "o1 has a");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o1.getHashCode), "o1 has no getHashCode");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o1.toJSON), "o1 has no toJSON");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o1.ctor), "o1 has no ctor");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o1.equals), "o1 has no equals");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o1.a), "o1 has a");
 
                 var o2 = { a: 1, b: "2" };
                 Bridge.Test.Assert.notNull$1(o2, "o2 not null");
@@ -4710,24 +4747,24 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 Bridge.Test.Assert.notNull$1(o5.b.getValue2().$clone(), "o5.B.Value2 not null");
                 Bridge.Test.Assert.areEqual$1(1, o5.b.getValue2().getValue1(), "o5.B.Value2.Value1 == 1");
 
-                Bridge.Test.Assert.null$1(o5.getHashCode, "o5 has no getHashCode");
-                Bridge.Test.Assert.null$1(o5.toJSON, "o5 has no toJSON");
-                Bridge.Test.Assert.null$1(o5.$constructor, "o5 has no $constructor");
-                Bridge.Test.Assert.null$1(o5.equals, "o5 has no equals");
-                Bridge.Test.Assert.notNull$1(o5.a, "o5 has a");
-                Bridge.Test.Assert.notNull$1(o5.b, "o5 has b");
-                Bridge.Test.Assert.notNull$1(o5.b.getValue1, "o5.B has getValue1");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o5.getHashCode), "o5 has no getHashCode");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o5.toJSON), "o5 has no toJSON");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o5.$constructor), "o5 has no $constructor");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o5.equals), "o5 has no equals");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.a), "o5 has a");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.b), "o5 has b");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.b.getValue1), "o5.B has getValue1");
             },
             testAnonymousTypeCreation: function () {
                 var o1 = new $_.$AnonymousType$1(1);
                 Bridge.Test.Assert.notNull$1(o1, "o1 not null");
                 Bridge.Test.Assert.areEqual$1(1, o1.a, "o1.A == 1");
 
-                Bridge.Test.Assert.notNull$1(o1.getHashCode, "o1 has getHashCode");
-                Bridge.Test.Assert.notNull$1(o1.toJSON, "o1 has toJSON");
-                Bridge.Test.Assert.notNull$1(o1.ctor, "o1 has ctor");
-                Bridge.Test.Assert.notNull$1(o1.equals, "o1 has equals");
-                Bridge.Test.Assert.notNull$1(o1.getA, "o1 has getA");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o1.getHashCode), "o1 has getHashCode");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o1.toJSON), "o1 has toJSON");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o1.ctor), "o1 has ctor");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o1.equals), "o1 has equals");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o1.getA), "o1 has getA");
 
                 var o2 = new $_.$AnonymousType$2(1, "2");
                 Bridge.Test.Assert.notNull$1(o2, "o2 not null");
@@ -4763,13 +4800,13 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 Bridge.Test.Assert.notNull$1(o5.b.getValue2().$clone(), "o5.B.Value2 not null");
                 Bridge.Test.Assert.areEqual$1(1, o5.b.getValue2().getValue1(), "o5.B.Value2.Value1 == 1");
 
-                Bridge.Test.Assert.notNull$1(o5.getHashCode, "o5 has getHashCode");
-                Bridge.Test.Assert.notNull$1(o5.toJSON, "o5 has toJSON");
-                Bridge.Test.Assert.notNull$1(o5.ctor, "o5 has ctor");
-                Bridge.Test.Assert.notNull$1(o5.equals, "o5 has equals");
-                Bridge.Test.Assert.notNull$1(o5.getA, "o5 has getA");
-                Bridge.Test.Assert.notNull$1(o5.getB, "o5 has getB");
-                Bridge.Test.Assert.notNull$1(o5.b.getValue1, "o5.B has getValue1");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.getHashCode), "o5 has getHashCode");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.toJSON), "o5 has toJSON");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.ctor), "o5 has ctor");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.equals), "o5 has equals");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.getA), "o5 has getA");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.getB), "o5 has getB");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o5.b.getValue1), "o5.B has getValue1");
             },
             testDiffStructHashCode: function () {
                 var s = Bridge.merge(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1341.SomeStructA(), {
@@ -4807,17 +4844,17 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
                 Bridge.Test.Assert.areEqual$1(Bridge.getHashCode(o1), Bridge.getHashCode(o5), "GetHashCode o1 == o5");
                 Bridge.Test.Assert.areNotEqual$1(Bridge.getHashCode(o1), Bridge.getHashCode(o6), "GetHashCode o1 != o6");
 
-                Bridge.Test.Assert.true$1(Bridge.equals(o1, o2), "Equals o1 == o2");
-                Bridge.Test.Assert.false$1(Bridge.equals(o1, o3), "Equals o1 != o3");
-                Bridge.Test.Assert.false$1(Bridge.equals(o1, o4), "Equals o1 != o4");
-                Bridge.Test.Assert.true$1(Bridge.equals(o1, o5), "Equals o1 == o5");
-                Bridge.Test.Assert.false$1(Bridge.equals(o1, o6), "Equals o1 != o6");
+                Bridge.Test.Assert.true$1(Bridge.equals(o1, Bridge.unbox(o2)), "Equals o1 == o2");
+                Bridge.Test.Assert.false$1(Bridge.equals(o1, Bridge.unbox(o3)), "Equals o1 != o3");
+                Bridge.Test.Assert.false$1(Bridge.equals(o1, Bridge.unbox(o4)), "Equals o1 != o4");
+                Bridge.Test.Assert.true$1(Bridge.equals(o1, Bridge.unbox(o5)), "Equals o1 == o5");
+                Bridge.Test.Assert.false$1(Bridge.equals(o1, Bridge.unbox(o6)), "Equals o1 != o6");
 
-                Bridge.Test.Assert.true$1(Bridge.equals(o2, o1), "Equals o2 == o1");
-                Bridge.Test.Assert.false$1(Bridge.equals(o3, o1), "Equals o3 != o1");
-                Bridge.Test.Assert.false$1(Bridge.equals(o4, o1), "Equals o4 != o1");
-                Bridge.Test.Assert.true$1(Bridge.equals(o5, o1), "Equals o5 == o1");
-                Bridge.Test.Assert.false$1(Bridge.equals(o6, o1), "Equals o6 != o1");
+                Bridge.Test.Assert.true$1(Bridge.equals(o2, Bridge.unbox(o1)), "Equals o2 == o1");
+                Bridge.Test.Assert.false$1(Bridge.equals(o3, Bridge.unbox(o1)), "Equals o3 != o1");
+                Bridge.Test.Assert.false$1(Bridge.equals(o4, Bridge.unbox(o1)), "Equals o4 != o1");
+                Bridge.Test.Assert.true$1(Bridge.equals(o5, Bridge.unbox(o1)), "Equals o5 == o1");
+                Bridge.Test.Assert.false$1(Bridge.equals(o6, Bridge.unbox(o1)), "Equals o6 != o1");
             },
             test1AnonymousType: function () {
                 var o1 = new $_.$AnonymousType$1(1);
@@ -5364,8 +5401,8 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1343", {
         statics: {
             testDoubleTemplate: function () {
-                var s1 = System.String.format("{0} {1}", 1, 2);
-                var s2 = Bridge.getHashCode(System.String.format("{0} {1}", 1, 2));
+                var s1 = System.String.format("{0} {1}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32));
+                var s2 = Bridge.getHashCode(System.String.format("{0} {1}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32)));
 
                 Bridge.Test.Assert.areEqual(Bridge.getHashCode(s1), s2);
             },
@@ -5380,7 +5417,7 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
 
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1343.M", {
         getHashCode: function () {
-            return Bridge.getHashCode(System.String.format("{0} {1}", 1, 2));
+            return Bridge.getHashCode(System.String.format("{0} {1}", Bridge.box(1, System.Int32), Bridge.box(2, System.Int32)));
         }
     });
 
@@ -5415,6 +5452,21 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
 
                 Bridge.Test.Assert.areEqual$1("1", $window, "window");
                 Bridge.Test.Assert.areEqual$1("1", r, "r");
+            }
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1357", {
+        statics: {
+            testBoxedValueType: function () {
+                var a1 = Bridge.box(7, System.Int32);
+                var b1 = Bridge.box(7, System.Int32);
+                var c1 = a1;
+
+                var r1 = Bridge.referenceEquals(a1, b1);
+                var r2 = Bridge.referenceEquals(a1, c1);
+                Bridge.Test.Assert.false(r1);
+                Bridge.Test.Assert.true(r2);
             }
         }
     });
@@ -5572,27 +5624,30 @@ Bridge.assembly("Bridge.ClientTest.Batch3", function ($asm, globals) {
 
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379", {
         statics: {
-            assertNaN: function (value) {
+            assertDoubleNaN: function (value) {
                 Bridge.Test.Assert.areEqual("System.Double", Bridge.Reflection.getTypeFullName(Bridge.getType(value)));
             },
+            assertSingleNaN: function (value) {
+                Bridge.Test.Assert.areEqual("System.Single", Bridge.Reflection.getTypeFullName(Bridge.getType(value)));
+            },
             testNanFiniteType: function () {
-                var value1 = NaN;
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertNaN(value1);
+                var value1 = Bridge.box(NaN, System.Double, $box_.System.Double.toString);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertDoubleNaN(value1);
 
-                var value2 = Infinity;
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertNaN(value2);
+                var value2 = Bridge.box(Infinity, System.Double, $box_.System.Double.toString);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertDoubleNaN(value2);
 
-                var value3 = -Infinity;
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertNaN(value3);
+                var value3 = Bridge.box(-Infinity, System.Double, $box_.System.Double.toString);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertDoubleNaN(value3);
 
-                var value4 = NaN;
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertNaN(value4);
+                var value4 = Bridge.box(NaN, System.Single, $box_.System.Single.toString);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertSingleNaN(value4);
 
-                var value5 = Infinity;
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertNaN(value5);
+                var value5 = Bridge.box(Infinity, System.Single, $box_.System.Single.toString);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertSingleNaN(value5);
 
-                var value6 = -Infinity;
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertNaN(value6);
+                var value6 = Bridge.box(-Infinity, System.Single, $box_.System.Single.toString);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379.assertSingleNaN(value6);
             }
         }
     });
@@ -5944,7 +5999,7 @@ Bridge.$N1391Result =                 r;
             }
         },
         someMethod: function () {
-            return System.String.concat("I'm ", Bridge.Reflection.getTypeFullName(Bridge.getType(this)), " and my value is ", this.getValue());
+            return System.String.concat("I'm ", Bridge.Reflection.getTypeFullName(Bridge.getType(this)), " and my value is ", Bridge.box(this.getValue(), System.Int32));
         }
     });
 
@@ -5958,12 +6013,12 @@ Bridge.$N1391Result =                 r;
                 var plainee = Bridge.toPlain(a);
 
                 Bridge.Test.Assert.notNull$1(plainee, "plainee not null");
-                Bridge.Test.Assert.notNull$1(plainee.data, "plainee has data");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(plainee.data), "plainee has data");
                 Bridge.Test.Assert.areEqual$1(5, plainee.data, "plainee.Data == 5");
-                Bridge.Test.Assert.null$1(plainee.getHashCode, "plainee has no getHashCode");
-                Bridge.Test.Assert.null$1(plainee.toJSON, "plainee has no toJSON");
-                Bridge.Test.Assert.null$1(plainee.$constructor, "plainee has no $constructor");
-                Bridge.Test.Assert.null$1(plainee.equals, "plainee has no equals");
+                Bridge.Test.Assert.null$1(Bridge.unbox(plainee.getHashCode), "plainee has no getHashCode");
+                Bridge.Test.Assert.null$1(Bridge.unbox(plainee.toJSON), "plainee has no toJSON");
+                Bridge.Test.Assert.null$1(Bridge.unbox(plainee.$constructor), "plainee has no $constructor");
+                Bridge.Test.Assert.null$1(Bridge.unbox(plainee.equals), "plainee has no equals");
             },
             testObjectLiteralProperty: function () {
                 var a = Bridge.merge(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1448.A(), {
@@ -5974,24 +6029,24 @@ Bridge.$N1391Result =                 r;
 
                 var plainee = l.v;
 
-                Bridge.Test.Assert.notNull$1(plainee, "plainee not null");
-                Bridge.Test.Assert.notNull$1(plainee.data, "plainee has data");
-                Bridge.Test.Assert.areEqual$1(5, plainee.data, "plainee.Data == 5");
-                Bridge.Test.Assert.null$1(plainee.getHashCode, "plainee has no getHashCode");
-                Bridge.Test.Assert.null$1(plainee.toJSON, "plainee has no toJSON");
-                Bridge.Test.Assert.null$1(plainee.$constructor, "plainee has no $constructor");
-                Bridge.Test.Assert.null$1(plainee.equals, "plainee has no equals");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(plainee), "plainee not null");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(plainee.data), "plainee has data");
+                Bridge.Test.Assert.areEqual$1(5, Bridge.unbox(plainee.data), "plainee.Data == 5");
+                Bridge.Test.Assert.null$1(Bridge.unbox(plainee.getHashCode), "plainee has no getHashCode");
+                Bridge.Test.Assert.null$1(Bridge.unbox(plainee.toJSON), "plainee has no toJSON");
+                Bridge.Test.Assert.null$1(Bridge.unbox(plainee.$constructor), "plainee has no $constructor");
+                Bridge.Test.Assert.null$1(Bridge.unbox(plainee.equals), "plainee has no equals");
             },
             testToObjectLiteralAlias: function () {
                 var o1 = { a: 1 };
                 Bridge.Test.Assert.notNull$1(o1, "o1 not null");
                 Bridge.Test.Assert.areEqual$1(1, o1.a, "o1.A == 1");
 
-                Bridge.Test.Assert.null$1(o1.getHashCode, "o1 has no getHashCode");
-                Bridge.Test.Assert.null$1(o1.toJSON, "o1 has no toJSON");
-                Bridge.Test.Assert.null$1(o1.$constructor, "o1 has no $constructor");
-                Bridge.Test.Assert.null$1(o1.equals, "o1 has no equals");
-                Bridge.Test.Assert.notNull$1(o1.a, "o1 has a");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o1.getHashCode), "o1 has no getHashCode");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o1.toJSON), "o1 has no toJSON");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o1.$constructor), "o1 has no $constructor");
+                Bridge.Test.Assert.null$1(Bridge.unbox(o1.equals), "o1 has no equals");
+                Bridge.Test.Assert.notNull$1(Bridge.unbox(o1.a), "o1 has a");
             }
         }
     });
@@ -6020,7 +6075,7 @@ Bridge.$N1391Result =                 r;
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1458.setOutput(null);
             },
             testConsoleWriteLineForLong: function () {
-                var v = System.Int64(1);
+                var v = Bridge.box(System.Int64(1), System.Int64);
 
                 Bridge.Console.log(v);
                 Bridge.Test.Assert.areEqual("1", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1458.getOutput());
@@ -6082,7 +6137,7 @@ Bridge.$N1391Result =                 r;
                 $t1 = Bridge.getEnumerator(Bridge.cast(["j"], System.Collections.IEnumerable));
                 while ($t1.moveNext()) {
                     var z2 = $t1.getCurrent();
-                    Bridge.Test.Assert.areEqual$1("j", z2, "string z2 in (IEnumerable)new[] { \"j\" } foreach var");
+                    Bridge.Test.Assert.areEqual$1("j", Bridge.unbox(z2), "string z2 in (IEnumerable)new[] { \"j\" } foreach var");
                 }
 
                 $t2 = Bridge.getEnumerator(Bridge.cast([Bridge.merge(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1467.SomeClass1(), {
@@ -6375,28 +6430,28 @@ Bridge.$N1391Result =                 r;
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1499", {
         testObjectStringCoalesceWorks: function () {
             var $t, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10, $t11, $t12, $t13, $t14, $t15, $t16;
-            var def = 1;
+            var def = Bridge.box(1, System.Int32);
             var app = null;
             var o1 = "";
             var o2 = "test";
             var o3 = null;
 
-            Bridge.Test.Assert.areStrictEqual(1, app || def);
-            Bridge.Test.Assert.areStrictEqual("", ($t = o1, $t != null ? $t : o2));
-            Bridge.Test.Assert.areStrictEqual("", ($t1 = o1, $t1 != null ? $t1 : "test"));
-            Bridge.Test.Assert.areStrictEqual("test", ($t2 = o3, $t2 != null ? $t2 : o2));
-            Bridge.Test.Assert.areStrictEqual("test", ($t3 = o3, $t3 != null ? $t3 : "test"));
+            Bridge.Test.Assert.areStrictEqual(1, Bridge.unbox(app || def));
+            Bridge.Test.Assert.areStrictEqual("", Bridge.unbox(($t = o1, $t != null ? $t : o2)));
+            Bridge.Test.Assert.areStrictEqual("", Bridge.unbox(($t1 = o1, $t1 != null ? $t1 : "test")));
+            Bridge.Test.Assert.areStrictEqual("test", Bridge.unbox(($t2 = o3, $t2 != null ? $t2 : o2)));
+            Bridge.Test.Assert.areStrictEqual("test", Bridge.unbox(($t3 = o3, $t3 != null ? $t3 : "test")));
 
             var s1 = "";
             var s2 = "test";
             var s3 = null;
 
             Bridge.Test.Assert.areStrictEqual("", ($t4 = s1, $t4 != null ? $t4 : s2));
-            Bridge.Test.Assert.areStrictEqual("", ($t5 = s1, $t5 != null ? $t5 : o2));
+            Bridge.Test.Assert.areStrictEqual("", Bridge.unbox(($t5 = s1, $t5 != null ? $t5 : o2)));
             Bridge.Test.Assert.areStrictEqual("", ($t6 = s1, $t6 != null ? $t6 : "test"));
             Bridge.Test.Assert.areStrictEqual("", ($t7 = "", $t7 != null ? $t7 : "test"));
             Bridge.Test.Assert.areStrictEqual("test", ($t8 = s3, $t8 != null ? $t8 : s2));
-            Bridge.Test.Assert.areStrictEqual("test", ($t9 = s3, $t9 != null ? $t9 : o2));
+            Bridge.Test.Assert.areStrictEqual("test", Bridge.unbox(($t9 = s3, $t9 != null ? $t9 : o2)));
             Bridge.Test.Assert.areStrictEqual("test", ($t10 = s3, $t10 != null ? $t10 : "test"));
             Bridge.Test.Assert.areStrictEqual("test", null || "test");
 
@@ -6405,10 +6460,10 @@ Bridge.$N1391Result =                 r;
             var i3 = null;
 
             Bridge.Test.Assert.areStrictEqual(0, ($t11 = i1, $t11 != null ? $t11 : i2));
-            Bridge.Test.Assert.areStrictEqual(0, ($t12 = i1, $t12 != null ? $t12 : o2));
+            Bridge.Test.Assert.areStrictEqual(0, Bridge.unbox(($t12 = i1, $t12 != null ? Bridge.box($t12, System.Int32, $box_.System.Nullable$1.toString) : o2)));
             Bridge.Test.Assert.areStrictEqual(0, ($t13 = i1, $t13 != null ? $t13 : 1));
             Bridge.Test.Assert.areStrictEqual(1, ($t14 = i3, $t14 != null ? $t14 : i2));
-            Bridge.Test.Assert.areStrictEqual("test", ($t15 = i3, $t15 != null ? $t15 : o2));
+            Bridge.Test.Assert.areStrictEqual("test", Bridge.unbox(($t15 = i3, $t15 != null ? Bridge.box($t15, System.Int32, $box_.System.Nullable$1.toString) : o2)));
             Bridge.Test.Assert.areStrictEqual(1, ($t16 = i3, $t16 != null ? $t16 : 1));
             Bridge.Test.Assert.areStrictEqual(1, null || i2);
         }
@@ -6418,18 +6473,18 @@ Bridge.$N1391Result =                 r;
         testPropertyChangedEventArgs: function () {
             var ea1 = new System.ComponentModel.PropertyChangedEventArgs("prop1");
             Bridge.Test.Assert.areEqual$1("prop1", ea1.propertyName, "prop1 PropertyName");
-            Bridge.Test.Assert.null$1(ea1.oldValue, "prop1 OldValue");
-            Bridge.Test.Assert.null$1(ea1.newValue, "prop1 NewValue");
+            Bridge.Test.Assert.null$1(Bridge.unbox(ea1.oldValue), "prop1 OldValue");
+            Bridge.Test.Assert.null$1(Bridge.unbox(ea1.newValue), "prop1 NewValue");
 
-            var ea2 = new System.ComponentModel.PropertyChangedEventArgs("prop2", 77);
+            var ea2 = new System.ComponentModel.PropertyChangedEventArgs("prop2", Bridge.box(77, System.Int32));
             Bridge.Test.Assert.areEqual$1("prop2", ea2.propertyName, "prop2 PropertyName");
-            Bridge.Test.Assert.null$1(ea2.oldValue, "prop2 OldValue");
-            Bridge.Test.Assert.areEqual$1(77, ea2.newValue, "prop2 NewValue");
+            Bridge.Test.Assert.null$1(Bridge.unbox(ea2.oldValue), "prop2 OldValue");
+            Bridge.Test.Assert.areEqual$1(77, Bridge.unbox(ea2.newValue), "prop2 NewValue");
 
-            var ea3 = new System.ComponentModel.PropertyChangedEventArgs("prop3", 120, 270);
+            var ea3 = new System.ComponentModel.PropertyChangedEventArgs("prop3", Bridge.box(120, System.Int32), Bridge.box(270, System.Int32));
             Bridge.Test.Assert.areEqual$1("prop3", ea3.propertyName, "prop3 PropertyName");
-            Bridge.Test.Assert.areEqual$1(270, ea3.oldValue, "prop3 OldValue");
-            Bridge.Test.Assert.areEqual$1(120, ea3.newValue, "prop3 NewValue");
+            Bridge.Test.Assert.areEqual$1(270, Bridge.unbox(ea3.oldValue), "prop3 OldValue");
+            Bridge.Test.Assert.areEqual$1(120, Bridge.unbox(ea3.newValue), "prop3 NewValue");
         }
     });
 
@@ -6439,7 +6494,7 @@ Bridge.$N1391Result =                 r;
             for (var i = 1; i < 10001; i = (i + 1) | 0) {
                 p = Bridge.global.performance.now();
                 if (!this.hasNoFraction(p)) {
-                    Bridge.Test.Assert.true$1(true, "Did " + i + " attempt(s) to check performance.now() returns float");
+                    Bridge.Test.Assert.true$1(true, "Did " + Bridge.box(i, System.Int32) + " attempt(s) to check performance.now() returns float");
                     return;
                 }
             }
@@ -6872,7 +6927,7 @@ Bridge.$N1391Result =                 r;
             s1 = System.String.concat(s1, s);
             Bridge.Test.Assert.areEqual$1("b", s1, "s1 += s");
 
-            s = System.String.concat(s, String.fromCharCode(98));
+            s = System.String.concat(s, String.fromCharCode(Bridge.box(98, System.Char, $box_.System.Char.toString)));
             Bridge.Test.Assert.areEqual$1("b", s, "s += 'b'");
 
             Bridge.Test.Assert.areEqual$1("b2", System.String.concat(s, "2"), "s + \"2\"");
@@ -6897,8 +6952,6 @@ Bridge.$N1391Result =                 r;
                                 done = Bridge.Test.Assert.async();
 
                                     foo = null; /// Async method lacks 'await' operators and will run synchronously
-
-
                                     bar = function () {
                                         var $step = 0,
                                             $jumpFromFinally, 
@@ -6911,7 +6964,7 @@ Bridge.$N1391Result =                 r;
                                                         $step = System.Array.min([0], $step);
                                                         switch ($step) {
                                                             case 0: {
-                                                                $tcs.setResult((foo = 1));
+                                                                $tcs.setResult((foo = Bridge.box(1, System.Int32)));
                                                                     return;
                                                             }
                                                             default: {
@@ -6928,7 +6981,7 @@ Bridge.$N1391Result =                 r;
 
                                         $asyncBody();
                                         return $tcs.task;
-                                    };
+                                    }; /// Async method lacks 'await' operators and will run synchronously
                                     $task1 = bar();
                                     $step = 1;
                                     $task1.continueWith($asyncBody, true);
@@ -6937,8 +6990,8 @@ Bridge.$N1391Result =                 r;
                             case 1: {
                                 $taskResult1 = $task1.getAwaitedResult();
                                 baz = $taskResult1;
-                                    Bridge.Test.Assert.areEqual(1, foo);
-                                    Bridge.Test.Assert.areEqual(1, baz);
+                                    Bridge.Test.Assert.areEqual(1, Bridge.unbox(foo));
+                                    Bridge.Test.Assert.areEqual(1, Bridge.unbox(baz));
 
                                     done();
                                 return;
@@ -7137,13 +7190,13 @@ Bridge.$N1391Result =                 r;
             var values = [Bridge.getDefaultValue(U)];
 
             var v1 = System.Linq.Enumerable.from(values).select(function (value) {
-                    return System.String.concat(value, " ", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653_Extensions.getSomething(U, value));
+                    return System.String.concat(Bridge.box(value, U), " ", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653_Extensions.getSomething(U, value));
                 });
             var v2 = System.Linq.Enumerable.from(values).select(function (value) {
-                    return System.String.concat(value, " ", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653_Extensions.getSomething(U, value));
+                    return System.String.concat(Bridge.box(value, U), " ", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653_Extensions.getSomething(U, value));
                 });
             var v3 = System.Linq.Enumerable.from(values).select(function (value) {
-                    return System.String.concat(value, " ", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653_Extensions.getSomething1(U, value));
+                    return System.String.concat(Bridge.box(value, U), " ", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653_Extensions.getSomething1(U, value));
                 });
             var v4 = System.Linq.Enumerable.from(values).select($_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653.Table$2.f1);
         }
@@ -7153,7 +7206,7 @@ Bridge.$N1391Result =                 r;
 
     Bridge.apply($_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653.Table$2, {
         f1: function (value) {
-            return System.String.concat(value, "_", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653_Extensions.getSomething1(String, "v4"));
+            return System.String.concat(value.toString(), "_", Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653_Extensions.getSomething1(String, "v4"));
         }
     });
 
@@ -7433,7 +7486,7 @@ Bridge.$N1391Result =                 r;
         },
         value: 0,
         valueOf: function () {
-            return this.value;
+            return Bridge.box(this.value, System.UInt32);
         }
     });
 
@@ -7517,7 +7570,7 @@ Bridge.$N1391Result =                 r;
             ]
         },
         add: function (T, item) {
-            Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712.setBuffer(System.String.concat(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712.getBuffer(), item));
+            Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712.setBuffer(System.String.concat(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712.getBuffer(), Bridge.box(item, T)));
         },
         getEnumerator: function () {
             throw new System.InvalidOperationException();
@@ -7547,7 +7600,7 @@ Bridge.$N1391Result =                 r;
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712MSDNExtensions", {
         statics: {
             add: function (T, collection, item) {
-                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712.setBuffer(System.String.concat(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712.getBuffer(), item));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712.setBuffer(System.String.concat(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712.getBuffer(), Bridge.box(item, T)));
             }
         }
     });
@@ -7705,10 +7758,10 @@ Bridge.$N1391Result =                 r;
             this.$initialize();
         },
         add: function (i) {
-            Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715.MyList.buffer = System.String.concat(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715.MyList.buffer, ("Add(" + i + ");"));
+            Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715.MyList.buffer = System.String.concat(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715.MyList.buffer, ("Add(" + Bridge.box(i, System.Int32) + ");"));
         },
         add$1: function (i, j) {
-            Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715.MyList.buffer = System.String.concat(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715.MyList.buffer, ("Add(" + i + ", " + j + ");"));
+            Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715.MyList.buffer = System.String.concat(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715.MyList.buffer, ("Add(" + Bridge.box(i, System.Int32) + ", " + Bridge.box(j, System.Int32) + ");"));
         },
         getEnumerator: function () {
             throw new System.Exception();
@@ -7884,16 +7937,16 @@ Bridge.$N1391Result =                 r;
             app.addSOME_EVENT($_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge1754.f1);
             app.addANOTHER_EVENt($_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge1754.f1);
 
-            Bridge.Test.Assert.areEqual("ID", app.ID);
-            Bridge.Test.Assert.areEqual("x", app.x);
+            Bridge.Test.Assert.areEqual("ID", Bridge.unbox(app.ID));
+            Bridge.Test.Assert.areEqual("x", Bridge.unbox(app.x));
             Bridge.Test.Assert.areEqual("PROP1", app.getPROP1());
-            Bridge.Test.Assert.notNull$1(app.FOO, "FOO");
-            Bridge.Test.Assert.notNull$1(app.m, "m");
-            Bridge.Test.Assert.notNull$1(app.m$1, "m$1");
-            Bridge.Test.Assert.notNull$1(app.AB, "AB");
+            Bridge.Test.Assert.notNull$1(Bridge.unbox(app.FOO), "FOO");
+            Bridge.Test.Assert.notNull$1(Bridge.unbox(app.m), "m");
+            Bridge.Test.Assert.notNull$1(Bridge.unbox(app.m$1), "m$1");
+            Bridge.Test.Assert.notNull$1(Bridge.unbox(app.AB), "AB");
             // We do not change event name case
-            Bridge.Test.Assert.notNull$1(app.SOME_EVENT, "SOME_EVENT");
-            Bridge.Test.Assert.notNull$1(app.ANOTHER_EVENt, "ANOTHER_EVENt");
+            Bridge.Test.Assert.notNull$1(Bridge.unbox(app.SOME_EVENT), "SOME_EVENT");
+            Bridge.Test.Assert.notNull$1(Bridge.unbox(app.ANOTHER_EVENt), "ANOTHER_EVENt");
         }
     });
 
@@ -8142,7 +8195,7 @@ Bridge.$N1391Result =                 r;
             var decimalSum = System.Linq.Enumerable.from(decimalList).sum(System.Decimal.Zero);
             var lessThanOne = decimalSum.lt(System.Decimal(1));
 
-            Bridge.Test.Assert.true$1(Bridge.is(decimalSum, System.Decimal), "is decimal");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(decimalSum, System.Decimal, $box_.System.Decimal.toString), System.Decimal), "is decimal");
             Bridge.Test.Assert.true$1(decimalSum.equalsT(System.Decimal(0)), "== 0");
             Bridge.Test.Assert.true$1(lessThanOne, "less than one");
         }
@@ -9131,9 +9184,9 @@ Bridge.$N1391Result =                 r;
         testInheritedPropertyInLiteral: function () {
             var x = { id: 12, name: "test" };
             Bridge.Test.Assert.areEqual(12, x.id);
-            Bridge.Test.Assert.areEqual(12, x.id);
+            Bridge.Test.Assert.areEqual(12, Bridge.unbox(x.id));
             Bridge.Test.Assert.areEqual("test", x.name);
-            Bridge.Test.Assert.areEqual("test", x.name);
+            Bridge.Test.Assert.areEqual("test", Bridge.unbox(x.name));
         }
     });
 
@@ -9442,10 +9495,10 @@ Bridge.$N1391Result =                 r;
 
             var o = {  };
             var l1 = function (_o28) {
-                    _o28.add(o);
+                    _o28.add(Bridge.unbox(o));
                     return _o28;
                 }(new (System.Collections.Generic.List$1(Object))());
-            Bridge.Test.Assert.true(l1.contains(o));
+            Bridge.Test.Assert.true(l1.contains(Bridge.unbox(o)));
         }
     });
 
@@ -9605,18 +9658,18 @@ Bridge.$N1391Result =                 r;
             var foo1 = new (Bridge.ClientTest.Batch3.BridgeIssues.Bridge1869.Foo$1(Object))();
 
             var n1 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1869.getFoo("Foo$1$Object");
-            Bridge.Test.Assert.null$1(n1, "Foo$1$Object should not exist");
+            Bridge.Test.Assert.null$1(Bridge.unbox(n1), "Foo$1$Object should not exist");
 
             var n2 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1869.getFoo("Foo$1");
-            Bridge.Test.Assert.notNull$1(n2, "Foo$1 should exist");
+            Bridge.Test.Assert.notNull$1(Bridge.unbox(n2), "Foo$1 should exist");
 
             var foo2 = new (Bridge.ClientTest.Batch3.BridgeIssues.Bridge1869.Foo$1(System.Int64))();
 
             var n3 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1869.getFoo("Foo$1$System.Int64");
-            Bridge.Test.Assert.null$1(n1, "Foo$1$System.Int64 should not exist");
+            Bridge.Test.Assert.null$1(Bridge.unbox(n1), "Foo$1$System.Int64 should not exist");
 
             var n4 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1869.getFoo("Foo$1");
-            Bridge.Test.Assert.notNull$1(n2, "Foo$1 should exist");
+            Bridge.Test.Assert.notNull$1(Bridge.unbox(n2), "Foo$1 should exist");
         }
     });
 
@@ -9972,7 +10025,7 @@ Bridge.$N1391Result =                 r;
         testCase: function () {
             var $t;
             var data = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj();
-            data = ($t = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_False(data) ? data : Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_BitwiseAnd(data, Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_Implicit(data.getlength() > 0)), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_False($t) ? $t : Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_BitwiseAnd($t, Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_Implicit((Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_Implicit$3(data.getItem(0).getItem("key")) === 1))));
+            data = ($t = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_False(data) ? data : Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_BitwiseAnd(data, Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_Implicit(data.getlength() > 0)), Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_False($t) ? $t : Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_BitwiseAnd($t, Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_Implicit((Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj.op_Implicit$3(data.getItem(Bridge.box(0, System.Int32)).getItem("key")) === 1))));
             Bridge.Test.Assert.notNull(data);
             var o = data;
             Bridge.Test.Assert.true(Bridge.is(o, Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj));
@@ -9989,7 +10042,7 @@ Bridge.$N1391Result =                 r;
             },
             op_Implicit: function (v) {
                 return Bridge.merge(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj(), {
-                    value: v
+                    value: Bridge.box(v, Boolean, $box_.Boolean.toString)
                 } );
             },
             op_Implicit$2: function (v) {
@@ -10000,7 +10053,7 @@ Bridge.$N1391Result =                 r;
             },
             op_Implicit$1: function (v) {
                 return Bridge.merge(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892.Obj(), {
-                    value: v
+                    value: Bridge.box(v, System.Int32)
                 } );
             },
             op_BitwiseOr: function (left, right) {
@@ -10063,11 +10116,11 @@ Bridge.$N1391Result =                 r;
 
             var v3 = { };
             var b3 = System.UInt32.tryParse("0x1700fffА", v3, radix);
-            Bridge.Test.Assert.false$1(b3, "b3: " + v3.v);
+            Bridge.Test.Assert.false$1(b3, "b3: " + Bridge.box(v3.v, System.UInt32));
 
             var v4 = { };
             var b4 = System.UInt32.tryParse("1700fffg", v4, radix);
-            Bridge.Test.Assert.false$1(b4, "b4: " + v4.v);
+            Bridge.Test.Assert.false$1(b4, "b4: " + Bridge.box(v4.v, System.UInt32));
         }
     });
 
@@ -10249,7 +10302,7 @@ Bridge.$N1391Result =                 r;
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1909", {
         testActivatorEnumCreation: function () {
             var et = Bridge.createInstance(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1909.EnumType);
-            Bridge.Test.Assert.areEqual(0, et);
+            Bridge.Test.Assert.areEqual(0, Bridge.unbox(et));
             Bridge.Test.Assert.true(Bridge.is(et, System.Int32));
         }
     });
@@ -10274,13 +10327,13 @@ Bridge.$N1391Result =                 r;
         value: null,
         ctor: function (value) {
             this.$initialize();
-            this.value = value;
+            this.value = Bridge.box(value, T);
         },
         getValue1: function () {
             return Bridge.cast(this.value, Bridge.ClientTest.Batch3.BridgeIssues.Bridge1910.ItemValue);
         },
         getValue2: function () {
-            return Bridge.cast(this.value, T);
+            return Bridge.cast(Bridge.unbox(this.value), T);
         }
     }; });
 
@@ -10292,7 +10345,7 @@ Bridge.$N1391Result =                 r;
                 return value;
             },
             getValue2: function (value) {
-                return value;
+                return Bridge.box(value, System.Int32);
             }
         },
         testExtensionMethodOfBaseClass: function () {
@@ -10307,7 +10360,7 @@ Bridge.$N1391Result =                 r;
             var max2 = System.Linq.Enumerable.from(System.Linq.Enumerable.from(values).select(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1911.getValue2)).max();
 
             Bridge.Test.Assert.areEqual(2, max1);
-            Bridge.Test.Assert.areEqual(2, max2);
+            Bridge.Test.Assert.areEqual(2, Bridge.unbox(max2));
         }
     });
 
@@ -10366,9 +10419,9 @@ Bridge.$N1391Result =                 r;
             var item = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge1915.LocalItem();
 
             Bridge.ClientTest.Batch3.BridgeIssues.Bridge1915.LocalTest.test(item);
-            Bridge.Test.Assert.areEqual(1, item.Bridge$ClientTestHelper$Internal$IItem$getValue());
+            Bridge.Test.Assert.areEqual(1, Bridge.unbox(item.Bridge$ClientTestHelper$Internal$IItem$getValue()));
             Bridge.ClientTestHelper.Internal.ClassLibraryTest.test(item);
-            Bridge.Test.Assert.areEqual(2, item.Bridge$ClientTestHelper$Internal$IItem$getValue());
+            Bridge.Test.Assert.areEqual(2, Bridge.unbox(item.Bridge$ClientTestHelper$Internal$IItem$getValue()));
         }
     });
 
@@ -10393,7 +10446,7 @@ Bridge.$N1391Result =                 r;
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1915.LocalTest", {
         statics: {
             test: function (item) {
-                item.Bridge$ClientTestHelper$Internal$IWriteableItem$setValue(1);
+                item.Bridge$ClientTestHelper$Internal$IWriteableItem$setValue(Bridge.box(1, System.Int32));
             }
         }
     });
@@ -10408,20 +10461,20 @@ Bridge.$N1391Result =                 r;
             var s = System.String.concat(s1, s2, s3, s4);
             Bridge.Test.Assert.areEqual("s1s2s3s4", s);
 
-            s = System.String.concat("a" + 1, null);
+            s = System.String.concat("a" + Bridge.box(1, System.Int32), null);
             Bridge.Test.Assert.areEqual("a1", s);
 
-            s = System.String.concat(null, "a", 1);
+            s = System.String.concat(null, "a", Bridge.box(1, System.Int32));
             Bridge.Test.Assert.areEqual("a1", s);
 
-            s = System.String.concat("a", null, 1);
+            s = System.String.concat("a", null, Bridge.box(1, System.Int32));
             Bridge.Test.Assert.areEqual("a1", s);
 
-            s = "a" + 1 + "b" + "c";
+            s = "a" + Bridge.box(1, System.Int32) + "b" + "c";
             Bridge.Test.Assert.areEqual("a1bc", s);
 
             s = null;
-            s = System.String.concat(String.fromCharCode(123), s, String.fromCharCode(125));
+            s = System.String.concat(String.fromCharCode(Bridge.box(123, System.Char, $box_.System.Char.toString)), s, String.fromCharCode(Bridge.box(125, System.Char, $box_.System.Char.toString)));
             Bridge.Test.Assert.areEqual("{}", s);
 
             s = System.String.concat("", s, "");
@@ -10436,14 +10489,14 @@ Bridge.$N1391Result =                 r;
             s = System.String.concat(s1, "", s2, "", s3);
             Bridge.Test.Assert.areEqual("s1s2s3", s);
 
-            s = "Test" + 2;
+            s = "Test" + Bridge.box(2, System.Int32);
             Bridge.Test.Assert.areEqual("Test2", s);
 
             var i = 2;
-            s = "" + i + "";
+            s = "" + Bridge.box(i, System.Int32) + "";
             Bridge.Test.Assert.areEqual("2", s);
 
-            s = "" + ((Bridge.Int.div(i, 2)) | 0);
+            s = "" + Bridge.box(((Bridge.Int.div(i, 2)) | 0), System.Int32);
             Bridge.Test.Assert.areEqual("1", s);
         }
     });
@@ -10587,7 +10640,7 @@ Bridge.$N1391Result =                 r;
 
     Bridge.apply($_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge1948, {
         f1: function (_o34) {
-            _o34.add("name", 1);
+            _o34.add("name", Bridge.box(1, System.Int32));
             return _o34;
         }
     });
@@ -10606,7 +10659,7 @@ Bridge.$N1391Result =                 r;
             this.dic = new (System.Collections.Generic.Dictionary$2(String,Object))();
         },
         add: function (key, value) {
-            this.dic.add(key, value);
+            this.dic.add(key, Bridge.unbox(value));
         },
         System$Collections$Generic$IEnumerable$1$System$Collections$Generic$KeyValuePair$2$String$Object$getEnumerator: function () {
             this.isGeneric = true;
@@ -10692,31 +10745,31 @@ Bridge.$N1391Result =                 r;
             for (var i = 0; i < p.length; i = (i + 1) | 0) {
                 s = p[i];
                 c = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1964.getCharCode(s);
-                Bridge.Test.Assert.true$1(System.String.isNullOrWhiteSpace(s), System.String.concat("White-spaces table 1. Index:" + i + " Char code:", c));
+                Bridge.Test.Assert.true$1(System.String.isNullOrWhiteSpace(s), System.String.concat("White-spaces table 1. Index:" + Bridge.box(i, System.Int32) + " Char code:", c));
             }
 
             for (var i1 = 0; i1 < p.length; i1 = (i1 + 1) | 0) {
                 s = System.String.concat(" ", p[i1]);
                 c = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1964.getCharCode(s);
-                Bridge.Test.Assert.true$1(System.String.isNullOrWhiteSpace(s), System.String.concat("White-spaces table 2. Index:" + i1 + " Char code:", c));
+                Bridge.Test.Assert.true$1(System.String.isNullOrWhiteSpace(s), System.String.concat("White-spaces table 2. Index:" + Bridge.box(i1, System.Int32) + " Char code:", c));
             }
 
             for (var i2 = 0; i2 < p.length; i2 = (i2 + 1) | 0) {
                 s = System.String.concat(p[i2], " ");
                 c = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1964.getCharCode(s, false);
-                Bridge.Test.Assert.true$1(System.String.isNullOrWhiteSpace(s), System.String.concat("White-spaces table 3. Index:" + i2 + " Char code:", c));
+                Bridge.Test.Assert.true$1(System.String.isNullOrWhiteSpace(s), System.String.concat("White-spaces table 3. Index:" + Bridge.box(i2, System.Int32) + " Char code:", c));
             }
 
             for (var i3 = 0; i3 < p.length; i3 = (i3 + 1) | 0) {
                 s = System.String.concat("a", p[i3]);
                 c = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1964.getCharCode(s);
-                Bridge.Test.Assert.false$1(System.String.isNullOrWhiteSpace(s), System.String.concat("Non white-spaces table 1. Index:" + i3 + " Char code:", c));
+                Bridge.Test.Assert.false$1(System.String.isNullOrWhiteSpace(s), System.String.concat("Non white-spaces table 1. Index:" + Bridge.box(i3, System.Int32) + " Char code:", c));
             }
 
             for (var i4 = 0; i4 < p.length; i4 = (i4 + 1) | 0) {
                 s = System.String.concat(p[i4], "b");
                 c = Bridge.ClientTest.Batch3.BridgeIssues.Bridge1964.getCharCode(s, false);
-                Bridge.Test.Assert.false$1(System.String.isNullOrWhiteSpace(s), System.String.concat("Non white-spaces table 2. Index:" + i4 + " Char code:", c));
+                Bridge.Test.Assert.false$1(System.String.isNullOrWhiteSpace(s), System.String.concat("Non white-spaces table 2. Index:" + Bridge.box(i4, System.Int32) + " Char code:", c));
             }
         }
     });
@@ -10755,8 +10808,8 @@ Bridge.$N1391Result =                 r;
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(type1));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(type2));
 
-            Bridge.Test.Assert.areEqual(0, value1);
-            Bridge.Test.Assert.null(value2);
+            Bridge.Test.Assert.areEqual(0, Bridge.unbox(value1));
+            Bridge.Test.Assert.null(Bridge.unbox(value2));
         }
     });
 
@@ -10787,7 +10840,7 @@ Bridge.$N1391Result =                 r;
         testRunClassConstructor: function () {
             var type1 = Bridge.Reflection.getType("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1970.Test, Bridge.ClientTest.Batch3");
 
-            Bridge.Test.Assert.areEqual(true, Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(type1, 4, 284, "IsInitialized"), null));
+            Bridge.Test.Assert.areEqual(true, Bridge.unbox(Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(type1, 4, 284, "IsInitialized"), null)));
         }
     });
 
@@ -10814,7 +10867,7 @@ Bridge.$N1391Result =                 r;
             $t = new Bridge.ArrayEnumerator(holder.array);
             while ($t.moveNext()) {
                 var item = $t.getCurrent();
-                Bridge.Test.Assert.areEqual(((i = (i + 1) | 0)), item);
+                Bridge.Test.Assert.areEqual(((i = (i + 1) | 0)), Bridge.unbox(item));
             }
         }
     });
@@ -11016,9 +11069,9 @@ Bridge.$N1391Result =                 r;
             testToStringForEnumWhenConcatWithString: function () {
                 var $t;
                 var value = Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options.Whatever;
-                Bridge.Test.Assert.areEqual("Value: Whatever", "Value: " + System.Enum.toString(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, value));
+                Bridge.Test.Assert.areEqual("Value: Whatever", "Value: " + System.Enum.toString(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, Bridge.box(value, Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, $box_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options.toString)));
                 Bridge.Test.Assert.areEqual("Value: Whatever", System.String.concat("Value: ", System.Enum.toString(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, value)));
-                Bridge.Test.Assert.areEqual("Value: Whatever", "Value: " + System.Enum.toString(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.getStatus()));
+                Bridge.Test.Assert.areEqual("Value: Whatever", "Value: " + System.Enum.toString(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.getStatus(), Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, $box_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options.toString)));
                 Bridge.Test.Assert.areEqual("Value: Whatever", System.String.concat("Value: ", ($t=Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.getStatus(), System.Enum.toString(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, $t))));
             }
         }
@@ -11049,7 +11102,7 @@ Bridge.$N1391Result =                 r;
             playing: "playing",
             finished: "finished"
         },
-        $utype: System.String
+        $utype: String
     });
 
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2038", {
@@ -11100,6 +11153,29 @@ Bridge.$N1391Result =                 r;
             var s = to || new Bridge.ClientTest.Batch3.BridgeIssues.Bridge2038.SimpleStruct();
             s.field1 = this.field1;
             return s;
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065", {
+        statics: {
+            testBoxedEnum: function () {
+                var $t;
+                var vehicleType = Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.VehicleType.Boat;
+                var box = Bridge.box(vehicleType, Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.VehicleType, $box_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.VehicleType.toString);
+
+                Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.VehicleType.Boat, vehicleType);
+                Bridge.Test.Assert.areEqual("Boat", box.toString());
+                Bridge.Test.Assert.areEqual("Boat", ($t=System.Enum.parse(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.VehicleType, "Boat"), System.Enum.toString(System.Enum, $t)));
+            }
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.VehicleType", {
+        $kind: "enum",
+        statics: {
+            Car: 0,
+            Plane: 1,
+            Boat: 2
         }
     });
 
@@ -11204,7 +11280,7 @@ Bridge.$N1391Result =                 r;
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge306Component$1", function (TProps) { return {
         statics: {
             new: function (TComponent, props) {
-                return System.String.concat(Bridge.Reflection.getTypeFullName(Bridge.getType(props)), ":", props);
+                return System.String.concat(Bridge.Reflection.getTypeFullName(Bridge.getType(props)), ":", Bridge.box(props, TProps));
             }
         }
     }; });
@@ -11321,7 +11397,7 @@ Bridge.$N1391Result =                 r;
                 var s2 = Bridge.toArray(animals).join(" ");
                 Bridge.Test.Assert.areEqual$1("Squirrel Gray Wolf Capybara", s2, "Join2");
 
-                var values = [null, "Cobb", 4189, 11434, 0.366];
+                var values = [null, "Cobb", Bridge.box(4189, System.Int32), Bridge.box(11434, System.Int32), Bridge.box(0.366, System.Double, $box_.System.Double.toString)];
                 var s31 = values.join("|");
                 Bridge.Test.Assert.areEqual$1("|Cobb|4189|11434|0.366", s31, "Join31");
 
@@ -11331,7 +11407,7 @@ Bridge.$N1391Result =                 r;
 
                 var sArr = System.Array.init(10, null);
                 for (var i = 0; i < 10; i = (i + 1) | 0) {
-                    sArr[i] = System.String.format("{0,-3}", ((i * 5) | 0));
+                    sArr[i] = System.String.format("{0,-3}", Bridge.box(((i * 5) | 0), System.Int32));
                 }
 
                 var s4 = sArr.join(":");
@@ -11889,7 +11965,7 @@ Bridge.$N1391Result =                 r;
                                         continue;
                                     }
                                     case 3: {
-                                        result = System.String.concat(result, (System.String.format("A({0})", Bridge.identity(i, (i = (i + 1) | 0)))));
+                                        result = System.String.concat(result, (System.String.format("A({0})", Bridge.box(Bridge.identity(i, (i = (i + 1) | 0)), System.Int32))));
                                     }
                                     case 4: {
                                         $task2 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge508.nextPage();
@@ -11927,7 +12003,7 @@ Bridge.$N1391Result =                 r;
                                         continue;
                                     }
                                     case 9: {
-                                        result = System.String.concat(result, (System.String.format("B({0})", Bridge.identity(i, (i = (i + 1) | 0)))));
+                                        result = System.String.concat(result, (System.String.format("B({0})", Bridge.box(Bridge.identity(i, (i = (i + 1) | 0)), System.Int32))));
                                     }
                                     case 10: {
                                         np1 = Bridge.ClientTest.Batch3.BridgeIssues.Bridge508.nextPage1();
@@ -12221,7 +12297,7 @@ Bridge.$N1391Result =                 r;
                 var srcString = "123";
                 var destString = "4";
 
-                destString = System.String.concat(destString, String.fromCharCode(srcString.charCodeAt(2)));
+                destString = System.String.concat(destString, String.fromCharCode(Bridge.box(srcString.charCodeAt(2), System.Char, $box_.System.Char.toString)));
 
                 Bridge.Test.Assert.areEqual$1("43", destString, "Bridge538 '43'");
             }
@@ -12242,7 +12318,7 @@ Bridge.$N1391Result =                 r;
                 Bridge.Test.Assert.areEqual$1(26.1, dbl, "Bridge544 double");
 
                 var d = Bridge.merge(Bridge.createInstance(System.Decimal), JSON.parse("27.2"));
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(d, 27.2, "Bridge544 decimal");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(d, System.Decimal, $box_.System.Decimal.toString), 27.2, "Bridge544 decimal");
 
                 var s = Bridge.merge(Bridge.createInstance(String), JSON.parse("\"Some string\""));
                 Bridge.Test.Assert.areEqual$1("Some string", s, "Bridge544 string");
@@ -13152,75 +13228,75 @@ Bridge.$N1391Result =                 r;
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge583", {
         statics: {
             testUseCase: function () {
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 6), System.Decimal(1.4), "Bridge583 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 6), System.Decimal(1.6), "Bridge583 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 6), System.Decimal(123.4568), "Bridge583 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 6), System.Decimal(123.456789), "Bridge583 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 6), System.Decimal(123.456789), "Bridge583 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 6), System.Decimal(-123.0), "Bridge583 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 6), System.Decimal, $box_.System.Decimal.toString), System.Decimal(1.4), "Bridge583 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 6), System.Decimal, $box_.System.Decimal.toString), System.Decimal(1.6), "Bridge583 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 6), System.Decimal, $box_.System.Decimal.toString), System.Decimal(123.4568), "Bridge583 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 6), System.Decimal, $box_.System.Decimal.toString), System.Decimal(123.456789), "Bridge583 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 6), System.Decimal, $box_.System.Decimal.toString), System.Decimal(123.456789), "Bridge583 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 6), System.Decimal, $box_.System.Decimal.toString), System.Decimal(-123.0), "Bridge583 6");
 
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 0), 1.5, "Bridge583 Up 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 0), 1.6, "Bridge583 Up 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 0), 123.4568, "Bridge583 Up 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 0), 123.456789, "Bridge583 Up 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 0), 123.456789, "Bridge583 Up 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 0), -124.0, "Bridge583 Up 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 0), System.Decimal, $box_.System.Decimal.toString), 1.5, "Bridge583 Up 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 0), System.Decimal, $box_.System.Decimal.toString), 1.6, "Bridge583 Up 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 0), System.Decimal, $box_.System.Decimal.toString), 123.4568, "Bridge583 Up 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 0), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 Up 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 0), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 Up 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 0), System.Decimal, $box_.System.Decimal.toString), -124.0, "Bridge583 Up 6");
 
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 4), 1.5, "Bridge583 AwayFromZero 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 4), 1.6, "Bridge583 AwayFromZero 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 4), 123.4568, "Bridge583 AwayFromZero 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 4), 123.456789, "Bridge583 AwayFromZero 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 4), 123.456789, "Bridge583 AwayFromZero 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 4), -123.0, "Bridge583 AwayFromZero 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 4), System.Decimal, $box_.System.Decimal.toString), 1.5, "Bridge583 AwayFromZero 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 4), System.Decimal, $box_.System.Decimal.toString), 1.6, "Bridge583 AwayFromZero 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 4), System.Decimal, $box_.System.Decimal.toString), 123.4568, "Bridge583 AwayFromZero 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 4), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 AwayFromZero 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 4), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 AwayFromZero 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 4), System.Decimal, $box_.System.Decimal.toString), -123.0, "Bridge583 AwayFromZero 6");
 
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 1), 1.4, "Bridge583 Down 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 1), 1.5, "Bridge583 Down 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 1), 123.4567, "Bridge583 Down 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 1), 123.456789, "Bridge583 Down 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 1), 123.456789, "Bridge583 Down 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 1), -123.0, "Bridge583 Down 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 1), System.Decimal, $box_.System.Decimal.toString), 1.4, "Bridge583 Down 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 1), System.Decimal, $box_.System.Decimal.toString), 1.5, "Bridge583 Down 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 1), System.Decimal, $box_.System.Decimal.toString), 123.4567, "Bridge583 Down 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 1), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 Down 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 1), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 Down 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 1), System.Decimal, $box_.System.Decimal.toString), -123.0, "Bridge583 Down 6");
 
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 2), 1.5, "Bridge583 InfinityPos 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 2), 1.6, "Bridge583 InfinityPos 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 2), 123.4568, "Bridge583 InfinityPos 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 2), 123.456789, "Bridge583 InfinityPos 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 2), 123.456789, "Bridge583 InfinityPos 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 2), -123.0, "Bridge583 InfinityPos 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 2), System.Decimal, $box_.System.Decimal.toString), 1.5, "Bridge583 InfinityPos 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 2), System.Decimal, $box_.System.Decimal.toString), 1.6, "Bridge583 InfinityPos 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 2), System.Decimal, $box_.System.Decimal.toString), 123.4568, "Bridge583 InfinityPos 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 2), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 InfinityPos 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 2), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 InfinityPos 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 2), System.Decimal, $box_.System.Decimal.toString), -123.0, "Bridge583 InfinityPos 6");
 
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 3), 1.4, "Bridge583 InfinityNeg 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 3), 1.5, "Bridge583 InfinityNeg 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 3), 123.4567, "Bridge583 InfinityNeg 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 3), 123.456789, "Bridge583 InfinityNeg 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 3), 123.456789, "Bridge583 InfinityNeg 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 3), -124.0, "Bridge583 InfinityNeg 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 3), System.Decimal, $box_.System.Decimal.toString), 1.4, "Bridge583 InfinityNeg 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 3), System.Decimal, $box_.System.Decimal.toString), 1.5, "Bridge583 InfinityNeg 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 3), System.Decimal, $box_.System.Decimal.toString), 123.4567, "Bridge583 InfinityNeg 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 3), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 InfinityNeg 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 3), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 InfinityNeg 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 3), System.Decimal, $box_.System.Decimal.toString), -124.0, "Bridge583 InfinityNeg 6");
 
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 5), 1.4, "Bridge583 TowardsZero 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 5), 1.5, "Bridge583 TowardsZero 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 5), 123.4568, "Bridge583 TowardsZero 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 5), 123.456789, "Bridge583 TowardsZero 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 5), 123.456789, "Bridge583 TowardsZero 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 5), -123.0, "Bridge583 TowardsZero 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 5), System.Decimal, $box_.System.Decimal.toString), 1.4, "Bridge583 TowardsZero 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 5), System.Decimal, $box_.System.Decimal.toString), 1.5, "Bridge583 TowardsZero 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 5), System.Decimal, $box_.System.Decimal.toString), 123.4568, "Bridge583 TowardsZero 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 5), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 TowardsZero 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 5), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 TowardsZero 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 5), System.Decimal, $box_.System.Decimal.toString), -123.0, "Bridge583 TowardsZero 6");
 
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 6), 1.4, "Bridge583 ToEven 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 6), 1.6, "Bridge583 ToEven 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 6), 123.4568, "Bridge583 ToEven 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 6), 123.456789, "Bridge583 ToEven 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 6), 123.456789, "Bridge583 ToEven 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 6), -123.0, "Bridge583 ToEven 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 6), System.Decimal, $box_.System.Decimal.toString), 1.4, "Bridge583 ToEven 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 6), System.Decimal, $box_.System.Decimal.toString), 1.6, "Bridge583 ToEven 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 6), System.Decimal, $box_.System.Decimal.toString), 123.4568, "Bridge583 ToEven 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 6), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 ToEven 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 6), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 ToEven 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 6), System.Decimal, $box_.System.Decimal.toString), -123.0, "Bridge583 ToEven 6");
 
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 7), 1.5, "Bridge583 Ceil 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 7), 1.6, "Bridge583 Ceil 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 7), 123.4568, "Bridge583 Ceil 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 7), 123.456789, "Bridge583 Ceil 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 7), 123.456789, "Bridge583 Ceil 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 7), -123.0, "Bridge583 Ceil 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 7), System.Decimal, $box_.System.Decimal.toString), 1.5, "Bridge583 Ceil 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 7), System.Decimal, $box_.System.Decimal.toString), 1.6, "Bridge583 Ceil 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 7), System.Decimal, $box_.System.Decimal.toString), 123.4568, "Bridge583 Ceil 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 7), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 Ceil 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 7), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 Ceil 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 7), System.Decimal, $box_.System.Decimal.toString), -123.0, "Bridge583 Ceil 6");
 
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 8), 1.4, "Bridge583 Floor 1");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 8), 1.5, "Bridge583 Floor 2");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 8), 123.4568, "Bridge583 Floor 3");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 8), 123.456789, "Bridge583 Floor 4");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 8), 123.456789, "Bridge583 Floor 5");
-                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 8), -123.0, "Bridge583 Floor 6");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.45), 1, 8), System.Decimal, $box_.System.Decimal.toString), 1.4, "Bridge583 Floor 1");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(1.55), 1, 8), System.Decimal, $box_.System.Decimal.toString), 1.5, "Bridge583 Floor 2");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 4, 8), System.Decimal, $box_.System.Decimal.toString), 123.4568, "Bridge583 Floor 3");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 6, 8), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 Floor 4");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(123.456789), 8, 8), System.Decimal, $box_.System.Decimal.toString), 123.456789, "Bridge583 Floor 5");
+                Bridge.ClientTest.Batch3.Utilities.DecimalHelper.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-123.456), 0, 8), System.Decimal, $box_.System.Decimal.toString), -123.0, "Bridge583 Floor 6");
             }
         }
     });
@@ -13460,10 +13536,10 @@ Bridge.$N1391Result =                 r;
 
     Bridge.apply($_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge597A, {
         f1: function (value, index) {
-            return System.String.concat(index + ":", value);
+            return System.String.concat(Bridge.box(index, System.Int32) + ":", value);
         },
         f2: function (value, index) {
-            return System.String.concat(this._something, ":", index, ":", value);
+            return System.String.concat(this._something, ":", Bridge.box(index, System.Int32), ":", value);
         }
     });
 
@@ -14023,10 +14099,10 @@ Bridge.$N1391Result =                 r;
                 var a = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge635A();
                 var b = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge635B();
 
-                Bridge.Test.Assert.areEqual$1("function", typeof a.internalFunc1, "Bridge635 A.internalFunc1");
+                Bridge.Test.Assert.areEqual$1("function", typeof Bridge.unbox(a.internalFunc1), "Bridge635 A.internalFunc1");
                 Bridge.Test.Assert.areEqual$1("A.Test1", a["internalFunc1"](), "Bridge635 A.internalFunc1 Invoke");
 
-                Bridge.Test.Assert.areEqual$1("function", typeof b.internalFunc1, "Bridge635 B.internalFunc1");
+                Bridge.Test.Assert.areEqual$1("function", typeof Bridge.unbox(b.internalFunc1), "Bridge635 B.internalFunc1");
                 Bridge.Test.Assert.areEqual$1("B.Test1", b["internalFunc1"](), "Bridge635 B.internalFunc1 Invoke");
             }
         }
@@ -14058,11 +14134,11 @@ Bridge.$N1391Result =                 r;
         statics: {
             testUseCase: function () {
                 var a = { bar: 1 };
-                Bridge.Test.Assert.areEqual$1(1, a.bar, "Bridge647 A");
+                Bridge.Test.Assert.areEqual$1(1, Bridge.unbox(a.bar), "Bridge647 A");
 
                 var b = { bar: 1, bar1: 12 };
-                Bridge.Test.Assert.areEqual$1(1, b.bar, "Bridge647 B bar");
-                Bridge.Test.Assert.areEqual$1(12, b.bar1, "Bridge647 B bar1");
+                Bridge.Test.Assert.areEqual$1(1, Bridge.unbox(b.bar), "Bridge647 B bar");
+                Bridge.Test.Assert.areEqual$1(12, Bridge.unbox(b.bar1), "Bridge647 B bar1");
             }
         }
     });
@@ -14157,7 +14233,7 @@ Bridge.$N1391Result =                 r;
             testUseCase: function () {
                 var item11 = $_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge655.f1;
                 Bridge.Test.Assert.areEqual$1(false, Bridge.ClientTest.Batch3.BridgeIssues.Bridge655A.isNullOrUndefined(item11), "Bridge655 IsNullOrUndefined11");
-                Bridge.Test.Assert.areEqual$1(11, item11(), "Bridge655 item11");
+                Bridge.Test.Assert.areEqual$1(11, Bridge.unbox(item11()), "Bridge655 item11");
 
                 var item12 = $_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge655.f2;
                 Bridge.Test.Assert.areEqual$1(false, Bridge.ClientTest.Batch3.BridgeIssues.Bridge655A.isNullOrUndefined(item12), "Bridge655 IsNullOrUndefined12");
@@ -14166,7 +14242,7 @@ Bridge.$N1391Result =                 r;
                 var item21 = $_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge655.f3;
                 Bridge.Test.Assert.areEqual$1(false, Bridge.ClientTest.Batch3.BridgeIssues.Bridge655A.isNullOrUndefined$1(item21, 21), "Bridge655 IsNullOrUndefined21 false");
                 Bridge.Test.Assert.areEqual$1(true, Bridge.ClientTest.Batch3.BridgeIssues.Bridge655A.isNullOrUndefined$1(item21, 0), "Bridge655 IsNullOrUndefined21 true");
-                Bridge.Test.Assert.areEqual$1(21, item21(), "Bridge655 item21");
+                Bridge.Test.Assert.areEqual$1(21, Bridge.unbox(item21()), "Bridge655 item21");
 
                 var item22 = $_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge655.f4;
                 Bridge.Test.Assert.areEqual$1("false", Bridge.ClientTest.Batch3.BridgeIssues.Bridge655A.isNullOrUndefined$2(item22, "22"), "Bridge655 IsNullOrUndefined22 false");
@@ -14184,13 +14260,13 @@ Bridge.$N1391Result =                 r;
 
     Bridge.apply($_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge655, {
         f1: function () {
-            return 11;
+            return Bridge.box(11, System.Int32);
         },
         f2: function (i) {
             return i;
         },
         f3: function () {
-            return 21;
+            return Bridge.box(21, System.Int32);
         },
         f4: function (i, s) {
             return ((i + s.length) | 0);
@@ -14436,13 +14512,13 @@ Bridge.$N1391Result =                 r;
                 // In .Net the code below produces null and does not fail. Changing the test to reflect this
                 var o = undefined;
 
-                Bridge.Test.Assert.areEqual$1(undefined, Bridge.cast(o, String), "Cast 'undefined' to string results in undefined");
-                Bridge.Test.Assert.areEqual$1(undefined, Bridge.cast(o, Array), "Cast 'undefined' to int[] results in undefined");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(undefined), Bridge.cast(o, String), "Cast 'undefined' to string results in undefined");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(undefined), Bridge.cast(o, Array), "Cast 'undefined' to int[] results in undefined");
             },
             testUndefinedToValueType: function () {
                 var o = undefined;
                 Bridge.Test.Assert.throws$5(function () {
-                    var i = System.Nullable.getValue(Bridge.cast(o, System.Int32));
+                    var i = System.Nullable.getValue(Bridge.cast(Bridge.unbox(o), System.Int32));
                 }, "Unable to cast 'undefined' to type int");
             }
         }
@@ -15094,9 +15170,9 @@ Bridge.$N1391Result =                 r;
 
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge706", {
         statics: {
-            value: 7,
+            value: Bridge.box(7, System.Int32),
             testFieldPropertyWithInitializer: function () {
-                Bridge.Test.Assert.areEqual(7, Bridge.ClientTest.Batch3.BridgeIssues.Bridge706.value);
+                Bridge.Test.Assert.areEqual(7, Bridge.unbox(Bridge.ClientTest.Batch3.BridgeIssues.Bridge706.value));
             }
         }
     });
@@ -15229,9 +15305,9 @@ Bridge.$N1391Result =                 r;
                 Bridge.Test.Assert.areEqual$1(4, Bridge.ClientTest.Batch3.BridgeIssues.Bridge722.M1((asset1 = (c1.setItem("path", 4), 4))), "Bridge722 M1 4");
 
                 var c2 = new $_.$AnonymousType$14();
-                var asset2 = (c2.path = 5, 5);
-                Bridge.Test.Assert.areEqual$1(5, asset2, "Bridge722 asset2");
-                Bridge.Test.Assert.areEqual$1(5, c2.path, "Bridge722 c2");
+                var asset2 = (c2.path = Bridge.box(5, System.Int32), Bridge.box(5, System.Int32));
+                Bridge.Test.Assert.areEqual$1(5, Bridge.unbox(asset2), "Bridge722 asset2");
+                Bridge.Test.Assert.areEqual$1(5, Bridge.unbox(c2.path), "Bridge722 c2");
 
                 var c3 = new (System.Collections.Generic.Dictionary$2(String,System.Int32))();
                 var asset3 = (c3.set("path", 6), 6);
@@ -15319,7 +15395,7 @@ Bridge.$N1391Result =                 r;
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge743", {
         statics: {
             testInlineMethodsAsReference: function () {
-                var aaa = 7;
+                var aaa = Bridge.box(7, System.Int32);
                 var fn1 = function (b) { return Bridge.equals(aaa, b); };
                 Bridge.Test.Assert.true(fn1(7));
 
@@ -15327,10 +15403,10 @@ Bridge.$N1391Result =                 r;
                 Bridge.Test.Assert.true(fn1(7));
 
                 var fn2 = function (a, b) { return Bridge.equals(a, b); };
-                Bridge.Test.Assert.true(fn2(aaa, 7));
+                Bridge.Test.Assert.true(fn2(Bridge.unbox(aaa), 7));
 
                 fn2 = function (a, b) { return Bridge.equals(a, b); };
-                Bridge.Test.Assert.true(fn2(aaa, 7));
+                Bridge.Test.Assert.true(fn2(Bridge.unbox(aaa), 7));
 
                 var list = $_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge743.f1(new (System.Collections.Generic.List$1(String))());
                 var converted = Bridge.ClientTest.Batch3.BridgeIssues.Bridge743ObjectExtention.convertAllItems(String, System.Int32, list, function (s) { return System.Int32.parse(s); });
@@ -15567,13 +15643,13 @@ Bridge.$N1391Result =                 r;
 
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.method((Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.setSomeProperty(o), o));
                 {
-                    Bridge.Test.Assert.notNull$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.getSomeProperty(), "Bridge777 SomeProperty");
+                    Bridge.Test.Assert.notNull$1(Bridge.unbox(Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.getSomeProperty()), "Bridge777 SomeProperty");
                 }
 
                 ($t = (Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.setP2(o), o), Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.setP1($t), $t);
                 {
-                    Bridge.Test.Assert.notNull$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.getP1(), "Bridge777 P1");
-                    Bridge.Test.Assert.notNull$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.getP2(), "Bridge777 P2");
+                    Bridge.Test.Assert.notNull$1(Bridge.unbox(Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.getP1()), "Bridge777 P1");
+                    Bridge.Test.Assert.notNull$1(Bridge.unbox(Bridge.ClientTest.Batch3.BridgeIssues.Bridge777.getP2()), "Bridge777 P2");
                 }
             }
         }
@@ -15815,7 +15891,7 @@ Bridge.$N1391Result =                 r;
         $kind: "struct",
         statics: {
             op_Equality: function (x, y) {
-                return x.equals(y.$clone());
+                return x.equals(Bridge.box(y.$clone(), Bridge.ClientTest.Batch3.BridgeIssues.Bridge795A));
             },
             op_Inequality: function (x, y) {
                 return !(Bridge.ClientTest.Batch3.BridgeIssues.Bridge795A.op_Equality(x, y));
@@ -15838,7 +15914,7 @@ Bridge.$N1391Result =                 r;
             if (!(Bridge.is(o, Bridge.ClientTest.Batch3.BridgeIssues.Bridge795A))) {
                 return false;
             }
-            return System.Nullable.getValue(Bridge.cast(o, Bridge.ClientTest.Batch3.BridgeIssues.Bridge795A)).getValue() === this.getValue();
+            return System.Nullable.getValue(Bridge.cast(Bridge.unbox(o), Bridge.ClientTest.Batch3.BridgeIssues.Bridge795A)).getValue() === this.getValue();
         },
         getHashCode: function () {
             return this.getValue();
@@ -15890,7 +15966,7 @@ Bridge.$N1391Result =                 r;
                 return false;
             }
 
-            return System.Nullable.getValue(Bridge.cast(o, Bridge.ClientTest.Batch3.BridgeIssues.Bridge795B)).getValue() === this.getValue();
+            return System.Nullable.getValue(Bridge.cast(Bridge.unbox(o), Bridge.ClientTest.Batch3.BridgeIssues.Bridge795B)).getValue() === this.getValue();
         },
         getHashCode: function () {
             return this.getValue();
@@ -16009,7 +16085,7 @@ Bridge.$N1391Result =                 r;
                 root.appendChild(textArea);
 
                 var ta = document.getElementById("textArea1");
-                Bridge.Test.Assert.areEqual$1("Test", ta.value, "Bridge816 textArea1.value");
+                Bridge.Test.Assert.areEqual$1("Test", Bridge.unbox(ta.value), "Bridge816 textArea1.value");
             }
         }
     });
@@ -16624,13 +16700,13 @@ Bridge.$N1391Result =                 r;
             },
             testMakeEnumerable: function () {
                 Bridge.Test.Assert.areEqual$1(0, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(Object)).count(), "MakeEnumerable object 0");
-                Bridge.Test.Assert.areEqual$1(2, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(Object, [1, 2.0])).count(), "MakeEnumerable object 2");
+                Bridge.Test.Assert.areEqual$1(2, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(Object, [Bridge.box(1, System.Int32), Bridge.box(2.0, System.Double, $box_.System.Double.toString)])).count(), "MakeEnumerable object 2");
 
                 Bridge.Test.Assert.areEqual$1(0, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(String)).count(), "MakeEnumerable string 0");
                 Bridge.Test.Assert.areEqual$1(3, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(String, ["a", "b", "c"])).count(), "MakeEnumerable string 3");
 
                 Bridge.Test.Assert.areEqual$1(0, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(System.Collections.Generic.IEnumerable$1(Object))).count(), "MakeEnumerable IEnumerable<object> 0");
-                Bridge.Test.Assert.areEqual$1(1, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(System.Collections.Generic.IEnumerable$1(Object), [[1, 2]])).count(), "MakeEnumerable IEnumerable<object> 1");
+                Bridge.Test.Assert.areEqual$1(1, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(System.Collections.Generic.IEnumerable$1(Object), [[Bridge.box(1, System.Int32), Bridge.box(2, System.Int32)]])).count(), "MakeEnumerable IEnumerable<object> 1");
 
                 Bridge.Test.Assert.areEqual$1(0, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(System.Collections.Generic.List$1(System.Collections.Generic.List$1(Object)))).count(), "MakeEnumerable List<List<object>> 0");
                 Bridge.Test.Assert.areEqual$1(2, System.Linq.Enumerable.from(Bridge.ClientTest.Batch3.BridgeIssues.Bridge889.makeEnumerable(System.Collections.Generic.List$1(System.Collections.Generic.List$1(System.Int32)), [new (System.Collections.Generic.List$1(System.Collections.Generic.List$1(System.Int32)))(), new (System.Collections.Generic.List$1(System.Collections.Generic.List$1(System.Int32)))()])).count(), "MakeEnumerable List<List<object>> 2");
@@ -17775,31 +17851,31 @@ Bridge.$N1391Result =                 r;
                 var x = System.Double.max;
 
                 var y1 = Bridge.Int.clip32(Math.floor(x / 0.2));
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-2147483648, y1, "int");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-2147483648, System.Int32), Bridge.box(y1, System.Int32), "int");
 
                 var y2 = Bridge.Int.clipu32(Math.floor(x / 0.2));
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, y2, "uint");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt32), Bridge.box(y2, System.UInt32), "uint");
 
                 var z1 = Bridge.Int.clip64(Math.floor(x / 0.2));
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.Int64.MinValue, z1, "long");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.Int64.MinValue, System.Int64), Bridge.box(z1, System.Int64), "long");
 
                 var z2 = Bridge.Int.clipu64(Math.floor(x / 0.2));
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.UInt64.MinValue, z2, "ulong");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.UInt64.MinValue, System.UInt64), Bridge.box(z2, System.UInt64), "ulong");
             },
             testIntegerDivisionInDefaultMode: function () {
                 var x = 1.1;
 
                 var y1 = Bridge.Int.clip32(1 / x);
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, y1, "int");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.Int32), Bridge.box(y1, System.Int32), "int");
 
                 var y2 = Bridge.Int.clipu32(1 / x);
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, y2, "uint");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt32), Bridge.box(y2, System.UInt32), "uint");
 
                 var z1 = Bridge.Int.clip64(1 / x);
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.Int64(0), z1, "long");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.Int64(0), System.Int64), Bridge.box(z1, System.Int64), "long");
 
                 var z2 = Bridge.Int.clipu64(1 / x);
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.UInt64(0), z2, "ulong");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.UInt64(0), System.UInt64), Bridge.box(z2, System.UInt64), "ulong");
             },
             testInfinityCastDefaultOverflowMode: function () {
                 var pi = Number.POSITIVE_INFINITY;
@@ -17815,14 +17891,14 @@ Bridge.$N1391Result =                 r;
 
                 // https://msdn.microsoft.com/en-us/library/aa691289(v=vs.71).aspx
                 // If the value of the operand is NaN or infinite, the result of the conversion is an unspecified value of the destination type.
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, y1, "PositiveInfinity -> byte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-128, y2, "PositiveInfinity -> sbyte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-32768, y3, "PositiveInfinity -> short");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, y4, "PositiveInfinity -> ushort");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-2147483648, y5, "PositiveInfinity -> int");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, y6, "PositiveInfinity -> uint");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.Int64.MinValue, y7, "PositiveInfinity -> long");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.UInt64.MinValue, y8, "PositiveInfinity -> ulong");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.Byte), Bridge.box(y1, System.Byte), "PositiveInfinity -> byte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-128, System.SByte), Bridge.box(y2, System.SByte), "PositiveInfinity -> sbyte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-32768, System.Int16), Bridge.box(y3, System.Int16), "PositiveInfinity -> short");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt16), Bridge.box(y4, System.UInt16), "PositiveInfinity -> ushort");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-2147483648, System.Int32), Bridge.box(y5, System.Int32), "PositiveInfinity -> int");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt32), Bridge.box(y6, System.UInt32), "PositiveInfinity -> uint");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.Int64.MinValue, System.Int64), Bridge.box(y7, System.Int64), "PositiveInfinity -> long");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.UInt64.MinValue, System.UInt64), Bridge.box(y8, System.UInt64), "PositiveInfinity -> ulong");
 
                 var ni = Number.NEGATIVE_INFINITY;
 
@@ -17837,14 +17913,14 @@ Bridge.$N1391Result =                 r;
 
                 // https://msdn.microsoft.com/en-us/library/aa691289(v=vs.71).aspx
                 // If the value of the operand is NaN or infinite, the result of the conversion is an unspecified value of the destination type.
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, z1, "NegativeInfinity -> byte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-128, z2, "NegativeInfinity -> sbyte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-32768, z3, "NegativeInfinity -> short");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, z4, "NegativeInfinity -> ushort");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-2147483648, z5, "NegativeInfinity -> int");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, z6, "NegativeInfinity -> uint");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.Int64.MinValue, z7, "NegativeInfinity -> long");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.UInt64.MinValue, z8, "NegativeInfinity -> ulong");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.Byte), Bridge.box(z1, System.Byte), "NegativeInfinity -> byte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-128, System.SByte), Bridge.box(z2, System.SByte), "NegativeInfinity -> sbyte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-32768, System.Int16), Bridge.box(z3, System.Int16), "NegativeInfinity -> short");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt16), Bridge.box(z4, System.UInt16), "NegativeInfinity -> ushort");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-2147483648, System.Int32), Bridge.box(z5, System.Int32), "NegativeInfinity -> int");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt32), Bridge.box(z6, System.UInt32), "NegativeInfinity -> uint");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.Int64.MinValue, System.Int64), Bridge.box(z7, System.Int64), "NegativeInfinity -> long");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.UInt64.MinValue, System.UInt64), Bridge.box(z8, System.UInt64), "NegativeInfinity -> ulong");
             },
             testInfinityCastWithNullable1DefaultOverflowMode: function () {
                 var pi = Number.POSITIVE_INFINITY;
@@ -17860,14 +17936,14 @@ Bridge.$N1391Result =                 r;
 
                 // https://msdn.microsoft.com/en-us/library/aa691289(v=vs.71).aspx
                 // If the value of the operand is NaN or infinite, the result of the conversion is an unspecified value of the destination type.
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, y1, "PositiveInfinity -> byte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-128, y2, "PositiveInfinity -> sbyte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-32768, y3, "PositiveInfinity -> short");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, y4, "PositiveInfinity -> ushort");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-2147483648, y5, "PositiveInfinity -> int");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, y6, "PositiveInfinity -> uint");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.Int64.MinValue, y7, "PositiveInfinity -> long");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.UInt64.MinValue, y8, "PositiveInfinity -> ulong");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.Byte), Bridge.box(y1, System.Byte, $box_.System.Nullable$1.toString), "PositiveInfinity -> byte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-128, System.SByte), Bridge.box(y2, System.SByte, $box_.System.Nullable$1.toString), "PositiveInfinity -> sbyte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-32768, System.Int16), Bridge.box(y3, System.Int16, $box_.System.Nullable$1.toString), "PositiveInfinity -> short");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt16), Bridge.box(y4, System.UInt16, $box_.System.Nullable$1.toString), "PositiveInfinity -> ushort");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-2147483648, System.Int32), Bridge.box(y5, System.Int32, $box_.System.Nullable$1.toString), "PositiveInfinity -> int");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt32), Bridge.box(y6, System.UInt32, $box_.System.Nullable$1.toString), "PositiveInfinity -> uint");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.Int64.MinValue, System.Int64), Bridge.box(y7, System.Int64, $box_.System.Nullable$1.toString), "PositiveInfinity -> long");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.UInt64.MinValue, System.UInt64), Bridge.box(y8, System.UInt64, $box_.System.Nullable$1.toString), "PositiveInfinity -> ulong");
 
                 var ni = Number.NEGATIVE_INFINITY;
 
@@ -17882,14 +17958,14 @@ Bridge.$N1391Result =                 r;
 
                 // https://msdn.microsoft.com/en-us/library/aa691289(v=vs.71).aspx
                 // If the value of the operand is NaN or infinite, the result of the conversion is an unspecified value of the destination type.
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, z1, "NegativeInfinity -> byte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-128, z2, "NegativeInfinity -> sbyte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-32768, z3, "NegativeInfinity -> short");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, z4, "NegativeInfinity -> ushort");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-2147483648, z5, "NegativeInfinity -> int");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, z6, "NegativeInfinity -> uint");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.Int64.MinValue, z7, "NegativeInfinity -> long");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.UInt64.MinValue, z8, "NegativeInfinity -> ulong");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.Byte), Bridge.box(z1, System.Byte, $box_.System.Nullable$1.toString), "NegativeInfinity -> byte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-128, System.SByte), Bridge.box(z2, System.SByte, $box_.System.Nullable$1.toString), "NegativeInfinity -> sbyte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-32768, System.Int16), Bridge.box(z3, System.Int16, $box_.System.Nullable$1.toString), "NegativeInfinity -> short");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt16), Bridge.box(z4, System.UInt16, $box_.System.Nullable$1.toString), "NegativeInfinity -> ushort");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-2147483648, System.Int32), Bridge.box(z5, System.Int32, $box_.System.Nullable$1.toString), "NegativeInfinity -> int");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt32), Bridge.box(z6, System.UInt32, $box_.System.Nullable$1.toString), "NegativeInfinity -> uint");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.Int64.MinValue, System.Int64), Bridge.box(z7, System.Int64, $box_.System.Nullable$1.toString), "NegativeInfinity -> long");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.UInt64.MinValue, System.UInt64), Bridge.box(z8, System.UInt64, $box_.System.Nullable$1.toString), "NegativeInfinity -> ulong");
             },
             testInfinityCastWithNullable2DefaultOverflowMode: function () {
                 var pi = Number.POSITIVE_INFINITY;
@@ -17905,14 +17981,14 @@ Bridge.$N1391Result =                 r;
 
                 // https://msdn.microsoft.com/en-us/library/aa691289(v=vs.71).aspx
                 // If the value of the operand is NaN or infinite, the result of the conversion is an unspecified value of the destination type.
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, System.Nullable.getValue(y1), "PositiveInfinity -> byte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-128, System.Nullable.getValue(y2), "PositiveInfinity -> sbyte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-32768, System.Nullable.getValue(y3), "PositiveInfinity -> short");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, System.Nullable.getValue(y4), "PositiveInfinity -> ushort");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-2147483648, System.Nullable.getValue(y5), "PositiveInfinity -> int");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, System.Nullable.getValue(y6), "PositiveInfinity -> uint");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.Int64.MinValue, System.Nullable.getValue(y7), "PositiveInfinity -> long");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.UInt64.MinValue, System.Nullable.getValue(y8), "PositiveInfinity -> ulong");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.Byte), Bridge.box(System.Nullable.getValue(y1), System.Byte), "PositiveInfinity -> byte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-128, System.SByte), Bridge.box(System.Nullable.getValue(y2), System.SByte), "PositiveInfinity -> sbyte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-32768, System.Int16), Bridge.box(System.Nullable.getValue(y3), System.Int16), "PositiveInfinity -> short");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt16), Bridge.box(System.Nullable.getValue(y4), System.UInt16), "PositiveInfinity -> ushort");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-2147483648, System.Int32), Bridge.box(System.Nullable.getValue(y5), System.Int32), "PositiveInfinity -> int");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt32), Bridge.box(System.Nullable.getValue(y6), System.UInt32), "PositiveInfinity -> uint");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.Int64.MinValue, System.Int64), Bridge.box(System.Nullable.getValue(y7), System.Int64), "PositiveInfinity -> long");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.UInt64.MinValue, System.UInt64), Bridge.box(System.Nullable.getValue(y8), System.UInt64), "PositiveInfinity -> ulong");
 
                 var ni = Number.NEGATIVE_INFINITY;
 
@@ -17927,14 +18003,14 @@ Bridge.$N1391Result =                 r;
 
                 // https://msdn.microsoft.com/en-us/library/aa691289(v=vs.71).aspx
                 // If the value of the operand is NaN or infinite, the result of the conversion is an unspecified value of the destination type.
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, System.Nullable.getValue(z1), "NegativeInfinity -> byte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-128, System.Nullable.getValue(z2), "NegativeInfinity -> sbyte");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-32768, System.Nullable.getValue(z3), "NegativeInfinity -> short");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, System.Nullable.getValue(z4), "NegativeInfinity -> ushort");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(-2147483648, System.Nullable.getValue(z5), "NegativeInfinity -> int");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(0, System.Nullable.getValue(z6), "NegativeInfinity -> uint");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.Int64.MinValue, System.Nullable.getValue(z7), "NegativeInfinity -> long");
-                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(System.UInt64.MinValue, System.Nullable.getValue(z8), "NegativeInfinity -> ulong");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.Byte), Bridge.box(System.Nullable.getValue(z1), System.Byte), "NegativeInfinity -> byte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-128, System.SByte), Bridge.box(System.Nullable.getValue(z2), System.SByte), "NegativeInfinity -> sbyte");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-32768, System.Int16), Bridge.box(System.Nullable.getValue(z3), System.Int16), "NegativeInfinity -> short");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt16), Bridge.box(System.Nullable.getValue(z4), System.UInt16), "NegativeInfinity -> ushort");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(-2147483648, System.Int32), Bridge.box(System.Nullable.getValue(z5), System.Int32), "NegativeInfinity -> int");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(0, System.UInt32), Bridge.box(System.Nullable.getValue(z6), System.UInt32), "NegativeInfinity -> uint");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.Int64.MinValue, System.Int64), Bridge.box(System.Nullable.getValue(z7), System.Int64), "NegativeInfinity -> long");
+                Bridge.ClientTest.Batch3.BridgeIssues.N1122.assertNumber(Bridge.box(System.UInt64.MinValue, System.UInt64), Bridge.box(System.Nullable.getValue(z8), System.UInt64), "NegativeInfinity -> ulong");
             }
         }
     });
@@ -18111,7 +18187,7 @@ Bridge.$N1391Result =                 r;
             N341: function () {
                 var o11 = {  };
                 var o12 = {  };
-                var b1 = System.Collections.Generic.EqualityComparer$1(Object).def.equals2(o11, o12);
+                var b1 = System.Collections.Generic.EqualityComparer$1(Object).def.equals2(Bridge.unbox(o11), Bridge.unbox(o12));
                 Bridge.Test.Assert.false$1(b1, "EqualityComparer<object>.Default.Equals(o11, o12) works");
 
                 var o21 = new $_.$AnonymousType$17(7);
@@ -18276,10 +18352,10 @@ Bridge.$N1391Result =                 r;
             },
             N409: function () {
                 var a = System.Decimal.round(System.Decimal(3.5), 6);
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(a, "4", "Math.Round(3.5M)");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(a, System.Decimal, $box_.System.Decimal.toString), "4", "Math.Round(3.5M)");
 
                 var b = System.Decimal.round(System.Decimal(4.5), 6);
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(b, "4", "Math.Round(4.5M)");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(b, System.Decimal, $box_.System.Decimal.toString), "4", "Math.Round(4.5M)");
             },
             ensureNumber: function (actual, expected, message) {
                 Bridge.Test.Assert.areEqual$1(expected, actual.toString(), message);
@@ -18290,7 +18366,7 @@ Bridge.$N1391Result =                 r;
                     diff = -diff;
                 }
 
-                Bridge.Test.Assert.true$1(diff < 1E-08, System.String.concat(message, "actual: ", System.Double.format(actual, 'G'), "expeted:", System.Double.format(expected, 'G')));
+                Bridge.Test.Assert.true$1(diff < 1E-08, System.String.concat(message, "actual: ", System.Double.format(Bridge.box(actual, System.Double, $box_.System.Double.toString), 'G'), "expeted:", System.Double.format(Bridge.box(expected, System.Double, $box_.System.Double.toString), 'G')));
             },
             N410: function () {
                 // Decimal consts
@@ -18300,11 +18376,11 @@ Bridge.$N1391Result =                 r;
                 var DecimalMaxValue = System.Decimal.MaxValue;
                 var DecimalMinValue = System.Decimal.MinValue;
 
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalZero, "0", "DecimalZero");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalOne, "1", "DecimalOne");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalMinusOne, "-1", "DecimalMinusOne");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalMaxValue, "7.9228162514264337593543950335e+28", "DecimalMaxValue");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalMinValue, "-7.9228162514264337593543950335e+28", "DecimalMinValue");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalZero, System.Decimal, $box_.System.Decimal.toString), "0", "DecimalZero");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalOne, System.Decimal, $box_.System.Decimal.toString), "1", "DecimalOne");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalMinusOne, System.Decimal, $box_.System.Decimal.toString), "-1", "DecimalMinusOne");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalMaxValue, System.Decimal, $box_.System.Decimal.toString), "79228162514264337593543950335", "DecimalMaxValue");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalMinValue, System.Decimal, $box_.System.Decimal.toString), "-79228162514264337593543950335", "DecimalMinValue");
 
                 // Decimal consts in expressions
                 var dz = System.Decimal(0.0);
@@ -18318,11 +18394,11 @@ Bridge.$N1391Result =                 r;
                 DecimalMinValue = System.Decimal.MinValue.add(dz);
                 ;
 
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalZero, "0", "DecimalZeroin expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalOne, "1", "DecimalOnein expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalMinusOne, "-1", "DecimalMinusOnein expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalMaxValue, "7.9228162514264337593543950335e+28", "DecimalMaxValuein expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DecimalMinValue, "-7.9228162514264337593543950335e+28", "DecimalMinValuein expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalZero, System.Decimal, $box_.System.Decimal.toString), "0", "DecimalZeroin expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalOne, System.Decimal, $box_.System.Decimal.toString), "1", "DecimalOnein expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalMinusOne, System.Decimal, $box_.System.Decimal.toString), "-1", "DecimalMinusOnein expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalMaxValue, System.Decimal, $box_.System.Decimal.toString), "79228162514264337593543950335", "DecimalMaxValuein expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DecimalMinValue, System.Decimal, $box_.System.Decimal.toString), "-79228162514264337593543950335", "DecimalMinValuein expression");
 
                 var numberPositiveInfinity = Number.POSITIVE_INFINITY;
                 var numberNegativeInfinity = Number.NEGATIVE_INFINITY;
@@ -18336,12 +18412,12 @@ Bridge.$N1391Result =                 r;
                 var DoublePositiveInfinity = Number.POSITIVE_INFINITY;
                 var DoubleNaN = Number.NaN;
 
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DoubleMaxValue, "1.7976931348623157e+308", "DoubleMaxValue");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DoubleMinValue, "-1.7976931348623157e+308", "DoubleMinValue");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DoubleEpsilon, "5e-324", "DoubleEpsilon");
-                Bridge.Test.Assert.areEqual$1(numberNegativeInfinity, DoubleNegativeInfinity, "DoubleNegativeInfinity");
-                Bridge.Test.Assert.areEqual$1(numberPositiveInfinity, DoublePositiveInfinity, "DoublePositiveInfinity");
-                Bridge.Test.Assert.areEqual$1(numberNaN, DoubleNaN, "DoubleNaN");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DoubleMaxValue, System.Double, $box_.System.Double.toString), "1.79769313486232E+308", "DoubleMaxValue");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DoubleMinValue, System.Double, $box_.System.Double.toString), "-1.79769313486232E+308", "DoubleMinValue");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DoubleEpsilon, System.Double, $box_.System.Double.toString), "4.94065645841247E-324", "DoubleEpsilon");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberNegativeInfinity), DoubleNegativeInfinity, "DoubleNegativeInfinity");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberPositiveInfinity), DoublePositiveInfinity, "DoublePositiveInfinity");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberNaN), DoubleNaN, "DoubleNaN");
 
                 // Double consts in expressions
                 var dblz = 0.0;
@@ -18352,12 +18428,12 @@ Bridge.$N1391Result =                 r;
                 DoublePositiveInfinity = Number.POSITIVE_INFINITY + dblz;
                 DoubleNaN = Number.NaN + dblz;
 
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DoubleMaxValue, "1.7976931348623157e+308", "DoubleMaxValuein expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DoubleMinValue, "-1.7976931348623157e+308", "DoubleMinValuein expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(DoubleEpsilon, "5e-324", "DoubleEpsilonin expression");
-                Bridge.Test.Assert.areEqual$1(numberNegativeInfinity, DoubleNegativeInfinity, "DoubleNegativeInfinityin expression");
-                Bridge.Test.Assert.areEqual$1(numberPositiveInfinity, DoublePositiveInfinity, "DoublePositiveInfinityin expression");
-                Bridge.Test.Assert.areEqual$1(numberNaN, DoubleNaN, "DoubleNaNin expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DoubleMaxValue, System.Double, $box_.System.Double.toString), "1.79769313486232E+308", "DoubleMaxValuein expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DoubleMinValue, System.Double, $box_.System.Double.toString), "-1.79769313486232E+308", "DoubleMinValuein expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(DoubleEpsilon, System.Double, $box_.System.Double.toString), "4.94065645841247E-324", "DoubleEpsilonin expression");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberNegativeInfinity), DoubleNegativeInfinity, "DoubleNegativeInfinityin expression");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberPositiveInfinity), DoublePositiveInfinity, "DoublePositiveInfinityin expression");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberNaN), DoubleNaN, "DoubleNaNin expression");
 
                 // Math consts
                 var MathE = Math.E;
@@ -18369,15 +18445,15 @@ Bridge.$N1391Result =                 r;
                 var MathSQRT1_2 = Math.SQRT1_2;
                 var MathSQRT2 = Math.SQRT2;
 
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathE, "2.718281828459045", "MathE");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathLN10, "2.302585092994046", "MathLN10");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathLN2, "0.6931471805599453", "MathLN2");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathE, System.Double, $box_.System.Double.toString), "2.71828182845905", "MathE");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathLN10, System.Double, $box_.System.Double.toString), "2.30258509299405", "MathLN10");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathLN2, System.Double, $box_.System.Double.toString), "0.69314718055995", "MathLN2");
                 //IE has Math.LOG2E defined as 1.4426950408889633 instead of standard 1.4426950408889634
                 Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.assertAlmostEqual(MathLOG2E, 1.4426950408889634, "MathLOG2E");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathLOG10E, "0.4342944819032518", "MathLOG10E");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathPI, "3.141592653589793", "MathPI");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathSQRT1_2, "0.7071067811865476", "MathSQRT1_2");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathSQRT2, "1.4142135623730951", "MathSQRT2");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathLOG10E, System.Double, $box_.System.Double.toString), "0.43429448190325", "MathLOG10E");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathPI, System.Double, $box_.System.Double.toString), "3.14159265358979", "MathPI");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathSQRT1_2, System.Double, $box_.System.Double.toString), "0.70710678118655", "MathSQRT1_2");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathSQRT2, System.Double, $box_.System.Double.toString), "1.4142135623731", "MathSQRT2");
 
                 // Math consts in expression
                 MathE = Math.E + 0;
@@ -18389,15 +18465,15 @@ Bridge.$N1391Result =                 r;
                 MathSQRT1_2 = Math.SQRT1_2 + 0;
                 MathSQRT2 = Math.SQRT2 + 0;
 
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathE, "2.718281828459045", "MathEin expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathLN10, "2.302585092994046", "MathLN10in expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathLN2, "0.6931471805599453", "MathLN2in expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathE, System.Double, $box_.System.Double.toString), "2.71828182845905", "MathEin expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathLN10, System.Double, $box_.System.Double.toString), "2.30258509299405", "MathLN10in expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathLN2, System.Double, $box_.System.Double.toString), "0.69314718055995", "MathLN2in expression");
                 //IE has Math.LOG2E defined as 1.4426950408889633 instead of standard 1.4426950408889634
                 Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.assertAlmostEqual(MathLOG2E, 1.4426950408889634, "MathLOG2Ein expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathLOG10E, "0.4342944819032518", "MathLOG10Ein expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathPI, "3.141592653589793", "MathPIin expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathSQRT1_2, "0.7071067811865476", "MathSQRT1_2in expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(MathSQRT2, "1.4142135623730951", "MathSQRT2in expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathLOG10E, System.Double, $box_.System.Double.toString), "0.43429448190325", "MathLOG10Ein expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathPI, System.Double, $box_.System.Double.toString), "3.14159265358979", "MathPIin expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathSQRT1_2, System.Double, $box_.System.Double.toString), "0.70710678118655", "MathSQRT1_2in expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(MathSQRT2, System.Double, $box_.System.Double.toString), "1.4142135623731", "MathSQRT2in expression");
 
                 // Single consts
                 var SingleMaxValue = 3.40282347E+38;
@@ -18407,12 +18483,12 @@ Bridge.$N1391Result =                 r;
                 var SingleNegativeInfinity = Number.NEGATIVE_INFINITY;
                 var SinglePositiveInfinity = Number.POSITIVE_INFINITY;
 
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(SingleMaxValue, "3.40282347e+38", "SingleMaxValue");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(SingleMinValue, "-3.40282347e+38", "SingleMinValue");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(SingleEpsilon, "1.401298e-45", "SingleEpsilon");
-                Bridge.Test.Assert.areEqual$1(numberNaN, SingleNaN, "SingleNaN");
-                Bridge.Test.Assert.areEqual$1(numberNegativeInfinity, SingleNegativeInfinity, "SingleNegativeInfinity");
-                Bridge.Test.Assert.areEqual$1(numberPositiveInfinity, SinglePositiveInfinity, "SinglePositiveInfinity");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(SingleMaxValue, System.Single, $box_.System.Single.toString), "3.402823E+38", "SingleMaxValue");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(SingleMinValue, System.Single, $box_.System.Single.toString), "-3.402823E+38", "SingleMinValue");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(SingleEpsilon, System.Single, $box_.System.Single.toString), "1.401298E-45", "SingleEpsilon");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberNaN), SingleNaN, "SingleNaN");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberNegativeInfinity), SingleNegativeInfinity, "SingleNegativeInfinity");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberPositiveInfinity), SinglePositiveInfinity, "SinglePositiveInfinity");
 
                 // Single consts in expression
                 var fz = 0;
@@ -18423,12 +18499,12 @@ Bridge.$N1391Result =                 r;
                 SingleNegativeInfinity = Number.NEGATIVE_INFINITY + fz;
                 SinglePositiveInfinity = Number.POSITIVE_INFINITY + fz;
 
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(SingleMaxValue, "3.40282347e+38", "SingleMaxValuein expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(SingleMinValue, "-3.40282347e+38", "SingleMinValuein expression");
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(SingleEpsilon, "1.401298e-45", "SingleEpsilonin expression");
-                Bridge.Test.Assert.areEqual$1(numberNaN, SingleNaN, "SingleNaNin expression");
-                Bridge.Test.Assert.areEqual$1(numberNegativeInfinity, SingleNegativeInfinity, "SingleNegativeInfinityin expression");
-                Bridge.Test.Assert.areEqual$1(numberPositiveInfinity, SinglePositiveInfinity, "SinglePositiveInfinityin expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(SingleMaxValue, System.Single, $box_.System.Single.toString), "3.402823E+38", "SingleMaxValuein expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(SingleMinValue, System.Single, $box_.System.Single.toString), "-3.402823E+38", "SingleMinValuein expression");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(SingleEpsilon, System.Single, $box_.System.Single.toString), "1.401298E-45", "SingleEpsilonin expression");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberNaN), SingleNaN, "SingleNaNin expression");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberNegativeInfinity), SingleNegativeInfinity, "SingleNegativeInfinityin expression");
+                Bridge.Test.Assert.areEqual$1(Bridge.unbox(numberPositiveInfinity), SinglePositiveInfinity, "SinglePositiveInfinityin expression");
             },
             N418: function () {
                 var t = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge418();
@@ -18448,7 +18524,7 @@ Bridge.$N1391Result =                 r;
             },
             N428: function () {
                 var number2 = System.Decimal(11.37);
-                var sum = "0.13 + " + Bridge.Int.format(number2, 'G');
+                var sum = "0.13 + " + Bridge.Int.format(Bridge.box(number2, System.Decimal, $box_.System.Decimal.toString), 'G');
 
                 Bridge.Test.Assert.areEqual$1("0.13 + 11.37", sum, "0.13 + 11.37");
             },
@@ -18487,10 +18563,10 @@ Bridge.$N1391Result =                 r;
             },
             N442: function () {
                 var a = System.Decimal(3.5);
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(a.round(), "4", "a.Round(3.5M)");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(a.round(), System.Decimal, $box_.System.Decimal.toString), "4", "a.Round(3.5M)");
 
                 var b = System.Decimal(4.5);
-                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(b.round(), "4", "b.Round(4.5M)");
+                Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues.ensureNumber(Bridge.box(b.round(), System.Decimal, $box_.System.Decimal.toString), "4", "b.Round(4.5M)");
             },
             N460: function () {
                 var number;
@@ -19602,6 +19678,112 @@ Bridge.$N1391Result =                 r;
 
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1339.Foo4", {
         inherits: [Bridge.ClientTest.Batch3.BridgeIssues.Bridge1339.Foo3]
+    });
+
+    var $box_ = {};
+
+    Bridge.ns("System.Decimal", $box_);
+
+    Bridge.apply($box_.System.Decimal, {
+        toString: function(obj) {return Bridge.Int.format(obj, 'G');}
+    });
+
+
+    Bridge.ns("System.Single", $box_);
+
+    Bridge.apply($box_.System.Single, {
+        toString: function(obj) {return System.Single.format(obj, 'G');}
+    });
+
+
+    Bridge.ns("System.Double", $box_);
+
+    Bridge.apply($box_.System.Double, {
+        toString: function(obj) {return System.Double.format(obj, 'G');}
+    });
+
+
+    Bridge.ns("System.Char", $box_);
+
+    Bridge.apply($box_.System.Char, {
+        toString: function(obj) {return String.fromCharCode(obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("Boolean", $box_);
+
+    Bridge.apply($box_.Boolean, {
+        toString: function(obj) {return System.Boolean.toString(obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027.Options, obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.VehicleType", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.VehicleType, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.VehicleType, obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
     });
 
     var $m = Bridge.setMetadata,

--- a/Tests/Runner/Batch3/test.js
+++ b/Tests/Runner/Batch3/test.js
@@ -122,10 +122,13 @@
             QUnit.test("#1260 - TestStringTrimEnd", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1260.testStringTrimEnd);
             QUnit.test("#1264 - TestDefaultGetHashCodeIsRepeatable", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1264.testDefaultGetHashCodeIsRepeatable);
             QUnit.test("#1266 - TestArrayToEnumerable", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1266.testArrayToEnumerable);
+            QUnit.test("#1290 - TestBoxedChar", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1290.testBoxedChar);
+            QUnit.test("#1292 - TestBoxedChar", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1292.testBoxedChar);
             QUnit.test("#1296 - TestImplicitOperator", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1296.testImplicitOperator);
             QUnit.test("#1296 - TestIgnoreCast", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1296.testIgnoreCast);
             QUnit.test("#1296 - TestExternalImplicit", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1296.testExternalImplicit);
             QUnit.test("#1298 - TestLongSwitch", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1298.testLongSwitch);
+            QUnit.test("#1301 - TestBoxedNumbers", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1301.testBoxedNumbers);
             QUnit.test("#1304 - TestWriteFormatString", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1304.testWriteFormatString);
             QUnit.test("#1304 - TestWriteLineFormatString", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1304.testWriteLineFormatString);
             QUnit.test("#1305 - TestAsyncIntReturnWithAssigmentFromResult", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1305.testAsyncIntReturnWithAssigmentFromResult);
@@ -170,6 +173,7 @@
             QUnit.test("#1344 - TestLocalVariableWithNameProto", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1344.testLocalVariableWithNameProto);
             QUnit.test("#1348 - TestVoidTypeOf", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1348.testVoidTypeOf);
             QUnit.test("#1355 - TestLocalVariableWithNameWindow", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1355.testLocalVariableWithNameWindow);
+            QUnit.test("#1357 - TestBoxedValueType", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1357.testBoxedValueType);
             QUnit.test("#1374 - TestConvertAllForIntListStaticMethod", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1374.testConvertAllForIntListStaticMethod);
             QUnit.test("#1374 - TestConvertAllForIntListInstanceMethod", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1374.testConvertAllForIntListInstanceMethod);
             QUnit.test("#1374 - TestConvertAllForIntListLambda", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1374.testConvertAllForIntListLambda);
@@ -351,6 +355,7 @@
             QUnit.test("#2027 - TestToStringForEnumWhenConcatWithString", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2027.testToStringForEnumWhenConcatWithString);
             QUnit.test("#2033 - TestClassEnumPropertiesInitialization", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2033.testClassEnumPropertiesInitialization);
             QUnit.test("#2038 - TestIncrementAssignmentInStructs", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2038.testIncrementAssignmentInStructs);
+            QUnit.test("#2065 - TestBoxedEnum", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2065.testBoxedEnum);
             QUnit.test("#381 - TestUseCase", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge381.testUseCase);
             QUnit.test("#447 - CheckInlineExpression", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge447.checkInlineExpression);
             QUnit.test("#447 - CheckInlineCalls", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge447.checkInlineCalls);
@@ -1468,6 +1473,26 @@
         }
     });
 
+    Bridge.define("Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1290", {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1290)],
+        statics: {
+            testBoxedChar: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1290).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1290);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1290.testBoxedChar();
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1292", {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1292)],
+        statics: {
+            testBoxedChar: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1292).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1292);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1292.testBoxedChar();
+            }
+        }
+    });
+
     Bridge.define("Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1296", {
         inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1296)],
         statics: {
@@ -1492,6 +1517,16 @@
             testLongSwitch: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1298).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1298, 3);
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1298.testLongSwitch();
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1301", {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1301)],
+        statics: {
+            testBoxedNumbers: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1301).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1301);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1301.testBoxedNumbers();
             }
         }
     });
@@ -1762,6 +1797,16 @@
             testLocalVariableWithNameWindow: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1355).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1355);
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge1355.testLocalVariableWithNameWindow();
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1357", {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1357)],
+        statics: {
+            testBoxedValueType: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1357).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1357);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge1357.testBoxedValueType();
             }
         }
     });
@@ -3360,6 +3405,16 @@
             testIncrementAssignmentInStructs: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2038).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2038);
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2038.testIncrementAssignmentInStructs();
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2065", {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065)],
+        statics: {
+            testBoxedEnum: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2065);
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge2065.testBoxedEnum();
             }
         }
     });

--- a/Tests/Runner/Batch4/code.js
+++ b/Tests/Runner/Batch4/code.js
@@ -20,7 +20,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(3, c.i);
 
             // #1540
-            var arr = [3];
+            var arr = [Bridge.box(3, System.Int32)];
             c = Bridge.cast(Bridge.Reflection.applyConstructor(Bridge.ClientTest.Batch4.ActivatorTests.C2, arr), Bridge.ClientTest.Batch4.ActivatorTests.C2);
             Bridge.Test.Assert.areNotEqual(null, c);
             Bridge.Test.Assert.areEqual(3, c.i);
@@ -32,7 +32,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(8, c.j);
 
             // #1541
-            var arr = [7, 8];
+            var arr = [Bridge.box(7, System.Int32), Bridge.box(8, System.Int32)];
             c = Bridge.cast(Bridge.Reflection.applyConstructor(Bridge.ClientTest.Batch4.ActivatorTests.C3, arr), Bridge.ClientTest.Batch4.ActivatorTests.C3);
             Bridge.Test.Assert.areNotEqual(null, c);
             Bridge.Test.Assert.areEqual(7, c.i);
@@ -49,7 +49,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(3, c.i);
 
             // #1542
-            var arr = [3];
+            var arr = [Bridge.box(3, System.Int32)];
             c = Bridge.Reflection.applyConstructor(Bridge.ClientTest.Batch4.ActivatorTests.C2, arr);
             Bridge.Test.Assert.areNotEqual(null, c);
             Bridge.Test.Assert.areEqual(3, c.i);
@@ -61,7 +61,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(8, c.j);
 
             // #1543
-            var arr = [7, 8];
+            var arr = [Bridge.box(7, System.Int32), Bridge.box(8, System.Int32)];
             c = Bridge.Reflection.applyConstructor(Bridge.ClientTest.Batch4.ActivatorTests.C3, arr);
             Bridge.Test.Assert.areNotEqual(null, c);
             Bridge.Test.Assert.areEqual(7, c.i);
@@ -244,23 +244,23 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         lengthWorks: function () {
             this.lengthHelper0();
-            this.lengthHelper1(4);
-            this.lengthHelper2(6, "x");
+            this.lengthHelper1(Bridge.box(4, System.Int32));
+            this.lengthHelper2(Bridge.box(6, System.Int32), "x");
         },
         getArgumentWorks: function () {
-            Bridge.Test.Assert.areEqual(0, this.getArgumentHelper(0, "x", "y"));
-            Bridge.Test.Assert.areEqual("x", this.getArgumentHelper(1, "x", "y"));
-            Bridge.Test.Assert.areEqual("y", this.getArgumentHelper(2, "x", "y"));
+            Bridge.Test.Assert.areEqual(0, Bridge.unbox(this.getArgumentHelper(0, "x", "y")));
+            Bridge.Test.Assert.areEqual("x", Bridge.unbox(this.getArgumentHelper(1, "x", "y")));
+            Bridge.Test.Assert.areEqual("y", Bridge.unbox(this.getArgumentHelper(2, "x", "y")));
         },
         toArrayWorks: function () {
-            Bridge.Test.Assert.areEqual(System.Array.init(0, null), this.toArrayHelper());
-            Bridge.Test.Assert.areEqual(["x"], this.toArrayHelper("x"));
-            Bridge.Test.Assert.areEqual(["x", 1], this.toArrayHelper("x", 1));
+            Bridge.Test.Assert.areEqual(System.Array.init(0, null), Bridge.unbox(this.toArrayHelper()));
+            Bridge.Test.Assert.areEqual(["x"], Bridge.unbox(this.toArrayHelper("x")));
+            Bridge.Test.Assert.areEqual(["x", Bridge.box(1, System.Int32)], Bridge.unbox(this.toArrayHelper("x", Bridge.box(1, System.Int32))));
         },
         toArrayOfTWorks: function () {
-            Bridge.Test.Assert.areEqual(System.Array.init(0, null), this.toArrayHelper$1(String));
-            Bridge.Test.Assert.areEqual(["x"], this.toArrayHelper$1(String, "x"));
-            Bridge.Test.Assert.areEqual(["x", "y"], this.toArrayHelper$1(String, "x", "y"));
+            Bridge.Test.Assert.areEqual(System.Array.init(0, null), Bridge.unbox(this.toArrayHelper$1(String)));
+            Bridge.Test.Assert.areEqual(["x"], Bridge.unbox(this.toArrayHelper$1(String, "x")));
+            Bridge.Test.Assert.areEqual(["x", "y"], Bridge.unbox(this.toArrayHelper$1(String, "x", "y")));
         }
     });
 
@@ -327,8 +327,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual("y", ["x", "y"][1]);
         },
         getValueWorks: function () {
-            Bridge.Test.Assert.areEqual("x", System.Array.get(["x", "y"], 0));
-            Bridge.Test.Assert.areEqual("y", System.Array.get(["x", "y"], 1));
+            Bridge.Test.Assert.areEqual("x", Bridge.unbox(System.Array.get(["x", "y"], 0)));
+            Bridge.Test.Assert.areEqual("y", Bridge.unbox(System.Array.get(["x", "y"], 1)));
         },
         settingValueByIndexWorks: function () {
             var arr = System.Array.init(2, null);
@@ -358,7 +358,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var arr = ["x", "y"];
             var arr2 = System.Array.clone(arr);
             Bridge.Test.Assert.false(Bridge.referenceEquals(arr, arr2));
-            Bridge.Test.Assert.areEqual(arr2, arr);
+            Bridge.Test.Assert.areEqual(Bridge.unbox(arr2), arr);
         },
         concatWorks: function () {
             var arr = ["a", "b"];
@@ -639,15 +639,15 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         defaultComparerReturnsZeroAsHashCodeForNullAndUndefined: function () {
             Bridge.Test.Assert.areEqual(0, System.Collections.Generic.EqualityComparer$1(Object).def.getHashCode2(null));
-            Bridge.Test.Assert.areEqual(0, System.Collections.Generic.EqualityComparer$1(Object).def.getHashCode2(undefined));
+            Bridge.Test.Assert.areEqual(0, System.Collections.Generic.EqualityComparer$1(Object).def.getHashCode2(Bridge.unbox(undefined)));
         },
         defaultComparerCanDetermineEquality: function () {
             var o1 = {  }, o2 = {  };
             Bridge.Test.Assert.true(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(null, null));
-            Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(null, o1));
-            Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(o1, null));
-            Bridge.Test.Assert.true(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(o1, o1));
-            Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(o1, o2));
+            Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(null, Bridge.unbox(o1)));
+            Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(Bridge.unbox(o1), null));
+            Bridge.Test.Assert.true(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(Bridge.unbox(o1), Bridge.unbox(o1)));
+            Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(Bridge.unbox(o1), Bridge.unbox(o2)));
         },
         defaultComparerInvokesOverriddenGetHashCode: function () {
             Bridge.Test.Assert.areEqual(42158, System.Collections.Generic.EqualityComparer$1(Object).def.getHashCode2(Bridge.merge(new Bridge.ClientTest.Batch4.Collections.Generic.EqualityComparerTests.MyClass(), {
@@ -659,17 +659,17 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var other = new Bridge.ClientTest.Batch4.Collections.Generic.EqualityComparerTests.MyClass();
             c.shouldEqual = false;
             Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(c, other));
-            Bridge.Test.Assert.areStrictEqual(other, c.other);
+            Bridge.Test.Assert.areStrictEqual(other, Bridge.unbox(c.other));
 
             c.shouldEqual = true;
             c.other = null;
             Bridge.Test.Assert.true(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(c, other));
-            Bridge.Test.Assert.areStrictEqual(other, c.other);
+            Bridge.Test.Assert.areStrictEqual(other, Bridge.unbox(c.other));
 
             c.shouldEqual = true;
             c.other = other;
             Bridge.Test.Assert.false(System.Collections.Generic.EqualityComparer$1(Object).def.equals2(c, null)); // We should not invoke our own equals so its return value does not matter.
-            Bridge.Test.Assert.areEqual(other, c.other); // We should not invoke our own equals so the 'other' member should not be set.
+            Bridge.Test.Assert.areEqual(other, Bridge.unbox(c.other)); // We should not invoke our own equals so the 'other' member should not be set.
         }
     });
 
@@ -903,9 +903,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var o = { };
 
             Bridge.Test.Assert.true(d.tryGetValue("a", o));
-            Bridge.Test.Assert.areEqual(1, o.v);
+            Bridge.Test.Assert.areEqual(1, Bridge.unbox(o.v));
             Bridge.Test.Assert.false(d.tryGetValue("c", o));
-            Bridge.Test.Assert.areStrictEqual(null, o.v);
+            Bridge.Test.Assert.areStrictEqual(null, Bridge.unbox(o.v));
         },
         canUseCustomComparer: function () {
             var d = $_.Bridge.ClientTest.Batch4.Collections.Generic.GenericDictionaryTests.f14(new (System.Collections.Generic.Dictionary$2(String, System.Int32))(null, new Bridge.ClientTest.Batch4.Collections.Generic.GenericDictionaryTests.TestEqualityComparer()));
@@ -1463,11 +1463,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         arrayGetEnumeratorMethodWorks: function () {
             var e = Bridge.getEnumerator(["x", "y", "z"]);
             Bridge.Test.Assert.true(e.System$Collections$IEnumerator$moveNext());
-            Bridge.Test.Assert.areEqual("x", e.System$Collections$IEnumerator$getCurrent());
+            Bridge.Test.Assert.areEqual("x", Bridge.unbox(e.System$Collections$IEnumerator$getCurrent()));
             Bridge.Test.Assert.true(e.System$Collections$IEnumerator$moveNext());
-            Bridge.Test.Assert.areEqual("y", e.System$Collections$IEnumerator$getCurrent());
+            Bridge.Test.Assert.areEqual("y", Bridge.unbox(e.System$Collections$IEnumerator$getCurrent()));
             Bridge.Test.Assert.true(e.System$Collections$IEnumerator$moveNext());
-            Bridge.Test.Assert.areEqual("z", e.System$Collections$IEnumerator$getCurrent());
+            Bridge.Test.Assert.areEqual("z", Bridge.unbox(e.System$Collections$IEnumerator$getCurrent()));
             Bridge.Test.Assert.false(e.System$Collections$IEnumerator$moveNext());
         },
         arrayCastToIEnumerableCanBeEnumerated: function () {
@@ -1711,10 +1711,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var enm = new Bridge.ClientTest.Batch4.Collections.Generic.IteratorBlockTests.C(sb).getEnumerator(2);
 
             while (enm.System$Collections$IEnumerator$moveNext()) {
-                sb.appendLine("got " + enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
+                sb.appendLine("got " + Bridge.box(enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")](), System.Int32));
             }
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n");
         },
         prematureDisposalOfIEnumeratorIteratorExecutesFinallyBlocks_SPI_1555: function () {
             // #1555
@@ -1723,11 +1723,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
             for (var i = 0; i < 2; i = (i + 1) | 0) {
                 enm.System$Collections$IEnumerator$moveNext();
-                sb.appendLine("got " + enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
+                sb.appendLine("got " + Bridge.box(enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")](), System.Int32));
             }
             enm.System$IDisposable$dispose();
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nin finally\n");
         },
         exceptionInIEnumeratorIteratorBodyExecutesFinallyBlocks_SPI_1554: function () {
             var sb = new System.Text.StringBuilder();
@@ -1742,7 +1742,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             try {
                 for (var i = 0; i < 100; i = (i + 1) | 0) {
                     enm.System$Collections$IEnumerator$moveNext();
-                    sb.appendLine("got " + enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
+                    sb.appendLine("got " + Bridge.box(enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")](), System.Int32));
                 }
                 Bridge.Test.Assert.fail$1("Should have thrown an exception in the loop");
             }
@@ -1751,7 +1751,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("caught exception");
             }
 
-            this.assertEqual(sb.toString(), "yielding 1\r\ngot 1\r\nyielding 2\r\ngot 2\r\nthrowing\r\nin finally\r\ncaught exception\r\n");
+            this.assertEqual(sb.toString(), "yielding 1\ngot 1\nyielding 2\ngot 2\nthrowing\nin finally\ncaught exception\n");
         },
         typeReturnedByIteratorBlockReturningIEnumerableImplementsThatInterface_SPI_1554: function () {
             var enm = null;
@@ -1773,16 +1773,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             $t = Bridge.getEnumerator(enm, System.Int32);
             while ($t.moveNext()) {
                 var i = $t.getCurrent();
-                sb.appendLine("got " + i);
+                sb.appendLine("got " + Bridge.box(i, System.Int32));
             }
             sb.appendLine("-");
             $t1 = Bridge.getEnumerator(enm, System.Int32);
             while ($t1.moveNext()) {
                 var i1 = $t1.getCurrent();
-                sb.appendLine("got " + i1);
+                sb.appendLine("got " + Bridge.box(i1, System.Int32));
             }
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n-\r\nyielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n-\nyielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n");
         },
         prematureDisposalOfIEnumerableIteratorExecutesFinallyBlocks_SPI_1555: function () {
             var $t;
@@ -1792,13 +1792,13 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             $t = Bridge.getEnumerator(new Bridge.ClientTest.Batch4.Collections.Generic.IteratorBlockTests.C(sb).getEnumerable(5), System.Int32);
             while ($t.moveNext()) {
                 var i = $t.getCurrent();
-                sb.appendLine("got " + i);
+                sb.appendLine("got " + Bridge.box(i, System.Int32));
                 if (((n = (n + 1) | 0)) === 2) {
                     break;
                 }
             }
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nin finally\n");
         },
         exceptionInIEnumerableIteratorBodyExecutesFinallyBlocks_SPI_1554: function () {
             var sb = new System.Text.StringBuilder();
@@ -1814,7 +1814,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 var enumerator = Bridge.getEnumerator(enumerable, System.Int32);
                 for (var i = 0; i < 100; i = (i + 1) | 0) {
                     enumerator.System$Collections$IEnumerator$moveNext();
-                    sb.appendLine("got " + enumerator[Bridge.geti(enumerator, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
+                    sb.appendLine("got " + Bridge.box(enumerator[Bridge.geti(enumerator, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")](), System.Int32));
                 }
                 Bridge.Test.Assert.fail$1("Should have thrown");
             }
@@ -1823,7 +1823,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("caught exception");
             }
 
-            this.assertEqual(sb.toString(), "yielding 1\r\ngot 1\r\nyielding 2\r\ngot 2\r\nthrowing\r\nin finally\r\ncaught exception\r\n");
+            this.assertEqual(sb.toString(), "yielding 1\ngot 1\nyielding 2\ngot 2\nthrowing\nin finally\ncaught exception\n");
         },
         enumeratingAnIteratorBlockReturningIEnumerableMultipleTimesUsesTheInitialValuesForParameters: function () {
             var $t, $t1;
@@ -1841,7 +1841,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine(i1.toString());
             }
 
-            this.assertEqual(sb.toString(), "3\r\n2\r\n1\r\n3\r\n2\r\n1\r\n");
+            this.assertEqual(sb.toString(), "3\n2\n1\n3\n2\n1\n");
         },
         differentGetEnumeratorCallsOnIteratorBlockReturningIEnumerableGetOwnCopiesOfLocals: function () {
             var sb = new System.Text.StringBuilder();
@@ -1856,7 +1856,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine(enm2[Bridge.geti(enm2, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]().toString());
             }
 
-            this.assertEqual(sb.toString(), "0\r\n0\r\n1\r\n1\r\n2\r\n2\r\n-1\r\n-1\r\n");
+            this.assertEqual(sb.toString(), "0\n0\n1\n1\n2\n2\n-1\n-1\n");
         }
     });
 
@@ -1870,7 +1870,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var $yield = [];
             try {
                 for (var i = 0; i < n; i = (i + 1) | 0) {
-                    this._sb.appendLine("yielding " + i);
+                    this._sb.appendLine("yielding " + Bridge.box(i, System.Int32));
                     $yield.push(i);
                 }
                 this._sb.appendLine("yielding -1");
@@ -1902,7 +1902,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var $yield = [];
             try {
                 for (var i = 0; i < n; i = (i + 1) | 0) {
-                    this._sb.appendLine("yielding " + i);
+                    this._sb.appendLine("yielding " + Bridge.box(i, System.Int32));
                     $yield.push(i);
                 }
                 this._sb.appendLine("yielding -1");
@@ -1964,8 +1964,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         typeTestWorksGeneric_SPI_1556: function () {
             // #1556
-            Bridge.Test.Assert.true$1(this.runCheck(System.Collections.Generic.KeyValuePair$2(System.Int32,String), new (System.Collections.Generic.KeyValuePair$2(System.Int32,String))()), "#1");
-            Bridge.Test.Assert.false$1(this.runCheck(System.Collections.Generic.KeyValuePair$2(System.Int32,String), 5), "#2");
+            Bridge.Test.Assert.true$1(this.runCheck(System.Collections.Generic.KeyValuePair$2(System.Int32,String), Bridge.box(new (System.Collections.Generic.KeyValuePair$2(System.Int32,String))(), System.Collections.Generic.KeyValuePair$2(System.Int32,String))), "#1");
+            Bridge.Test.Assert.false$1(this.runCheck(System.Collections.Generic.KeyValuePair$2(System.Int32,String), Bridge.box(5, System.Int32)), "#2");
         },
         theDefaultConstructorCanBeUsed_SPI_1556: function () {
             // #1556
@@ -2956,12 +2956,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.define("Bridge.ClientTest.Batch4.Collections.TypedArrays.Float32ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", System.Single.format(actual[i], 'G')));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", System.Single.format(Bridge.box(actual[i], System.Single, $box_.System.Single.toString), 'G')));
                     return;
                 }
             }
@@ -3169,12 +3169,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.define("Bridge.ClientTest.Batch4.Collections.TypedArrays.Float64ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", System.Double.format(actual[i], 'G')));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", System.Double.format(Bridge.box(actual[i], System.Double, $box_.System.Double.toString), 'G')));
                     return;
                 }
             }
@@ -3383,12 +3383,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.define("Bridge.ClientTest.Batch4.Collections.TypedArrays.Int16ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.Int16)));
                     return;
                 }
             }
@@ -3596,12 +3596,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.define("Bridge.ClientTest.Batch4.Collections.TypedArrays.Int32ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.Int32)));
                     return;
                 }
             }
@@ -3808,12 +3808,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.define("Bridge.ClientTest.Batch4.Collections.TypedArrays.Int8ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.SByte)));
                     return;
                 }
             }
@@ -4020,12 +4020,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.define("Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint16ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.UInt16)));
                     return;
                 }
             }
@@ -4232,12 +4232,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.define("Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint32ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (System.Int64(actual[i]).ne(System.Int64(expected[i]))) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.UInt32)));
                     return;
                 }
             }
@@ -4444,12 +4444,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.define("Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint8ArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.Byte)));
                     return;
                 }
             }
@@ -4656,12 +4656,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.define("Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint8ClampedArrayTests", {
         assertContent: function (actual, expected, message) {
             if (actual.length !== expected.length) {
-                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", expected.length, ", actual: ", actual.length));
+                Bridge.Test.Assert.fail$1(System.String.concat(message, ": Expected length ", Bridge.box(expected.length, System.Int32), ", actual: ", Bridge.box(actual.length, System.Int32)));
                 return;
             }
             for (var i = 0; i < expected.length; i = (i + 1) | 0) {
                 if (actual[i] !== expected[i]) {
-                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", i, ": expected ", expected[i], ", actual: ", actual[i]));
+                    Bridge.Test.Assert.fail$1(System.String.concat(message, ": Position ", Bridge.box(i, System.Int32), ": expected ", Bridge.box(expected[i], System.Int32), ", actual: ", Bridge.box(actual[i], System.Byte)));
                     return;
                 }
             }
@@ -4939,9 +4939,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         getFormatWorks: function () {
             var culture = System.Globalization.CultureInfo.invariantCulture;
-            Bridge.Test.Assert.areEqual(null, culture.getFormat(System.Int32));
-            Bridge.Test.Assert.areEqual(culture.numberFormat, culture.getFormat(System.Globalization.NumberFormatInfo));
-            Bridge.Test.Assert.areEqual(culture.dateTimeFormat, culture.getFormat(System.Globalization.DateTimeFormatInfo));
+            Bridge.Test.Assert.areEqual(null, Bridge.unbox(culture.getFormat(System.Int32)));
+            Bridge.Test.Assert.areEqual(culture.numberFormat, Bridge.unbox(culture.getFormat(System.Globalization.NumberFormatInfo)));
+            Bridge.Test.Assert.areEqual(culture.dateTimeFormat, Bridge.unbox(culture.getFormat(System.Globalization.DateTimeFormatInfo)));
         },
         invariantWorks: function () {
             var culture = System.Globalization.CultureInfo.invariantCulture;
@@ -4961,8 +4961,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         getFormatWorks: function () {
             var format = System.Globalization.DateTimeFormatInfo.invariantInfo;
-            Bridge.Test.Assert.areEqual(null, format.getFormat(System.Int32));
-            Bridge.Test.Assert.areEqual(format, format.getFormat(System.Globalization.DateTimeFormatInfo));
+            Bridge.Test.Assert.areEqual(null, Bridge.unbox(format.getFormat(System.Int32)));
+            Bridge.Test.Assert.areEqual(format, Bridge.unbox(format.getFormat(System.Globalization.DateTimeFormatInfo)));
         },
         invariantWorks_SPI_1562: function () {
             var format = System.Globalization.DateTimeFormatInfo.invariantInfo;
@@ -5831,11 +5831,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual("The message", ex.getMessage());
         },
         constructorWithParamNameAndActualValueAndMessageWorks: function () {
-            var ex = new System.ArgumentOutOfRangeException("someParam", "The message", null, 42);
+            var ex = new System.ArgumentOutOfRangeException("someParam", "The message", null, Bridge.box(42, System.Int32));
             Bridge.Test.Assert.true$1(Bridge.is(ex, System.ArgumentOutOfRangeException), "is ArgumentOutOfRangeException");
             Bridge.Test.Assert.areEqual$1("someParam", ex.getParamName(), "ParamName");
             Bridge.Test.Assert.true$1(ex.getInnerException() == null, "InnerException");
-            Bridge.Test.Assert.areEqual$1(42, ex.getActualValue(), "ActualValue");
+            Bridge.Test.Assert.areEqual$1(42, Bridge.unbox(ex.getActualValue()), "ActualValue");
             Bridge.Test.Assert.areEqual("The message", ex.getMessage());
         },
         rangeErrorIsConvertedToArgumentOutOfRangeException: function () {
@@ -6426,7 +6426,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(0, interfaces.length, "Interfaces length");
         },
         argumentsOnlyConstructorWorks: function () {
-            var args = ["a", 1];
+            var args = ["a", Bridge.box(1, System.Int32)];
             var ex = new Bridge.PromiseException(args);
             Bridge.Test.Assert.true$1(Bridge.is(ex, Bridge.PromiseException), "is PromiseException");
             Bridge.Test.Assert.areEqual$1(args, ex.arguments, "Arguments");
@@ -6435,7 +6435,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1("Promise exception: [a, 1]", ex.getMessage(), "Message");
         },
         argumentsAndMessageConstructorWorks: function () {
-            var args = ["a", 1];
+            var args = ["a", Bridge.box(1, System.Int32)];
             var ex = new Bridge.PromiseException(args, "Some message");
             Bridge.Test.Assert.true$1(Bridge.is(ex, Bridge.PromiseException), "is PromiseException");
             Bridge.Test.Assert.true$1(ex.getInnerException() == null, "InnerException");
@@ -6444,7 +6444,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         argumentsAndMessageAndInnerExceptionConstructorWorks: function () {
             var inner = new System.Exception("a");
-            var args = ["a", 1];
+            var args = ["a", Bridge.box(1, System.Int32)];
             var ex = new Bridge.PromiseException(args, "Some message", inner);
             Bridge.Test.Assert.true$1(Bridge.is(ex, Bridge.PromiseException), "is PromiseException");
             Bridge.Test.Assert.true$1(Bridge.referenceEquals(ex.getInnerException(), inner), "InnerException");
@@ -6626,26 +6626,26 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         getArgumentWorks: function () {
             var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
-            Bridge.Test.Assert.areEqual$1("x", s.getArgument(0), "0");
-            Bridge.Test.Assert.areEqual$1("y", s.getArgument(1), "1");
+            Bridge.Test.Assert.areEqual$1("x", Bridge.unbox(s.getArgument(0)), "0");
+            Bridge.Test.Assert.areEqual$1("y", Bridge.unbox(s.getArgument(1)), "1");
         },
         getArgumentsWorks: function () {
             var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
             var args = s.getArguments();
-            Bridge.Test.Assert.areEqual$1("x", args[0], "0");
-            Bridge.Test.Assert.areEqual$1("y", args[1], "1");
+            Bridge.Test.Assert.areEqual$1("x", Bridge.unbox(args[0]), "0");
+            Bridge.Test.Assert.areEqual$1("y", Bridge.unbox(args[1]), "1");
         },
         arrayReturnedByGetArgumentsCanBeModified: function () {
             var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1}", ["x", "y"]);
             var args = s.getArguments();
-            Bridge.Test.Assert.areEqual$1("x", args[0], "#1");
+            Bridge.Test.Assert.areEqual$1("x", Bridge.unbox(args[0]), "#1");
             args[0] = "z";
             var args2 = s.getArguments();
-            Bridge.Test.Assert.areEqual$1("z", args2[0], "#2");
+            Bridge.Test.Assert.areEqual$1("z", Bridge.unbox(args2[0]), "#2");
             Bridge.Test.Assert.areEqual$1("x = z, y = y", s.toString(), "#3");
         },
         toStringWorks: function () {
-            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", 291]);
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", Bridge.box(291, System.Int32)]);
             Bridge.Test.Assert.areEqual("x = x, y = 123", s.toString());
         },
         toStringWithFormatProviderWorks_SPI_1651: function () {
@@ -6660,7 +6660,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual("x = Formatted: MyFormatProvider, y = Formatted: FMT, MyFormatProvider", Bridge.format(s, null, new Bridge.ClientTest.Batch4.FormattableStringTests.MyFormatProvider()));
         },
         invariantWorks: function () {
-            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", 291]);
+            var s = System.Runtime.CompilerServices.FormattableStringFactory.create("x = {0}, y = {1:x}", ["x", Bridge.box(291, System.Int32)]);
             Bridge.Test.Assert.areEqual("x = x, y = 123", System.FormattableString.invariant(s));
         }
     });
@@ -6695,7 +6695,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.Guid));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.Guid), System.Guid));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.Guid), System.Guid));
-            var o = new System.Guid.ctor();
+            var o = Bridge.box(new System.Guid.ctor(), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(o, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(o, System.IComparable$1(System.Guid)));
             Bridge.Test.Assert.true(Bridge.is(o, System.IEquatable$1(System.Guid)));
@@ -6705,7 +6705,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true(System.Array.contains(interfaces, System.IComparable$1(System.Guid), Function));
             Bridge.Test.Assert.true(System.Array.contains(interfaces, System.IEquatable$1(System.Guid), Function));
 
-            Bridge.Test.Assert.false(Bridge.is(1, System.Guid));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(1, System.Int32), System.Guid));
             Bridge.Test.Assert.false(Bridge.is("abcd", System.Guid));
             Bridge.Test.Assert.false(Bridge.is("{00000000-0000-0000-0000-000000000000}", System.Guid));
         },
@@ -6715,12 +6715,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual("00000000-0000-0000-0000-000000000000", result.toString());
         },
         createInstanceWorks: function () {
-            var result = Bridge.createInstance(System.Guid);
+            var result = Bridge.box(Bridge.createInstance(System.Guid), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(result, System.Guid));
             Bridge.Test.Assert.areEqual("00000000-0000-0000-0000-000000000000", result.toString());
         },
         defaultConstructorWorks: function () {
-            var result = new System.Guid.ctor();
+            var result = Bridge.box(new System.Guid.ctor(), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(result, System.Guid));
             Bridge.Test.Assert.areEqual("00000000-0000-0000-0000-000000000000", result.toString());
         },
@@ -6733,30 +6733,30 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         byteArrayConstructorWorks: function () {
             var g = new System.Guid.$ctor1([120, 149, 98, 168, 38, 122, 69, 97, 144, 50, 217, 26, 61, 84, 189, 104]);
-            Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Should be Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Should be Guid");
             Bridge.Test.Assert.areEqual$1("a8629578-7a26-6145-9032-d91a3d54bd68", g.toString(), "value");
             Bridge.Test.Assert.throws$4($_.Bridge.ClientTest.Batch4.GuidTests.f1, System.ArgumentException, "Invalid array should throw");
         },
         int32Int16Int16ByteArrayConstructorWorks: function () {
             var g = new System.Guid.$ctor3(2023056040, 9850, 17761, [144, 50, 217, 26, 61, 84, 189, 104]);
-            Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Should be Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Should be Guid");
             Bridge.Test.Assert.areEqual$1("789562a8-267a-4561-9032-d91a3d54bd68", g.toString(), "value");
         },
         int32Int16Int16BytesConstructorWorks: function () {
             var g = new System.Guid.$ctor2(2023056040, 9850, 17761, 144, 50, 217, 26, 61, 84, 189, 104);
-            Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Should be Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Should be Guid");
             Bridge.Test.Assert.areEqual$1("789562a8-267a-4561-9032-d91a3d54bd68", g.toString(), "value");
         },
         uInt32UInt16UInt16BytesConstructorWorks: function () {
             var g = new System.Guid.$ctor5(2023056040, 9850, 17761, 144, 50, 217, 26, 61, 84, 189, 104);
-            Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Should be Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Should be Guid");
             Bridge.Test.Assert.areEqual$1("789562a8-267a-4561-9032-d91a3d54bd68", g.toString(), "value");
         },
         stringConstructorWorks: function () {
-            var g1 = new System.Guid.$ctor4("A6993C0A-A8CB-45D9-994B-90E7203E4FC6");
-            var g2 = new System.Guid.$ctor4("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}");
-            var g3 = new System.Guid.$ctor4("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)");
-            var g4 = new System.Guid.$ctor4("A6993C0AA8CB45D9994B90E7203E4FC6");
+            var g1 = Bridge.box(new System.Guid.$ctor4("A6993C0A-A8CB-45D9-994B-90E7203E4FC6"), System.Guid);
+            var g2 = Bridge.box(new System.Guid.$ctor4("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}"), System.Guid);
+            var g3 = Bridge.box(new System.Guid.$ctor4("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)"), System.Guid);
+            var g4 = Bridge.box(new System.Guid.$ctor4("A6993C0AA8CB45D9994B90E7203E4FC6"), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(g1, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g2, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g3, System.Guid));
@@ -6768,10 +6768,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.throws$4($_.Bridge.ClientTest.Batch4.GuidTests.f2, System.FormatException, "Invalid should throw");
         },
         parseWorks: function () {
-            var g1 = System.Guid.parse("A6993C0A-A8CB-45D9-994B-90E7203E4FC6");
-            var g2 = System.Guid.parse("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}");
-            var g3 = System.Guid.parse("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)");
-            var g4 = System.Guid.parse("A6993C0AA8CB45D9994B90E7203E4FC6");
+            var g1 = Bridge.box(System.Guid.parse("A6993C0A-A8CB-45D9-994B-90E7203E4FC6"), System.Guid);
+            var g2 = Bridge.box(System.Guid.parse("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}"), System.Guid);
+            var g3 = Bridge.box(System.Guid.parse("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)"), System.Guid);
+            var g4 = Bridge.box(System.Guid.parse("A6993C0AA8CB45D9994B90E7203E4FC6"), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(g1, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g2, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g3, System.Guid));
@@ -6783,10 +6783,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.throws$4($_.Bridge.ClientTest.Batch4.GuidTests.f3, System.FormatException, "Invalid should throw");
         },
         parseExactWorks: function () {
-            var g1 = System.Guid.parseExact("A6993C0A-A8CB-45D9-994B-90E7203E4FC6", "D");
-            var g2 = System.Guid.parseExact("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}", "B");
-            var g3 = System.Guid.parseExact("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)", "P");
-            var g4 = System.Guid.parseExact("A6993C0AA8CB45D9994B90E7203E4FC6", "N");
+            var g1 = Bridge.box(System.Guid.parseExact("A6993C0A-A8CB-45D9-994B-90E7203E4FC6", "D"), System.Guid);
+            var g2 = Bridge.box(System.Guid.parseExact("{A6993C0A-A8CB-45D9-994B-90E7203E4FC6}", "B"), System.Guid);
+            var g3 = Bridge.box(System.Guid.parseExact("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)", "P"), System.Guid);
+            var g4 = Bridge.box(System.Guid.parseExact("A6993C0AA8CB45D9994B90E7203E4FC6", "N"), System.Guid);
             Bridge.Test.Assert.true(Bridge.is(g1, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g2, System.Guid));
             Bridge.Test.Assert.true(Bridge.is(g3, System.Guid));
@@ -6807,11 +6807,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true$1(System.Guid.tryParse("(A6993C0A-A8CB-45D9-994B-90E7203E4FC6)", g3), "g3 result");
             Bridge.Test.Assert.true$1(System.Guid.tryParse("A6993C0AA8CB45D9994B90E7203E4FC6", g4), "g4 result");
             Bridge.Test.Assert.false$1(System.Guid.tryParse("x", g5), "Invalid should throw");
-            Bridge.Test.Assert.true$1(Bridge.is(g1.v, System.Guid), "g1 is Guid");
-            Bridge.Test.Assert.true$1(Bridge.is(g2.v, System.Guid), "g2 is Guid");
-            Bridge.Test.Assert.true$1(Bridge.is(g3.v, System.Guid), "g3 is Guid");
-            Bridge.Test.Assert.true$1(Bridge.is(g4.v, System.Guid), "g4 is Guid");
-            Bridge.Test.Assert.true$1(Bridge.is(g5.v, System.Guid), "g5 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g1.v, System.Guid), System.Guid), "g1 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g2.v, System.Guid), System.Guid), "g2 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g3.v, System.Guid), System.Guid), "g3 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g4.v, System.Guid), System.Guid), "g4 is Guid");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g5.v, System.Guid), System.Guid), "g5 is Guid");
             Bridge.Test.Assert.areEqual$1("a6993c0a-a8cb-45d9-994b-90e7203e4fc6", g1.v.toString(), "g1");
             Bridge.Test.Assert.areEqual$1("a6993c0a-a8cb-45d9-994b-90e7203e4fc6", g2.v.toString(), "g2");
             Bridge.Test.Assert.areEqual$1("a6993c0a-a8cb-45d9-994b-90e7203e4fc6", g3.v.toString(), "g3");
@@ -6828,14 +6828,14 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.false$1(System.Guid.tryParseExact("A6993C0A-A8CB-45D9-994B-90E7203E4FC6", "P", g6), "g6 result");
             Bridge.Test.Assert.false$1(System.Guid.tryParseExact("A6993C0A-A8CB-45D9-994B-90E7203E4FC6", "N", g7), "g7 result");
             Bridge.Test.Assert.false$1(System.Guid.tryParseExact("A6993C0AA8CB45D9994B90E7203E4FC6", "D", g8), "g8 result");
-            Bridge.Test.Assert.true(Bridge.is(g1.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g2.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g3.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g4.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g5.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g6.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g7.v, System.Guid));
-            Bridge.Test.Assert.true(Bridge.is(g8.v, System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g1.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g2.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g3.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g4.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g5.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g6.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g7.v, System.Guid), System.Guid));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(g8.v, System.Guid), System.Guid));
             Bridge.Test.Assert.areEqual$1("a6993c0a-a8cb-45d9-994b-90e7203e4fc6", g1.v.toString(), "g1");
             Bridge.Test.Assert.areEqual$1("a6993c0a-a8cb-45d9-994b-90e7203e4fc6", g2.v.toString(), "g2");
             Bridge.Test.Assert.areEqual$1("a6993c0a-a8cb-45d9-994b-90e7203e4fc6", g3.v.toString(), "g3");
@@ -6851,14 +6851,14 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual$1(0, g.compareTo(new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0")), "not equal");
         },
         iComparableCompareToWorks: function () {
-            var g = Bridge.cast(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.IComparable$1(System.Guid));
+            var g = Bridge.cast(Bridge.box(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.Guid), System.IComparable$1(System.Guid));
             Bridge.Test.Assert.areEqual$1(0, Bridge.compare(g, new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), false, System.Guid), "Equal");
             Bridge.Test.Assert.areNotEqual$1(0, Bridge.compare(g, new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0"), false, System.Guid), "Not equal");
         },
         equalsObjectWorks: function () {
             var g = new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C");
-            Bridge.Test.Assert.true$1(Bridge.equals(g, new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C")), "Equal");
-            Bridge.Test.Assert.false$1(Bridge.equals(g, new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0")), "Not equal");
+            Bridge.Test.Assert.true$1(Bridge.equals(g, Bridge.unbox(Bridge.box(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.Guid))), "Equal");
+            Bridge.Test.Assert.false$1(Bridge.equals(g, Bridge.unbox(Bridge.box(new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0"), System.Guid))), "Not equal");
             Bridge.Test.Assert.false$1(Bridge.equals(g, "X"), "Not equal");
         },
         equalsGuidWorks: function () {
@@ -6867,7 +6867,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.false$1(g.equalsT(new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0")), "Not equal");
         },
         iEquatableEqualsWorks: function () {
-            var g = Bridge.cast(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.IEquatable$1(System.Guid));
+            var g = Bridge.cast(Bridge.box(new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.Guid), System.IEquatable$1(System.Guid));
             Bridge.Test.Assert.true$1(Bridge.equalsT(g, new System.Guid.$ctor4("F3D8B3C0-88F0-4148-844C-232ED03C153C"), System.Guid), "Equal");
             Bridge.Test.Assert.false$1(Bridge.equalsT(g, new System.Guid.$ctor4("E4C221BE-9B39-4398-B82A-48BA4648CAE0"), System.Guid), "Not equal");
         },
@@ -6896,7 +6896,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var d = new (System.Collections.Generic.Dictionary$2(String,Object))();
             for (var i = 0; i < 1000; i = (i + 1) | 0) {
                 var g = System.Guid.newGuid();
-                Bridge.Test.Assert.true$1(Bridge.is(g, System.Guid), "Generated Guid should be Guid");
+                Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(g, System.Guid), System.Guid), "Generated Guid should be Guid");
                 var s = g.toString$1("N");
                 Bridge.Test.Assert.true$1(s.charCodeAt(16) === 56 || s.charCodeAt(16) === 57 || s.charCodeAt(16) === 97 || s.charCodeAt(16) === 98, "Should be standard guid");
                 Bridge.Test.Assert.true$1(s.charCodeAt(12) === 52, "Should be type 4 guid");
@@ -7072,7 +7072,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(System.Int32, f.rt);
             Bridge.Test.Assert.areEqual(9, f.body.ntype);
             Bridge.Test.Assert.areEqual(System.Int32, f.body.t);
-            Bridge.Test.Assert.areEqual(42, ($t1 = f.body, Bridge.cast($t1, Bridge.hasValue($t1) && ($t1.ntype === 9))).value);
+            Bridge.Test.Assert.areEqual(42, Bridge.unbox(($t1 = f.body, Bridge.cast($t1, Bridge.hasValue($t1) && ($t1.ntype === 9))).value));
         },
         lambdaWorks: function () {
             var $t, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9;
@@ -7134,9 +7134,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(System.Int32, c1.t, "c1.Type");
             Bridge.Test.Assert.areEqual$1(String, c2.t, "c2.Type");
             Bridge.Test.Assert.areEqual$1(System.Int32, c3.t, "c3.Type");
-            Bridge.Test.Assert.areEqual$1(42, c1.value, "c1.Value");
-            Bridge.Test.Assert.areEqual$1("Hello, world", c2.value, "c2.Value");
-            Bridge.Test.Assert.areEqual$1(17, c3.value, "c3.Value");
+            Bridge.Test.Assert.areEqual$1(42, Bridge.unbox(c1.value), "c1.Value");
+            Bridge.Test.Assert.areEqual$1("Hello, world", Bridge.unbox(c2.value), "c2.Value");
+            Bridge.Test.Assert.areEqual$1(17, Bridge.unbox(c3.value), "c3.Value");
 
             Bridge.Test.Assert.false$1(($t = { ntype: 38, t: System.Int32 }, Bridge.is($t, Bridge.hasValue($t) && ($t.ntype === 9))), "Parameter is ConstantExpression");
         },
@@ -7589,7 +7589,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 Bridge.Test.Assert.areEqual$1("Get", me.method.n, System.String.concat(title, " method name"));
                 Bridge.Test.Assert.areEqual$1(Array, me.method.td, System.String.concat(title, " method declaring type"));
                 Bridge.Test.Assert.areEqual$1([System.Int32, System.Int32], (me.method.p || []), System.String.concat(title, " method parameter types"));
-                Bridge.Test.Assert.areEqual$1(2.5, Bridge.Reflection.midel(me.method, arr)(1, 2), System.String.concat(title, " method invoke result"));
+                Bridge.Test.Assert.areEqual$1(2.5, Bridge.unbox(Bridge.Reflection.midel(me.method, arr)(1, 2)), System.String.concat(title, " method invoke result"));
             };
 
             asserter(e1.body, "e1");
@@ -7643,7 +7643,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
             Bridge.Test.Assert.true$1(Bridge.referenceEquals(($t21 = e9.body, Bridge.cast($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))).method, Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C, 8, 284, "M1")), "e9 member");
             Bridge.Test.Assert.areEqual$1("M3", ($t21 = e10.body, Bridge.cast($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))).method.n, "e10 member name");
-            Bridge.Test.Assert.areEqual$1(73, Bridge.Reflection.midel(($t21 = e10.body, Bridge.cast($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))).method, new Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C.ctor())(39), "e10 member result");
+            Bridge.Test.Assert.areEqual$1(73, Bridge.unbox(Bridge.Reflection.midel(($t21 = e10.body, Bridge.cast($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))).method, new Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C.ctor())(39)), "e10 member result");
 
             Bridge.Test.Assert.false$1(($t21 = { ntype: 9, t: Object, value: null }, Bridge.is($t21, Bridge.hasValue($t21) && ($t21.ntype === 6))), "Constant should not be MethodCallExpression");
         },
@@ -7851,10 +7851,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var propB = ne.m.get(1);
             Bridge.Test.Assert.true$1(Bridge.is(propA, System.Reflection.PropertyInfo), "A should be property");
             Bridge.Test.Assert.areEqual$1("A", propA.n, "A name");
-            Bridge.Test.Assert.areEqual$1(42, Bridge.Reflection.midel(Bridge.cast(propA, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$1(42, 17))(null), "A getter result");
+            Bridge.Test.Assert.areEqual$1(42, Bridge.unbox(Bridge.Reflection.midel(Bridge.cast(propA, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$1(42, 17))(null)), "A getter result");
             Bridge.Test.Assert.true$1(Bridge.is(propB, System.Reflection.PropertyInfo), "B should be property");
             Bridge.Test.Assert.areEqual$1("B", propB.n, "B name");
-            Bridge.Test.Assert.areEqual$1(17, Bridge.Reflection.midel(Bridge.cast(propB, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$1(42, 17))(null), "B getter result");
+            Bridge.Test.Assert.areEqual$1(17, Bridge.unbox(Bridge.Reflection.midel(Bridge.cast(propB, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$1(42, 17))(null)), "B getter result");
 
             var instance = Bridge.Reflection.invokeCI(ne.constructor, [42, 17]);
             Bridge.Test.Assert.areEqual$1(42, instance.a, "Constructor invocation result A");
@@ -7882,10 +7882,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var propB = ne.m.get(1);
             Bridge.Test.Assert.true$1(Bridge.is(propA, System.Reflection.PropertyInfo), "A should be property");
             Bridge.Test.Assert.areEqual$1("a", propA.n, "a name");
-            Bridge.Test.Assert.areEqual$1(42, Bridge.Reflection.midel(Bridge.cast(propA, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$2(42, 17))(null), "a getter result");
+            Bridge.Test.Assert.areEqual$1(42, Bridge.unbox(Bridge.Reflection.midel(Bridge.cast(propA, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$2(42, 17))(null)), "a getter result");
             Bridge.Test.Assert.true$1(Bridge.is(propB, System.Reflection.PropertyInfo), "B should be property");
             Bridge.Test.Assert.areEqual$1("b", propB.n, "b name");
-            Bridge.Test.Assert.areEqual$1(17, Bridge.Reflection.midel(Bridge.cast(propB, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$2(42, 17))(null), "b getter result");
+            Bridge.Test.Assert.areEqual$1(17, Bridge.unbox(Bridge.Reflection.midel(Bridge.cast(propB, System.Reflection.PropertyInfo).g, new $_.$AnonymousType$2(42, 17))(null)), "b getter result");
 
             var instance = Bridge.Reflection.invokeCI(ne.constructor, [42, 17]);
             Bridge.Test.Assert.areEqual$1(42, instance.a, "Constructor invocation result a");
@@ -8247,8 +8247,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(Object, prop.s.rt, "setter return type");
             Bridge.Test.Assert.areEqual$1(0, (prop.s.tpc || 0), "setter type parameter count");
 
-            Bridge.Test.Assert.areEqual$1(42, Bridge.Reflection.midel(prop.g, expr.value)(), "property get");
-            Bridge.Reflection.midel(prop.s, expr.value)(120);
+            Bridge.Test.Assert.areEqual$1(42, Bridge.unbox(Bridge.Reflection.midel(prop.g, Bridge.unbox(expr.value))()), "property get");
+            Bridge.Reflection.midel(prop.s, Bridge.unbox(expr.value))(120);
             Bridge.Test.Assert.areEqual$1(120, a, "property set");
         },
         throwAndRethrowWork: function () {
@@ -8736,9 +8736,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(returnType, expr.rt, System.String.concat(title, " return type"));
             Bridge.Test.Assert.areEqual$1(parmTypes.length, expr.p.getCount(), System.String.concat(title, " param count"));
             for (var i = 0; i < expr.p.getCount(); i = (i + 1) | 0) {
-                Bridge.Test.Assert.areEqual$1(38, expr.p.get(i).ntype, System.String.concat(title, " parameter ", i, " node type"));
-                Bridge.Test.Assert.areEqual$1(parmNames[i], expr.p.get(i).n, System.String.concat(title, " parameter ", i, " name"));
-                Bridge.Test.Assert.areEqual$1(parmTypes[i], expr.p.get(i).t, System.String.concat(title, " parameter ", i, " type"));
+                Bridge.Test.Assert.areEqual$1(38, expr.p.get(i).ntype, System.String.concat(title, " parameter ", Bridge.box(i, System.Int32), " node type"));
+                Bridge.Test.Assert.areEqual$1(parmNames[i], expr.p.get(i).n, System.String.concat(title, " parameter ", Bridge.box(i, System.Int32), " name"));
+                Bridge.Test.Assert.areEqual$1(parmTypes[i], expr.p.get(i).t, System.String.concat(title, " parameter ", Bridge.box(i, System.Int32), " type"));
             }
         },
         f2: function (expr, nodeType, type, method, title) {
@@ -8809,12 +8809,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(System.Int32, me.t, System.String.concat(title, " type"));
             Bridge.Test.Assert.true$1(($t22 = me.expression, Bridge.is($t22, Bridge.hasValue($t22) && ($t22.ntype === 38))) && Bridge.referenceEquals(($t22 = me.expression, Bridge.cast($t22, Bridge.hasValue($t22) && ($t22.ntype === 38))).n, "a"), System.String.concat(title, " expression"));
             if (Bridge.referenceEquals(memberName, "F1") || Bridge.referenceEquals(memberName, "P1")) {
-                Bridge.Test.Assert.true$1(Bridge.referenceEquals(me.member, System.String.startsWith(memberName, "F") ? Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C, 4, 284, memberName) : Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C, 16, 284, memberName)), System.String.concat(title, " member"));
+                Bridge.Test.Assert.true$1(Bridge.referenceEquals(me.member, Bridge.unbox(System.String.startsWith(memberName, "F") ? Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C, 4, 284, memberName) : Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C, 16, 284, memberName))), System.String.concat(title, " member"));
             } else {
                 Bridge.Test.Assert.areEqual$1(System.String.startsWith(memberName, "F") ? 4 : 16, me.member.t, System.String.concat(title, " member type"));
                 Bridge.Test.Assert.areEqual$1(memberName, me.member.n, System.String.concat(title, " name"));
             }
-            Bridge.Test.Assert.areEqual$1(result, Bridge.is(me.member, System.Reflection.FieldInfo) ? Bridge.Reflection.fieldAccess(Bridge.cast(me.member, System.Reflection.FieldInfo), new Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C.ctor()) : Bridge.Reflection.midel(Bridge.cast(me.member, System.Reflection.PropertyInfo).g, new Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C.ctor())(null), System.String.concat(title, " member result"));
+            Bridge.Test.Assert.areEqual$1(result, Bridge.unbox(Bridge.is(me.member, System.Reflection.FieldInfo) ? Bridge.Reflection.fieldAccess(Bridge.cast(me.member, System.Reflection.FieldInfo), new Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C.ctor()) : Bridge.Reflection.midel(Bridge.cast(me.member, System.Reflection.PropertyInfo).g, new Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C.ctor())(null)), System.String.concat(title, " member result"));
         },
         f7: function (expr, member, type, title) {
             var $t;
@@ -8836,11 +8836,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C, ne.t, System.String.concat(title, " type"));
             Bridge.Test.Assert.areEqual$1(argTypes.length, ne.arguments.getCount(), System.String.concat(title, " argument count"));
             for (var i = 0; i < ne.arguments.getCount(); i = (i + 1) | 0) {
-                Bridge.Test.Assert.true$1(($t = ne.arguments.get(i), Bridge.is($t, Bridge.hasValue($t) && ($t.ntype === 38))) && Bridge.referenceEquals(($t = ne.arguments.get(i), Bridge.cast($t, Bridge.hasValue($t) && ($t.ntype === 38))).n, String.fromCharCode((((((97 + i) | 0))) & 65535))), System.String.concat(title, " argument ", i));
+                Bridge.Test.Assert.true$1(($t = ne.arguments.get(i), Bridge.is($t, Bridge.hasValue($t) && ($t.ntype === 38))) && Bridge.referenceEquals(($t = ne.arguments.get(i), Bridge.cast($t, Bridge.hasValue($t) && ($t.ntype === 38))).n, String.fromCharCode((((((97 + i) | 0))) & 65535))), System.String.concat(title, " argument ", Bridge.box(i, System.Int32)));
             }
             Bridge.Test.Assert.areEqual$1(argTypes.length, (ne.constructor.p || []).length, System.String.concat(title, " constructor argument length"));
             for (var i1 = 0; i1 < (ne.constructor.p || []).length; i1 = (i1 + 1) | 0) {
-                Bridge.Test.Assert.areEqual$1(argTypes[i1], (ne.constructor.p || [])[i1], System.String.concat(title, " constructor parameter type ", i1));
+                Bridge.Test.Assert.areEqual$1(argTypes[i1], (ne.constructor.p || [])[i1], System.String.concat(title, " constructor parameter type ", Bridge.box(i1, System.Int32)));
             }
             if (checkReference) {
                 var $ctor = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests.C, 1, 284, null, argTypes);
@@ -8894,7 +8894,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true$1(Bridge.referenceEquals(se.defaultBody, defaultBody), System.String.concat(title, " default value"));
             Bridge.Test.Assert.areEqual$1(cases.length, se.cases.getCount(), System.String.concat(title, " cases count"));
             for (var i = 0; i < se.cases.getCount(); i = (i + 1) | 0) {
-                Bridge.Test.Assert.true$1(Bridge.referenceEquals(se.cases.get(i), cases[i]), System.String.concat(title, " case ", i));
+                Bridge.Test.Assert.true$1(Bridge.referenceEquals(se.cases.get(i), cases[i]), System.String.concat(title, " case ", Bridge.box(i, System.Int32)));
             }
         }
     });
@@ -9009,7 +9009,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             this.$initialize();
         },
         getItem: function (a, b) {
-            return System.String.concat(this.F1 + " " + a + " ", b);
+            return System.String.concat(Bridge.box(this.F1, System.Int32) + " " + Bridge.box(a, System.Int32) + " ", b);
         },
         M1: function (a, b) {
             return 0;
@@ -9131,9 +9131,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(17.5, Math.abs(-17.5));
         },
         absOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(10.5).abs(), 10.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal(-10.5).abs(), 10.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal(0.0).abs(), 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(10.5).abs(), System.Decimal, $box_.System.Decimal.toString), 10.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-10.5).abs(), System.Decimal, $box_.System.Decimal.toString), 10.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(0.0).abs(), System.Decimal, $box_.System.Decimal.toString), 0);
         },
         acosWorks: function () {
             this.assertAlmostEqual(Math.acos(0.5), 1.0471975511965979);
@@ -9152,9 +9152,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(-3.0, Math.ceil(-3.2));
         },
         ceilingOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.1).ceil(), 4);
-            this.assertIsDecimalAndEqualTo(System.Decimal(-3.9).ceil(), -3);
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).ceil(), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.1).ceil(), System.Decimal, $box_.System.Decimal.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-3.9).ceil(), System.Decimal, $box_.System.Decimal.toString), -3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).ceil(), System.Decimal, $box_.System.Decimal.toString), 3);
         },
         cosWorks: function () {
             this.assertAlmostEqual(Math.cos(0.5), 0.87758256189037276);
@@ -9176,9 +9176,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(-4.0, Math.floor(-3.6));
         },
         floorOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.9).floor(), 3);
-            this.assertIsDecimalAndEqualTo(System.Decimal(-3.1).floor(), -4);
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).floor(), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.9).floor(), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-3.1).floor(), System.Decimal, $box_.System.Decimal.toString), -4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).floor(), System.Decimal, $box_.System.Decimal.toString), 3);
         },
         logWorks: function () {
             this.assertAlmostEqual(Math.log(0.5), -0.69314718055994529);
@@ -9203,8 +9203,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(5.0, Math.max(5, 3));
         },
         maxOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.max(System.Decimal(-14.5), System.Decimal(3.0)), 3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.max(System.Decimal(5.4), System.Decimal(3.0)), 5.4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.max(System.Decimal(-14.5), System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), 3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.max(System.Decimal(5.4), System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), 5.4);
         },
         maxOfDoubleWorks: function () {
             Bridge.Test.Assert.areEqual(3.0, Math.max(1.0, 3.0));
@@ -9247,8 +9247,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(3.0, Math.min(5, 3));
         },
         minOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.min(System.Decimal(-14.5), System.Decimal(3.0)), -14.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal.min(System.Decimal(5.4), System.Decimal(3.0)), 3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.min(System.Decimal(-14.5), System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), -14.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.min(System.Decimal(5.4), System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), 3.0);
         },
         minOfDoubleWorks: function () {
             Bridge.Test.Assert.areEqual(1.0, Math.min(1.0, 3.0));
@@ -9305,12 +9305,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(-4.0, Bridge.Math.round(-4.5, 0, 6));
         },
         roundOfDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.432), 6), 3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.6), 6), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 6), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(4.5), 6), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-3.5), 6), -4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-4.5), 6), -4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.432), 6), System.Decimal, $box_.System.Decimal.toString), 3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.6), 6), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 6), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(4.5), 6), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-3.5), 6), System.Decimal, $box_.System.Decimal.toString), -4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-4.5), 6), System.Decimal, $box_.System.Decimal.toString), -4.0);
         },
         jsRoundOfDoubleWorks: function () {
             Bridge.Test.Assert.areEqual(3.0, Math.round(3.432));
@@ -9329,12 +9329,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(-3.4, Bridge.Math.round(-3.45, 1, 6));
         },
         roundOfDecimalWithDigitsWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.432), 2, 6), 3.43);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.6), 0, 6), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.35), 1, 6), 3.4);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.45), 1, 6), 3.4);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-3.35), 1, 6), -3.4);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-3.45), 1, 6), -3.4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.432), 2, 6), System.Decimal, $box_.System.Decimal.toString), 3.43);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.6), 0, 6), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.35), 1, 6), System.Decimal, $box_.System.Decimal.toString), 3.4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.45), 1, 6), System.Decimal, $box_.System.Decimal.toString), 3.4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-3.35), 1, 6), System.Decimal, $box_.System.Decimal.toString), -3.4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-3.45), 1, 6), System.Decimal, $box_.System.Decimal.toString), -3.4);
         },
         signWithDecimalWorks: function () {
             Bridge.Test.Assert.areEqual(-1, System.Decimal(-0.5).sign());
@@ -9365,8 +9365,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(-3.0, Bridge.Int.trunc(-3.9));
         },
         truncateWithDecimalWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.9).trunc(), 3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal(-3.9).trunc(), -3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.9).trunc(), System.Decimal, $box_.System.Decimal.toString), 3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-3.9).trunc(), System.Decimal, $box_.System.Decimal.toString), -3.0);
         },
         iEEERemainderWorks: function () {
             Bridge.Test.Assert.areEqual(-1.0, 3.0 - (2.0 * Math.round(3.0 / 2.0)));
@@ -9394,16 +9394,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(-2.0, Bridge.Math.round(-2.5, 0, 6));
         },
         roundOfDecimalWithMidpointRoundingWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.432), 4), 3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.432), 6), 3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 4), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.5), 6), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.64), 4), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.64), 6), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(2.5), 4), 3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(2.5), 6), 2.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-2.5), 4), -3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-2.5), 6), -2.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.432), 4), System.Decimal, $box_.System.Decimal.toString), 3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.432), 6), System.Decimal, $box_.System.Decimal.toString), 3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 4), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.5), 6), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.64), 4), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.64), 6), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(2.5), 4), System.Decimal, $box_.System.Decimal.toString), 3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(2.5), 6), System.Decimal, $box_.System.Decimal.toString), 2.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-2.5), 4), System.Decimal, $box_.System.Decimal.toString), -3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-2.5), 6), System.Decimal, $box_.System.Decimal.toString), -2.0);
         },
         roundOfDoubleWithDigitsAndMidpointRoundingWorks: function () {
             Bridge.Test.Assert.areEqual(3.5, Bridge.Math.round(3.45, 1, 4));
@@ -9418,16 +9418,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(-2.5, Bridge.Math.round(-2.5, 1, 6));
         },
         roundOfDecimalWithDigitsAndMidpointRoundingWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.45), 1, 4), 3.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.45), 1, 6), 3.4);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.5), 0, 4), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.5), 0, 6), 4.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.645), 2, 4), 3.65);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.645), 2, 6), 3.64);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(2.5), 0, 4), 3.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(2.5), 0, 6), 2.0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-2.5), 1, 4), -2.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-2.5), 1, 6), -2.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.45), 1, 4), System.Decimal, $box_.System.Decimal.toString), 3.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.45), 1, 6), System.Decimal, $box_.System.Decimal.toString), 3.4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.5), 0, 4), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.5), 0, 6), System.Decimal, $box_.System.Decimal.toString), 4.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.645), 2, 4), System.Decimal, $box_.System.Decimal.toString), 3.65);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.645), 2, 6), System.Decimal, $box_.System.Decimal.toString), 3.64);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(2.5), 0, 4), System.Decimal, $box_.System.Decimal.toString), 3.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(2.5), 0, 6), System.Decimal, $box_.System.Decimal.toString), 2.0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-2.5), 1, 4), System.Decimal, $box_.System.Decimal.toString), -2.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-2.5), 1, 6), System.Decimal, $box_.System.Decimal.toString), -2.5);
         },
         divRemWorks: function () {
             var result = { };
@@ -9462,16 +9462,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         getValueWorks: function () {
             var arr = System.Array.create(0, [[1, 2], [3, 4], [5, 6]], 3, 2);
-            Bridge.Test.Assert.areEqual(1, System.Array.get(arr, 0, 0));
-            Bridge.Test.Assert.areEqual(2, System.Array.get(arr, 0, 1));
-            Bridge.Test.Assert.areEqual(3, System.Array.get(arr, 1, 0));
-            Bridge.Test.Assert.areEqual(4, System.Array.get(arr, 1, 1));
-            Bridge.Test.Assert.areEqual(5, System.Array.get(arr, 2, 0));
-            Bridge.Test.Assert.areEqual(6, System.Array.get(arr, 2, 1));
+            Bridge.Test.Assert.areEqual(1, Bridge.unbox(System.Array.get(arr, 0, 0)));
+            Bridge.Test.Assert.areEqual(2, Bridge.unbox(System.Array.get(arr, 0, 1)));
+            Bridge.Test.Assert.areEqual(3, Bridge.unbox(System.Array.get(arr, 1, 0)));
+            Bridge.Test.Assert.areEqual(4, Bridge.unbox(System.Array.get(arr, 1, 1)));
+            Bridge.Test.Assert.areEqual(5, Bridge.unbox(System.Array.get(arr, 2, 0)));
+            Bridge.Test.Assert.areEqual(6, Bridge.unbox(System.Array.get(arr, 2, 1)));
         },
         getValueWorksForUninitializedElement: function () {
             var arr = System.Array.create(0, null, 2, 2);
-            Bridge.Test.Assert.areStrictEqual(0, System.Array.get(arr, 0, 0));
+            Bridge.Test.Assert.areStrictEqual(0, Bridge.unbox(System.Array.get(arr, 0, 0)));
         },
         getValueByIndexWorksForUninitializedElement: function () {
             var arr = System.Array.create(0, null, 2, 2);
@@ -9604,13 +9604,13 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             });
             Bridge.Test.Assert.true$1(b1, "GenericArguments");
 
-            Bridge.Test.Assert.true$1(Bridge.is(a, System.Int32), "is int? #1");
-            Bridge.Test.Assert.false$1(Bridge.is(b, System.Int32), "is int? #2");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(a, System.Int32, $box_.System.Nullable$1.toString), System.Int32), "is int? #1");
+            Bridge.Test.Assert.false$1(Bridge.is(Bridge.box(b, System.Int32, $box_.System.Nullable$1.toString), System.Int32), "is int? #2");
 
-            Bridge.Test.Assert.true$1(this.isOfType(System.Nullable$1(System.Int32), 3), "IsOfType #1");
-            Bridge.Test.Assert.false$1(this.isOfType(System.Nullable$1(System.Int32), 3.14), "IsOfType #2");
-            Bridge.Test.Assert.true$1(this.isOfType(System.Nullable$1(System.TimeSpan), new System.TimeSpan(System.Int64(1))), "IsOfType #3");
-            Bridge.Test.Assert.false$1(this.isOfType(System.Nullable$1(System.TimeSpan), 3.14), "IsOfType #4");
+            Bridge.Test.Assert.true$1(this.isOfType(System.Nullable$1(System.Int32), Bridge.box(3, System.Int32)), "IsOfType #1");
+            Bridge.Test.Assert.false$1(this.isOfType(System.Nullable$1(System.Int32), Bridge.box(3.14, System.Double, $box_.System.Double.toString)), "IsOfType #2");
+            Bridge.Test.Assert.true$1(this.isOfType(System.Nullable$1(System.TimeSpan), Bridge.box(new System.TimeSpan(System.Int64(1)), System.TimeSpan)), "IsOfType #3");
+            Bridge.Test.Assert.false$1(this.isOfType(System.Nullable$1(System.TimeSpan), Bridge.box(3.14, System.Double, $box_.System.Double.toString)), "IsOfType #4");
         },
         convertingToNullableWorks: function () {
             var i = 3;
@@ -9626,8 +9626,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         boxingWorks: function () {
             var a = 3, b = null;
-            Bridge.Test.Assert.true(a != null);
-            Bridge.Test.Assert.false(b != null);
+            Bridge.Test.Assert.true(Bridge.box(a, System.Int32, $box_.System.Nullable$1.toString) != null);
+            Bridge.Test.Assert.false(Bridge.box(b, System.Int32, $box_.System.Nullable$1.toString) != null);
         },
         unboxingWorks: function () {
             var a = 3, b = null;
@@ -9906,7 +9906,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
     Bridge.apply($_.Bridge.ClientTest.Batch4.NullableTests, {
         f1: function () {
             var o = "x";
-            var x = System.Nullable.getValue(Bridge.cast(o, System.Int32));
+            var x = System.Nullable.getValue(Bridge.cast(Bridge.unbox(o), System.Int32));
         }
     });
 
@@ -9977,8 +9977,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         getFormatWorks: function () {
             var format = System.Globalization.NumberFormatInfo.invariantInfo;
-            Bridge.Test.Assert.areEqual(null, format.getFormat(System.Int32));
-            Bridge.Test.Assert.areEqual(format, format.getFormat(System.Globalization.NumberFormatInfo));
+            Bridge.Test.Assert.areEqual(null, Bridge.unbox(format.getFormat(System.Int32)));
+            Bridge.Test.Assert.areEqual(format, Bridge.unbox(format.getFormat(System.Globalization.NumberFormatInfo)));
         },
         invariantWorks: function () {
             var format = System.Globalization.NumberFormatInfo.invariantInfo;
@@ -10224,32 +10224,32 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var rand = new System.Random.ctor();
             for (var i = 0; i < 10; i = (i + 1) | 0) {
                 var randomNumber = rand.next();
-                Bridge.Test.Assert.true$1(randomNumber >= 0, randomNumber + " is greater or equal to 0");
-                Bridge.Test.Assert.true$1(randomNumber <= 2147483647, randomNumber + " is less than or equal to int.MaxValue");
+                Bridge.Test.Assert.true$1(randomNumber >= 0, Bridge.box(randomNumber, System.Int32) + " is greater or equal to 0");
+                Bridge.Test.Assert.true$1(randomNumber <= 2147483647, Bridge.box(randomNumber, System.Int32) + " is less than or equal to int.MaxValue");
             }
         },
         nextWithMaxWorks: function () {
             var rand = new System.Random.ctor();
             for (var i = 0; i < 10; i = (i + 1) | 0) {
                 var randomNumber = rand.next$1(5);
-                Bridge.Test.Assert.true$1(randomNumber >= 0, randomNumber + " is greater or equal to 0");
-                Bridge.Test.Assert.true$1(randomNumber < 5, randomNumber + " is smaller than 5");
+                Bridge.Test.Assert.true$1(randomNumber >= 0, Bridge.box(randomNumber, System.Int32) + " is greater or equal to 0");
+                Bridge.Test.Assert.true$1(randomNumber < 5, Bridge.box(randomNumber, System.Int32) + " is smaller than 5");
             }
         },
         nextWithMinAndMaxWorks: function () {
             var rand = new System.Random.ctor();
             for (var i = 0; i < 10; i = (i + 1) | 0) {
                 var randomNumber = rand.next$2(5, 10);
-                Bridge.Test.Assert.true$1(randomNumber >= 5, randomNumber + " is greater or equal to 5");
-                Bridge.Test.Assert.true$1(randomNumber < 10, randomNumber + " is smaller than 10");
+                Bridge.Test.Assert.true$1(randomNumber >= 5, Bridge.box(randomNumber, System.Int32) + " is greater or equal to 5");
+                Bridge.Test.Assert.true$1(randomNumber < 10, Bridge.box(randomNumber, System.Int32) + " is smaller than 10");
             }
         },
         nextDoubleWorks: function () {
             var rand = new System.Random.ctor();
             for (var i = 0; i < 10; i = (i + 1) | 0) {
                 var randomNumber = rand.nextDouble();
-                Bridge.Test.Assert.true$1(randomNumber >= 0.0, System.Double.format(randomNumber, 'G') + " is greater or equal to 0.0");
-                Bridge.Test.Assert.true$1(randomNumber < 1.0, System.Double.format(randomNumber, 'G') + " is smaller than 1.0");
+                Bridge.Test.Assert.true$1(randomNumber >= 0.0, System.Double.format(Bridge.box(randomNumber, System.Double, $box_.System.Double.toString), 'G') + " is greater or equal to 0.0");
+                Bridge.Test.Assert.true$1(randomNumber < 1.0, System.Double.format(Bridge.box(randomNumber, System.Double, $box_.System.Double.toString), 'G') + " is smaller than 1.0");
             }
         },
         nextBytesWorks: function () {
@@ -10257,8 +10257,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var bytes = System.Array.init(150, 0);
             rand.nextBytes(bytes);
             for (var i = 0; i < bytes.length; i = (i + 1) | 0) {
-                Bridge.Test.Assert.true$1(bytes[i] >= 0, "a: " + bytes[i] + " is greater or equal to " + 0);
-                Bridge.Test.Assert.true$1(bytes[i] <= 255, "a: " + bytes[i] + " is smaller than or equal to " + 255);
+                Bridge.Test.Assert.true$1(bytes[i] >= 0, "a: " + Bridge.box(bytes[i], System.Byte) + " is greater or equal to " + Bridge.box(0, System.Byte));
+                Bridge.Test.Assert.true$1(bytes[i] <= 255, "a: " + Bridge.box(bytes[i], System.Byte) + " is smaller than or equal to " + Bridge.box(255, System.Byte));
             }
         }
     });
@@ -10348,7 +10348,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         createInstanceWorks: function () {
             Bridge.Test.Assert.true$1(Bridge.is(Bridge.Reflection.createAssemblyInstance(Bridge.Reflection.getTypeAssembly(Bridge.ClientTest.Batch4.Reflection.AssemblyTests.C), Bridge.Reflection.getTypeFullName(Bridge.ClientTest.Batch4.Reflection.AssemblyTests.C)), Bridge.ClientTest.Batch4.Reflection.AssemblyTests.C), "#1");
-            Bridge.Test.Assert.areEqual$1(0, Bridge.Reflection.createAssemblyInstance(Bridge.Reflection.getTypeAssembly(System.Int32), Bridge.Reflection.getTypeFullName(System.Int32)), "#2");
+            Bridge.Test.Assert.areEqual$1(0, Bridge.unbox(Bridge.Reflection.createAssemblyInstance(Bridge.Reflection.getTypeAssembly(System.Int32), Bridge.Reflection.getTypeFullName(System.Int32))), "#2");
             Bridge.Test.Assert.true$1(Bridge.Reflection.createAssemblyInstance(Bridge.Reflection.getTypeAssembly(Bridge.ClientTest.Batch4.Reflection.AssemblyTests.C), "NonExistentType") == null, "#3");
         },
         getCustomAttributesWorks: function () {
@@ -10588,7 +10588,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(49, a6.getH(), "H");
             Bridge.Test.Assert.areEqual$1(Bridge.ClientTest.Batch4.Reflection.AttributeTests.E1.V1, a6.getE(), "E");
             Bridge.Test.Assert.areEqual$1("Test_string", a6.getS(), "S");
-            Bridge.Test.Assert.areEqual$1(null, a6.getO(), "O");
+            Bridge.Test.Assert.areEqual$1(null, Bridge.unbox(a6.getO()), "O");
             Bridge.Test.Assert.areEqual$1(String, a6.getT(), "T");
         },
         arraysCanBeUsedAsAttributeArguments: function () {
@@ -10864,7 +10864,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             V1: "v1",
             V2: "v2"
         },
-        $utype: System.String
+        $utype: String
     });
 
     Bridge.define("Bridge.ClientTest.Batch4.Reflection.AttributeTests.I1", {
@@ -11600,10 +11600,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 Bridge.Reflection.midel(m);
             }, "Without target without delegate type should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null);
+                Bridge.Reflection.midel(m, Bridge.unbox(null));
             }, "Null target with delegate type should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null);
+                Bridge.Reflection.midel(m, Bridge.unbox(null));
             }, "Null target without delegate type should throw");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, c, [String]);
@@ -11612,7 +11612,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 Bridge.Reflection.midel(m, null, [String]);
             }, "With type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, [String]);
+                Bridge.Reflection.midel(m, Bridge.unbox(null), [String]);
             }, "With type arguments with null target should throw");
         },
         delegateCreateDelegateWorksForNonGenericInstanceMethods: function () {
@@ -11624,8 +11624,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8, 8, 284, "M2");
             var f1 = Bridge.Reflection.midel(m);
             var f2 = Bridge.Reflection.midel(m);
-            var f3 = Bridge.Reflection.midel(m, null);
-            var f4 = Bridge.Reflection.midel(m, null);
+            var f3 = Bridge.Reflection.midel(m, Bridge.unbox(null));
+            var f4 = Bridge.Reflection.midel(m, Bridge.unbox(null));
             Bridge.Test.Assert.areEqual$1("a b", f1("a", "b"), "Delegate created with delegate type without target should be correct");
             Bridge.Test.Assert.areEqual$1("c d", f2("c", "d"), "Delegate created without delegate type without target should be correct");
             Bridge.Test.Assert.areEqual$1("e f", f3("e", "f"), "Delegate created with delegate type with null target should be correct");
@@ -11643,7 +11643,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 Bridge.Reflection.midel(m, null, [String]);
             }, "With type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, [String]);
+                Bridge.Reflection.midel(m, Bridge.unbox(null), [String]);
             }, "With type arguments with null target should throw");
         },
         createDelegateWorksNonGenericStaticMethodOfGenericType: function () {
@@ -11657,7 +11657,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var f = Bridge.Reflection.midel(m, c, [System.Int32, String]);
             Bridge.Test.Assert.areEqual$1("X System.Int32 String a", f("a"), "Result of invoking delegate should be correct");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, [System.Int32, String]);
+                Bridge.Reflection.midel(m, Bridge.unbox(null), [System.Int32, String]);
             }, "Null target with correct type arguments should throw");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, c);
@@ -11674,30 +11674,30 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         createDelegateWorksForGenericStaticMethods: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8, 8, 284, "M4");
-            var f = Bridge.Reflection.midel(m, null, [System.Int32, String]);
+            var f = Bridge.Reflection.midel(m, Bridge.unbox(null), [System.Int32, String]);
             Bridge.Test.Assert.areEqual$1("System.Int32 String a", f("a"), "Result of invoking delegate should be correct");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8(""), [System.Int32, String]);
             }, "Target with correct type arguments should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null);
+                Bridge.Reflection.midel(m, Bridge.unbox(null));
             }, "No type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, System.Array.init(0, null));
+                Bridge.Reflection.midel(m, Bridge.unbox(null), System.Array.init(0, null));
             }, "0 type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, System.Array.init(1, null));
+                Bridge.Reflection.midel(m, Bridge.unbox(null), System.Array.init(1, null));
             }, "1 type arguments without target should throw");
             Bridge.Test.Assert.throws$5(function () {
-                Bridge.Reflection.midel(m, null, System.Array.init(3, null));
+                Bridge.Reflection.midel(m, Bridge.unbox(null), System.Array.init(3, null));
             }, "3 type arguments without target should throw");
         },
         invokeWorksForNonGenericInstanceMethods: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8, 8, 284, "M1");
             var argsArr = ["c", "d"];
             var c = new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8("X");
-            Bridge.Test.Assert.areEqual$1("X a b", Bridge.Reflection.midel(m, c)("a", "b"), "Invoke with target should work");
-            Bridge.Test.Assert.areEqual$1("X c d", Bridge.Reflection.midel(m, c).apply(null, argsArr), "Invoke (non-expanded) with target should work");
+            Bridge.Test.Assert.areEqual$1("X a b", Bridge.unbox(Bridge.Reflection.midel(m, c)("a", "b")), "Invoke with target should work");
+            Bridge.Test.Assert.areEqual$1("X c d", Bridge.unbox(Bridge.Reflection.midel(m, c).apply(null, argsArr)), "Invoke (non-expanded) with target should work");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, null)("a", "b");
             }, "Invoke without target should throw");
@@ -11710,7 +11710,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         invokeWorksForNonGenericStaticMethods: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8, 8, 284, "M2");
-            Bridge.Test.Assert.areEqual$1("a b", Bridge.Reflection.midel(m, null)("a", "b"), "Invoke without target should work");
+            Bridge.Test.Assert.areEqual$1("a b", Bridge.unbox(Bridge.Reflection.midel(m, null)("a", "b")), "Invoke without target should work");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8(""))("a", "b");
             }, "Invoke with target should throw");
@@ -11723,24 +11723,24 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         invokeWorksForNonGenericInstanceMethodsOnSerializableTypes: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C7, 8, 284, "M1");
-            Bridge.Test.Assert.areEqual$1(27, Bridge.Reflection.midel(m, Bridge.merge(new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C7(), {
+            Bridge.Test.Assert.areEqual$1(27, Bridge.unbox(Bridge.Reflection.midel(m, Bridge.merge(new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C7(), {
                     x: 13
-                } ))(14), "Invoke should work");
+                } ))(14)), "Invoke should work");
         },
         invokeWorksForNonGenericInlineCodeMethods: function () {
-            Bridge.Test.Assert.areEqual$1(45, Bridge.Reflection.midel(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C21, 8, 284, "M1"), new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C21(14))(15, 16), "Instance invoke should work");
-            Bridge.Test.Assert.areEqual$1(31, Bridge.Reflection.midel(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C21, 8, 284, "M2"), null)(15, 16), "Static invoke should work");
+            Bridge.Test.Assert.areEqual$1(45, Bridge.unbox(Bridge.Reflection.midel(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C21, 8, 284, "M1"), new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C21(14))(15, 16)), "Instance invoke should work");
+            Bridge.Test.Assert.areEqual$1(31, Bridge.unbox(Bridge.Reflection.midel(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C21, 8, 284, "M2"), null)(15, 16)), "Static invoke should work");
         },
         invokeWorksForGenericInlineCodeMethods: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C21, 8, 284, "M3");
-            Bridge.Test.Assert.areEqual$1("42StringWorld", Bridge.Reflection.midel(m, new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C21(42), [String])("World"), "Invoke should work");
+            Bridge.Test.Assert.areEqual$1("42StringWorld", Bridge.unbox(Bridge.Reflection.midel(m, new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C21(42), [String])("World")), "Invoke should work");
         },
         invokeWorksForGenericInstanceMethod: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8, 8, 284, "M3");
             var argsArr = ["x"];
             var c = new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8("X");
-            Bridge.Test.Assert.areEqual$1("X System.Int32 String a", Bridge.Reflection.midel(m, c, [System.Int32, String])("a"), "Result of invoking delegate should be correct");
-            Bridge.Test.Assert.areEqual$1("X System.Int32 String x", Bridge.Reflection.midel(m, c, [System.Int32, String]).apply(null, argsArr), "Result of invoking delegate should be correct");
+            Bridge.Test.Assert.areEqual$1("X System.Int32 String a", Bridge.unbox(Bridge.Reflection.midel(m, c, [System.Int32, String])("a")), "Result of invoking delegate should be correct");
+            Bridge.Test.Assert.areEqual$1("X System.Int32 String x", Bridge.unbox(Bridge.Reflection.midel(m, c, [System.Int32, String]).apply(null, argsArr)), "Result of invoking delegate should be correct");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, null, [System.Int32, String])("a");
             }, "Null target with correct type arguments should throw");
@@ -11759,7 +11759,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         invokeWorksForGenericStaticMethod: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8, 8, 284, "M4");
-            Bridge.Test.Assert.areEqual$1("System.Int32 String a", Bridge.Reflection.midel(m, null, [System.Int32, String])("a"), "Result of invoking delegate should be correct");
+            Bridge.Test.Assert.areEqual$1("System.Int32 String a", Bridge.unbox(Bridge.Reflection.midel(m, null, [System.Int32, String])("a")), "Result of invoking delegate should be correct");
             Bridge.Test.Assert.throws$5(function () {
                 Bridge.Reflection.midel(m, new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C8(""), [System.Int32, String])("a");
             }, "Target with correct type arguments should throw");
@@ -11778,18 +11778,18 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         invokeWorksForGenericInstanceMethodsOnSerializableTypes: function () {
             var m = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C7, 8, 284, "M3");
-            Bridge.Test.Assert.areEqual$1("13 System.Int32 String Suffix", Bridge.Reflection.midel(m, Bridge.merge(new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C7(), {
+            Bridge.Test.Assert.areEqual$1("13 System.Int32 String Suffix", Bridge.unbox(Bridge.Reflection.midel(m, Bridge.merge(new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C7(), {
                     x: 13
-                } ), [System.Int32, String])("Suffix"), "Invoke should work");
+                } ), [System.Int32, String])("Suffix")), "Invoke should work");
         },
         invokeWorksForExpandParamsMethods: function () {
             var m1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C22, 8, 284, "M2");
-            var r1 = Bridge.cast(Bridge.Reflection.midel(m1, new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C22.ctor(0, null)).apply(null, [2, [17, 31]]), Array);
-            Bridge.Test.Assert.areEqual([2, [17, 31]], r1);
+            var r1 = Bridge.cast(Bridge.Reflection.midel(m1, new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C22.ctor(0, null)).apply(null, [Bridge.box(2, System.Int32), [17, 31]]), Array);
+            Bridge.Test.Assert.areEqual([Bridge.box(2, System.Int32), [17, 31]], r1);
 
             var m2 = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C23, 8, 284, "M2");
-            var r2 = Bridge.cast(Bridge.Reflection.midel(m2, new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C23.ctor(0, null)).apply(null, [2, [17, 32]]), Array);
-            Bridge.Test.Assert.areEqual([2, [17, 32]], r2);
+            var r2 = Bridge.cast(Bridge.Reflection.midel(m2, new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C23.ctor(0, null)).apply(null, [Bridge.box(2, System.Int32), [17, 32]]), Array);
+            Bridge.Test.Assert.areEqual([Bridge.box(2, System.Int32), [17, 32]], r2);
         },
         invokeWorksForAllKindsOfConstructors: function () {
             var c1 = Bridge.cast(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C10, 31, 28).filter($_.Bridge.ClientTest.Batch4.Reflection.ReflectionTests.f2)[0], System.Reflection.ConstructorInfo);
@@ -11812,18 +11812,18 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
             var c20 = Bridge.cast(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C20, 31, 28)[0], System.Reflection.ConstructorInfo);
             var o5 = Bridge.Reflection.invokeCI(c20, [42, "Hello"]);
-            Bridge.Test.Assert.areDeepEqual({ a: 42, b: "Hello" }, o5);
+            Bridge.Test.Assert.areDeepEqual({ a: 42, b: "Hello" }, Bridge.unbox(o5));
         },
         invokeWorksForExpandParamsConstructors: function () {
             var c1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C22, 1, 284, null, [String, Array]);
             var o1 = Bridge.cast(Bridge.Reflection.invokeCI(c1, ["a", ["b", "c"]]), Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C22);
-            Bridge.Test.Assert.areEqual$1("a", o1.a, "o1.a");
-            Bridge.Test.Assert.areEqual$1(["b", "c"], o1.b, "o1.b");
+            Bridge.Test.Assert.areEqual$1("a", Bridge.unbox(o1.a), "o1.a");
+            Bridge.Test.Assert.areEqual$1(["b", "c"], Bridge.unbox(o1.b), "o1.b");
 
             var c2 = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C23, 1, 284, null, [String, Array]);
             var o2 = Bridge.cast(Bridge.Reflection.invokeCI(c2, ["a", ["b", "c"]]), Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C23);
-            Bridge.Test.Assert.areEqual$1("a", o2.a, "o1.a");
-            Bridge.Test.Assert.areEqual$1(["b", "c"], o2.b, "o1.b");
+            Bridge.Test.Assert.areEqual$1("a", Bridge.unbox(o2.a), "o1.a");
+            Bridge.Test.Assert.areEqual$1(["b", "c"], Bridge.unbox(o2.b), "o1.b");
         },
         memberTypeIsFieldForField: function () {
             Bridge.Test.Assert.areEqual$1(4, Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C12, 4, 284, "F1").t, "Instance");
@@ -11855,11 +11855,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var c = Bridge.merge(new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C12(), {
                 F1: 42
             } );
-            Bridge.Test.Assert.areEqual(42, Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C12, 4, 284, "F1"), c));
+            Bridge.Test.Assert.areEqual(42, Bridge.unbox(Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C12, 4, 284, "F1"), c)));
         },
         getValueWorksForStaticField: function () {
             Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C12.F3 = "X_Test";
-            Bridge.Test.Assert.areEqual("X_Test", Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C12, 4, 284, "F3"), null));
+            Bridge.Test.Assert.areEqual("X_Test", Bridge.unbox(Bridge.Reflection.fieldAccess(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C12, 4, 284, "F3"), null)));
         },
         setValueWorksForInstanceField: function () {
             var c = new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C12();
@@ -12154,21 +12154,21 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 setP1: 78
             } );
             var p1 = Bridge.Reflection.midel(m1, c)(null);
-            Bridge.Test.Assert.areEqual$1(78, p1, "m1.Invoke");
+            Bridge.Test.Assert.areEqual$1(78, Bridge.unbox(p1), "m1.Invoke");
 
             Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C14.setP3(new Date(2012, 4 - 1, 2));
             var p2 = Bridge.Reflection.midel(m2, null)(null);
-            Bridge.Test.Assert.areEqual$1(new Date(2012, 4 - 1, 2), p2, "m2.Invoke");
+            Bridge.Test.Assert.areEqual$1(new Date(2012, 4 - 1, 2), Bridge.unbox(p2), "m2.Invoke");
 
             c = Bridge.merge(new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C14(), {
                 p13Field: 13
             } );
             var p3 = Bridge.Reflection.midel(m3, c)(null);
-            Bridge.Test.Assert.areEqual$1(13, p3, "m3.Invoke");
+            Bridge.Test.Assert.areEqual$1(13, Bridge.unbox(p3), "m3.Invoke");
 
             Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C14.p14Field = 124;
             var p4 = Bridge.Reflection.midel(m4, null)(null);
-            Bridge.Test.Assert.areEqual$1(124, p4, "m4.Invoke");
+            Bridge.Test.Assert.areEqual$1(124, Bridge.unbox(p4), "m4.Invoke");
         },
         propertiesForSetMethodAreCorrectForPropertyImplementedAsGetAndSetMethods: function () {
             var m1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C14, 16, 284, "P1").s;
@@ -12247,11 +12247,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 P2: "Hello, world"
             } );
             var p1 = Bridge.Reflection.midel(m1, c)(null);
-            Bridge.Test.Assert.areEqual$1("Hello, world", p1, "m1.Invoke");
+            Bridge.Test.Assert.areEqual$1("Hello, world", Bridge.unbox(p1), "m1.Invoke");
 
             Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C14.P4 = 3.5;
             var p2 = Bridge.Reflection.midel(m2, null)(null);
-            Bridge.Test.Assert.areEqual$1(3.5, p2, "m2.Invoke");
+            Bridge.Test.Assert.areEqual$1(3.5, Bridge.unbox(p2), "m2.Invoke");
         },
         propertiesForSetMethodAreCorrectForPropertyImplementedAsFields: function () {
             var m1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C14, 16, 284, "P2").s;
@@ -12311,13 +12311,13 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 v: "X"
             } );
             var v1 = Bridge.Reflection.midel(m1, c1)(42, "Hello");
-            Bridge.Test.Assert.areEqual$1("X 42 Hello", v1, "m1.Invoke");
+            Bridge.Test.Assert.areEqual$1("X 42 Hello", Bridge.unbox(v1), "m1.Invoke");
 
             var c2 = Bridge.merge(new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C24(), {
                 v: "Y"
             } );
             var v2 = Bridge.Reflection.midel(m2, c2)(24, "World");
-            Bridge.Test.Assert.areEqual$1("Y 24 World", v2, "m2.Invoke");
+            Bridge.Test.Assert.areEqual$1("Y 24 World", Bridge.unbox(v2), "m2.Invoke");
         },
         propertiesForSetMethodAreCorrectForIndexer: function () {
             var m1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C15, 16, 284, "Item").s;
@@ -12435,15 +12435,15 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             } );
             Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C14.setP3(new Date(2013, 3 - 1, 5));
             Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C14.P4 = 7.5;
-            Bridge.Test.Assert.areEqual$1(42, Bridge.Reflection.midel(p1.g, c14)(), "P1.GetValue");
-            Bridge.Test.Assert.areEqual$1("Hello, world!", Bridge.Reflection.midel(p2.g, c14)(), "P2.GetValue");
-            Bridge.Test.Assert.areEqual$1(new Date(2013, 3 - 1, 5), Bridge.Reflection.midel(p3.g, null)(), "P3.GetValue");
-            Bridge.Test.Assert.areEqual$1(7.5, Bridge.Reflection.midel(p4.g, null)(), "P4.GetValue");
+            Bridge.Test.Assert.areEqual$1(42, Bridge.unbox(Bridge.Reflection.midel(p1.g, c14)()), "P1.GetValue");
+            Bridge.Test.Assert.areEqual$1("Hello, world!", Bridge.unbox(Bridge.Reflection.midel(p2.g, c14)()), "P2.GetValue");
+            Bridge.Test.Assert.areEqual$1(new Date(2013, 3 - 1, 5), Bridge.unbox(Bridge.Reflection.midel(p3.g, null)()), "P3.GetValue");
+            Bridge.Test.Assert.areEqual$1(7.5, Bridge.unbox(Bridge.Reflection.midel(p4.g, null)()), "P4.GetValue");
 
             var c15 = Bridge.merge(new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C15(), {
                 v: "X"
             } );
-            Bridge.Test.Assert.areEqual$1("X 42 Hello", Bridge.Reflection.midel(i.g, c15).apply(null, [42, "Hello"]), "Item.GetValue");
+            Bridge.Test.Assert.areEqual$1("X 42 Hello", Bridge.unbox(Bridge.Reflection.midel(i.g, c15).apply(null, [Bridge.box(42, System.Int32), "Hello"])), "Item.GetValue");
         },
         propertyInfoSetValueWorks: function () {
             var p1 = Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C14, 16, 284, "P1");
@@ -12466,7 +12466,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var c15 = Bridge.merge(new Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C15(), {
                 v: "X"
             } );
-            Bridge.Reflection.midel(i.s, c15).apply(null, [378, "X"].concat("The_value"));
+            Bridge.Reflection.midel(i.s, c15).apply(null, [Bridge.box(378, System.Int32), "X"].concat("The_value"));
             Bridge.Test.Assert.areEqual$1("X", c15.s, "Item.SetValue.s");
             Bridge.Test.Assert.areEqual$1(378, c15.x, "Item.SetValue.x");
             Bridge.Test.Assert.areEqual$1("The_value", c15.v, "Item.SetValue.value");
@@ -12770,7 +12770,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         s: null,
         v: null,
         getItem: function (x, s) {
-            return System.String.concat(this.v, " ", x, " ", s);
+            return System.String.concat(this.v, " ", Bridge.box(x, System.Int32), " ", s);
         },
         setItem: function (x, s, value) {
             this.x = x;
@@ -12845,7 +12845,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             if (b === void 0) { b = []; }
 
             this.$initialize();
-            this.a = a;
+            this.a = Bridge.box(a, System.Int32);
             this.b = b;
         },
         $ctor1: function (a, b) {
@@ -12857,11 +12857,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         M1: function (a, b) {
             if (b === void 0) { b = []; }
-            return [a, b];
+            return [Bridge.box(a, System.Int32), b];
         },
         M2: function (a, b) {
             b = Array.prototype.slice.call(arguments, 1);
-            return [a, b];
+            return [Bridge.box(a, System.Int32), b];
         }
     });
 
@@ -12872,7 +12872,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             if (b === void 0) { b = []; }
 
             this.$initialize();
-            this.a = a;
+            this.a = Bridge.box(a, System.Int32);
             this.b = b;
         },
         $ctor1: function (a, b) {
@@ -12884,11 +12884,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         M1: function (a, b) {
             if (b === void 0) { b = []; }
-            return [a, b];
+            return [Bridge.box(a, System.Int32), b];
         },
         M2: function (a, b) {
             b = Array.prototype.slice.call(arguments, 1);
-            return [a, b];
+            return [Bridge.box(a, System.Int32), b];
         }
     });
 
@@ -13105,9 +13105,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         statics: {
             canConvert: function (T, arg) {
                 try { /// The variable `x' is assigned but its value is never used
-
-
-                    var x = Bridge.cast(arg, T);
+                    var x = Bridge.cast(Bridge.unbox(arg), T);
                     return true;
                 }
                 catch ($e1) {
@@ -13136,9 +13134,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true$1(Bridge.is(new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.D4(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I3), "#17");
             Bridge.Test.Assert.true$1(Bridge.is(new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.D4(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I4), "#18");
             Bridge.Test.Assert.true$1(Bridge.is(new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X2(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I1), "#19");
-            Bridge.Test.Assert.true$1(Bridge.is((0), System.Int32), "#20");
-            Bridge.Test.Assert.true$1(Bridge.is((0), System.Int32), "#21");
-            Bridge.Test.Assert.true$1(Bridge.hasValue((0)), "#22");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box((0), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E2, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E2.toString), System.Int32), "#20");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box((0), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1.toString), System.Int32), "#21");
+            Bridge.Test.Assert.true$1(Bridge.hasValue(Bridge.box((0), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1.toString)), "#22");
             Bridge.Test.Assert.false$1(Bridge.is(new (Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1))(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I7$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1)), "#23");
             Bridge.Test.Assert.true$1(Bridge.is(new (Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1))(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1)), "#24");
             Bridge.Test.Assert.true$1(Bridge.is(new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.Y1X1(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1)), "#25");
@@ -13276,9 +13274,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true$1((Bridge.as(new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.D4(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I3)) != null, "#17");
             Bridge.Test.Assert.true$1((Bridge.as(new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.D4(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I4)) != null, "#18");
             Bridge.Test.Assert.true$1((Bridge.as(new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X2(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I1)) != null, "#19");
-            Bridge.Test.Assert.true$1((Bridge.as((0), System.Int32, true)) != null, "#20");
-            Bridge.Test.Assert.true$1((Bridge.as((0), System.Int32, true)) != null, "#21");
-            Bridge.Test.Assert.true$1(((0)) != null, "#22");
+            Bridge.Test.Assert.true$1((Bridge.as(Bridge.box((0), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E2, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E2.toString), System.Int32, true)) != null, "#20");
+            Bridge.Test.Assert.true$1((Bridge.as(Bridge.box((0), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1.toString), System.Int32, true)) != null, "#21");
+            Bridge.Test.Assert.true$1((Bridge.box((0), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1.toString)) != null, "#22");
             Bridge.Test.Assert.false$1((Bridge.as(new (Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1))(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I7$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1))) != null, "#23");
             Bridge.Test.Assert.true$1((Bridge.as(new (Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1))(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1))) != null, "#24");
             Bridge.Test.Assert.true$1((Bridge.as(new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.Y1X1(), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1))) != null, "#25");
@@ -13416,9 +13414,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I3, new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.D4()), "#17");
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I4, new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.D4()), "#18");
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I1, new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X2()), "#19");
-            Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, (0)), "#20");
-            Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(System.Int32, (0)), "#21");
-            Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Object, (0)), "#22");
+            Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, Bridge.box((0), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E2, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E2.toString)), "#20");
+            Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(System.Int32, Bridge.box((0), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1.toString)), "#21");
+            Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Object, Bridge.box((0), Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1.toString)), "#22");
             Bridge.Test.Assert.false$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I7$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1), new (Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1))()), "#23");
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1), new (Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.Y1$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1))()), "#24");
             Bridge.Test.Assert.true$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.canConvert(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.I6$1(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.X1), new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.Y1X1()), "#25");
@@ -13551,12 +13549,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.throws($_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.f2);
         },
         cast: function (T, o) {
-            return Bridge.cast(o, T);
+            return Bridge.cast(Bridge.unbox(o), T);
         },
         castOperatorForSerializableTypeWithoutTypeCheckCodeAlwaysSucceedsGeneric: function () {
             var o = {  };
             var b = this.cast(Object, o);
-            Bridge.Test.Assert.true(Bridge.referenceEquals(o, b));
+            Bridge.Test.Assert.true(Bridge.referenceEquals(Bridge.unbox(o), b));
         },
         typeCheckForSubTypeOfGenericType: function () {
             var c12 = new Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.C12();
@@ -14002,9 +14000,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true(Bridge.Reflection.isInterface(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IG$1(System.Int32)));
         },
         isInstanceOfTypeWorksForReferenceTypes: function () {
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType({  }, Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#1");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox({  }), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#1");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1(), Object), "#2");
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType({  }, Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#3");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox({  }), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#3");
             Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1(), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.D1), "#4");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.D1(), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#5");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.D1(), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#6");
@@ -14027,9 +14025,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType((0), Object), "#23");
             Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(null, Object), "#24");
 
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType({  }, Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#25");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox({  }), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#25");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1(), Object), "#26");
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType({  }, Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#27");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox({  }), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#27");
             Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1(), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.D1), "#28");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.D1(), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.C1), "#29");
             Bridge.Test.Assert.true$1(Bridge.Reflection.isInstanceOfType(new Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.D1(), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.I1), "#30");
@@ -14224,7 +14222,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.BX$1(Object), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.BX$1(Object));
         },
         falseIsFunctionShouldReturnFalse: function () {
-            Bridge.Test.Assert.false(Bridge.is(false, Function));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(false, Boolean, $box_.Boolean.toString), Function));
         },
         castingUndefinedToOtherTypeShouldReturnUndefined: function () {
             Bridge.Test.Assert.areEqual("undefined", typeof Bridge.cast(undefined, Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.C));
@@ -14243,7 +14241,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         instanceOfWorksForSerializableTypesWithCustomTypeCheckCode: function () {
             var o1 = new $_.$AnonymousType$3(1);
             var o2 = new $_.$AnonymousType$4(1, 2);
-            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(o1, Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.DS2), "o1 should not be of type");
+            Bridge.Test.Assert.false$1(Bridge.Reflection.isInstanceOfType(Bridge.unbox(o1), Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.DS2), "o1 should not be of type");
             //Assert.True (typeof(DS2).IsInstanceOfType(o2), "o2 should be of type");
         },
         staticGetTypeMethodWorks: function () {
@@ -14279,30 +14277,30 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             return Bridge.getDefaultValue(T);
         },
         castingToNamedValuesEnumCastsToString: function () {
-            Bridge.Test.Assert.true$1(Bridge.is("firstValue", String), "#1");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box("firstValue", Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum.toString), String), "#1");
             Bridge.Test.Assert.true$1(Bridge.is("firstValue", String), "#2");
-            Bridge.Test.Assert.false$1(Bridge.is(0, String), "#3");
+            Bridge.Test.Assert.false$1(Bridge.is(Bridge.box(0, System.Int32), String), "#3");
             Bridge.Test.Assert.false$1(this.doesItThrow($_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.f2), "#4");
             Bridge.Test.Assert.true$1(this.doesItThrow($_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.f3), "#5");
 
-            Bridge.Test.Assert.notNull$1(Bridge.as("firstValue", String, true), "#6");
+            Bridge.Test.Assert.notNull$1(Bridge.as(Bridge.box("firstValue", Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum.toString), String, true), "#6");
             Bridge.Test.Assert.notNull$1(Bridge.as("firstValue", String, true), "#7");
-            Bridge.Test.Assert.null$1(Bridge.as(0, String, true), "#8");
+            Bridge.Test.Assert.null$1(Bridge.as(Bridge.box(0, System.Int32), String, true), "#8");
 
-            Bridge.Test.Assert.true$1(this.isOfType(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, "firstValue"), "#9");
+            Bridge.Test.Assert.true$1(this.isOfType(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, Bridge.box("firstValue", Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum.toString)), "#9");
             Bridge.Test.Assert.true$1(this.isOfType(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, "firstValue"), "#10");
-            Bridge.Test.Assert.false$1(this.isOfType(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, 0), "#11");
+            Bridge.Test.Assert.false$1(this.isOfType(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, Bridge.box(0, System.Int32)), "#11");
         },
         castingToImportedNamedValuesEnumCastsToString: function () {
-            Bridge.Test.Assert.true$1(Bridge.is("firstValue", String), "#1");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box("firstValue", Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.ImportedNamedValuesEnum, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.ImportedNamedValuesEnum.toString), String), "#1");
             Bridge.Test.Assert.true$1(Bridge.is("firstValue", String), "#2");
-            Bridge.Test.Assert.false$1(Bridge.is(0, String), "#3");
+            Bridge.Test.Assert.false$1(Bridge.is(Bridge.box(0, System.Int32), String), "#3");
             Bridge.Test.Assert.false$1(this.doesItThrow($_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.f2), "#4");
             Bridge.Test.Assert.true$1(this.doesItThrow($_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.f3), "#5");
 
-            Bridge.Test.Assert.notNull$1(Bridge.as("firstValue", String, true), "#6");
+            Bridge.Test.Assert.notNull$1(Bridge.as(Bridge.box("firstValue", Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.ImportedNamedValuesEnum, $box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.ImportedNamedValuesEnum.toString), String, true), "#6");
             Bridge.Test.Assert.notNull$1(Bridge.as("firstValue", String, true), "#7");
-            Bridge.Test.Assert.null$1(Bridge.as(0, String, true), "#8");
+            Bridge.Test.Assert.null$1(Bridge.as(Bridge.box(0, System.Int32), String, true), "#8");
         },
         defaultValueOfNamedValuesEnumIsNull: function () {
             Bridge.Test.Assert.null$1(null, "#1");
@@ -14379,10 +14377,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             return _o71;
         },
         f2: function () {
-            var x = Bridge.cast("firstValue", String);
+            var x = Bridge.cast(Bridge.unbox("firstValue"), String);
         },
         f3: function () {
-            var x = Bridge.cast(0, String);
+            var x = Bridge.cast(Bridge.unbox(Bridge.box(0, System.Int32)), String);
         }
     });
 
@@ -14407,7 +14405,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         messageB: null,
         ctor: function (x, y) {
             this.$initialize();
-            this.messageB = x + " " + y;
+            this.messageB = Bridge.box(x, System.Int32) + " " + Bridge.box(y, System.Int32);
         }
     });
 
@@ -14427,7 +14425,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         messageB: null,
         ctor: function (x, y) {
             this.$initialize();
-            this.messageB = x + " " + y;
+            this.messageB = Bridge.box(x, System.Int32) + " " + Bridge.box(y, System.Int32);
         }
     });
 
@@ -14503,7 +14501,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             firstValue: "firstValue",
             secondValue: "secondValue"
         },
-        $utype: System.String
+        $utype: String
     });
 
     Bridge.define("Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes");
@@ -14561,7 +14559,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             return ((((x + y) | 0) + this.m) | 0);
         },
         g: function (T, x, y) {
-            return System.String.concat(((((x + y) | 0) + this.m) | 0), Bridge.Reflection.getTypeName(T));
+            return System.String.concat(Bridge.box(((((x + y) | 0) + this.m) | 0), System.Int32), Bridge.Reflection.getTypeName(T));
         }
     });
 
@@ -14575,7 +14573,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             return ((((x + y) | 0) + this.m) | 0);
         },
         g: function (T, x, y) {
-            return System.String.concat(((((x + y) | 0) + this.m) | 0), Bridge.Reflection.getTypeName(T));
+            return System.String.concat(Bridge.box(((((x + y) | 0) + this.m) | 0), System.Int32), Bridge.Reflection.getTypeName(T));
         },
         getF: function () {
             return Bridge.fn.bind(this, this.f);
@@ -14591,7 +14589,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             firstValue: "firstValue",
             secondValue: "secondValue"
         },
-        $utype: System.String
+        $utype: String
     });
 
     Bridge.define("Bridge.ClientTest.Batch4.RefParameterTests", {
@@ -14749,8 +14747,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         getHashCodeWoksForObject_SPI_1570: function () {
             // #1570
             var o1 = {  }, o2 = {  };
-            Bridge.Test.Assert.areEqual(Bridge.getHashCode(o1), Bridge.getHashCode(o1));
-            Bridge.Test.Assert.areEqual(Bridge.getHashCode(o2), Bridge.getHashCode(o2));
+            Bridge.Test.Assert.areEqual(Bridge.getHashCode(Bridge.unbox(o1)), Bridge.getHashCode(o1));
+            Bridge.Test.Assert.areEqual(Bridge.getHashCode(o2), Bridge.getHashCode(Bridge.unbox(o2)));
         },
         getHashCodeCallsGetHashCodeNonVirtually_SPI_1570: function () {
             // #1570
@@ -14780,10 +14778,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             }
         },
         evalWorks: function () {
-            Bridge.Test.Assert.areEqual(5, eval("2 + 3"));
+            Bridge.Test.Assert.areEqual(5, Bridge.unbox(eval("2 + 3")));
         },
         typeOfWorks: function () {
-            Bridge.Test.Assert.areEqual$1("undefined", typeof undefined, "#1");
+            Bridge.Test.Assert.areEqual$1("undefined", typeof Bridge.unbox(undefined), "#1");
             Bridge.Test.Assert.areEqual$1("object", typeof null, "#2");
             Bridge.Test.Assert.areEqual$1("boolean", typeof true, "#3");
             Bridge.Test.Assert.areEqual$1("number", typeof 0, "#4");
@@ -14807,9 +14805,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             //Script.Delete(c, "i");
             var ui = null;
             Bridge.ClientTest.Batch4.TestHelper.safe(function () {
-                ui = c.i;
+                ui = Bridge.box(c.i, System.Int32);
             });
-            Bridge.Test.Assert.areEqual("undefined", typeof ui);
+            Bridge.Test.Assert.areEqual("undefined", typeof Bridge.unbox(ui));
 
             var c2 = null;
             Bridge.ClientTest.Batch4.TestHelper.safe(function () {
@@ -15032,7 +15030,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.BooleanTests", {
         typePropertiesAreCorrect_SPI_1575: function () {
-            Bridge.Test.Assert.true(Bridge.is(true, Boolean));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(true, Boolean, $box_.Boolean.toString), Boolean));
             Bridge.Test.Assert.areEqual("Boolean", Bridge.Reflection.getTypeFullName(Boolean));
             // #1575
             Bridge.Test.Assert.areEqual(Object, Bridge.Reflection.getBaseType(Boolean));
@@ -15040,7 +15038,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(Boolean), Boolean));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(Boolean), Boolean));
 
-            var b = false;
+            var b = Bridge.box(false, Boolean, $box_.Boolean.toString);
             Bridge.Test.Assert.true(Bridge.is(b, System.IComparable$1(Boolean)));
             Bridge.Test.Assert.true(Bridge.is(b, System.IEquatable$1(Boolean)));
 
@@ -15079,10 +15077,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((true)), Bridge.getHashCode((false)));
         },
         objectEqualsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((true), true));
-            Bridge.Test.Assert.false(Bridge.equals((true), false));
-            Bridge.Test.Assert.false(Bridge.equals((false), true));
-            Bridge.Test.Assert.true(Bridge.equals((false), false));
+            Bridge.Test.Assert.true(Bridge.equals((true), Bridge.unbox(Bridge.box(true, Boolean, $box_.Boolean.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((true), Bridge.unbox(Bridge.box(false, Boolean, $box_.Boolean.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((false), Bridge.unbox(Bridge.box(true, Boolean, $box_.Boolean.toString))));
+            Bridge.Test.Assert.true(Bridge.equals((false), Bridge.unbox(Bridge.box(false, Boolean, $box_.Boolean.toString))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((true) === true);
@@ -15111,16 +15109,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.ByteTests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.Byte));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Byte));
-            Bridge.Test.Assert.false(Bridge.is(-1, System.Byte));
-            Bridge.Test.Assert.false(Bridge.is(256, System.Byte));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.Byte), System.Byte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Byte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-1, System.Int32), System.Byte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(256, System.Int32), System.Byte));
             Bridge.Test.Assert.areEqual("System.Byte", Bridge.Reflection.getTypeFullName(System.Byte));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.Byte));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.Byte), System.Byte));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.Byte), System.Byte));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.Byte));
-            var b = 0;
+            var b = Bridge.box(0, System.Byte);
             Bridge.Test.Assert.true(Bridge.is(b, System.Byte));
             Bridge.Test.Assert.true(Bridge.is(b, System.IComparable$1(System.Byte)));
             Bridge.Test.Assert.true(Bridge.is(b, System.IEquatable$1(System.Byte)));
@@ -15252,10 +15250,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.Byte))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.Byte))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.Byte))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.Byte))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -15305,10 +15303,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.CharTests", {
         typePropertiesAreInt32_SPI_1603: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.Char));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Char));
-            Bridge.Test.Assert.false(Bridge.is(-1, System.Char));
-            Bridge.Test.Assert.false(Bridge.is(65536, System.Char));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.Int32), System.Char));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Char));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-1, System.Int32), System.Char));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(65536, System.Int32), System.Char));
             Bridge.Test.Assert.areEqual("System.Char", Bridge.Reflection.getTypeFullName(System.Char));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.Char));
             Bridge.Test.Assert.false(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.Byte), System.Char));
@@ -15513,7 +15511,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         creatingInstanceReturnsTodaysDate_SPI_1604: function () {
             var fullYear = Bridge.createInstance(Date).getFullYear();
-            Bridge.Test.Assert.true$1(fullYear > 2011, fullYear + " > 2011");
+            Bridge.Test.Assert.true$1(fullYear > 2011, Bridge.box(fullYear, System.Int32) + " > 2011");
         },
         millisecondSinceEpochConstructorWorks: function () {
             var dt = new Date(43200000000.0);
@@ -15605,11 +15603,11 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         valueOfWorks: function () {
             var dt = new Date(1970, 0, 2);
             dt = Bridge.ClientTest.Batch4.SimpleTypes.DateTests.addTimezoneMinutesOffset(dt);
-            Bridge.Test.Assert.areEqual(86400000, dt.valueOf());
+            Bridge.Test.Assert.areEqual(86400000, Bridge.unbox(dt.valueOf()));
         },
         getTimezoneOffsetWorks: function () {
             var dt = new Date(0);
-            Bridge.Test.Assert.areEqual(System.Nullable.getValue(Bridge.cast((new Date(1970, 0, 1).valueOf()), System.Double)) / 60000, dt.getTimezoneOffset());
+            Bridge.Test.Assert.areEqual(System.Nullable.getValue(Bridge.cast(Bridge.unbox((new Date(1970, 0, 1).valueOf())), System.Double)) / 60000, dt.getTimezoneOffset());
         },
         getUtcFullYearWorks: function () {
             var dt = new Date(2011, 7, 12, 13, 42, 56, 345);
@@ -15831,10 +15829,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true(System.Int64(Bridge.getHashCode(new Date(3000, 1, 1))).lt(System.Int64([-1,0])));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals(new Date(0), new Date(0)));
-            Bridge.Test.Assert.false(Bridge.equals(new Date(1), new Date(0)));
-            Bridge.Test.Assert.false(Bridge.equals(new Date(0), new Date(1)));
-            Bridge.Test.Assert.true(Bridge.equals(new Date(1), new Date(1)));
+            Bridge.Test.Assert.true(Bridge.equals(new Date(0), Bridge.unbox(new Date(0))));
+            Bridge.Test.Assert.false(Bridge.equals(new Date(1), Bridge.unbox(new Date(0))));
+            Bridge.Test.Assert.false(Bridge.equals(new Date(0), Bridge.unbox(new Date(1))));
+            Bridge.Test.Assert.true(Bridge.equals(new Date(1), Bridge.unbox(new Date(1))));
         }
     });
 
@@ -15847,7 +15845,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(Date), Date));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, Date));
 
-            var d = new Date();
+            var d = Bridge.box(new Date(), Date, $box_.Date.toString);
             Bridge.Test.Assert.true(Bridge.is(d, Date));
             // #1609
             Bridge.Test.Assert.true(Bridge.is(d, System.IComparable$1(Date)));
@@ -15982,7 +15980,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         iFormattableToStringWorks: function () {
             var dt = new Date(2011, 7 - 1, 12);
-            Bridge.Test.Assert.areEqual("2011-07-12", Bridge.format(Bridge.cast(dt, System.IFormattable), "yyyy-MM-dd", System.Globalization.CultureInfo.invariantCulture));
+            Bridge.Test.Assert.areEqual("2011-07-12", Bridge.format(Bridge.cast(Bridge.box(dt, Date, $box_.Date.toString), System.IFormattable), "yyyy-MM-dd", System.Globalization.CultureInfo.invariantCulture));
         },
         getFullYearWorks: function () {
             var dt = new Date(2011, 7 - 1, 12, 13, 42, 56, 345);
@@ -16022,7 +16020,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         valueOfWorks: function () {
             var dt = new Date(System.Int64(Date.UTC(1970, 1 - 1, 2)).mul(10000).toNumber()/10000);
-            Bridge.Test.Assert.areEqual(86400000, dt.valueOf());
+            Bridge.Test.Assert.areEqual(86400000, Bridge.unbox(dt.valueOf()));
         },
         getUtcFullYearWorks: function () {
             var dt = new Date(System.Int64(Date.UTC(2011, 7 - 1, 12, 13, 42, 56, 345)).mul(10000).toNumber()/10000);
@@ -16199,7 +16197,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         convertingDateToMutableDateReturnsANewButEqualInstance: function () {
             var dt = new Date(2011, 7 - 1, 12);
             var mdt = new Date(dt.valueOf());
-            Bridge.Test.Assert.false(Bridge.referenceEquals(dt, mdt));
+            Bridge.Test.Assert.false(Bridge.referenceEquals(Bridge.box(dt, Date, $box_.Date.toString), mdt));
             Bridge.Test.Assert.areEqual(2011, mdt.getFullYear());
             Bridge.Test.Assert.areEqual(6, mdt.getMonth());
             Bridge.Test.Assert.areEqual(12, mdt.getDate());
@@ -16207,7 +16205,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         convertingMutableDateToDateReturnsANewButEqualInstance: function () {
             var mdt = new Date(2011, 7, 12);
             var dt = new Date(mdt.valueOf());
-            Bridge.Test.Assert.false(Bridge.referenceEquals(dt, mdt));
+            Bridge.Test.Assert.false(Bridge.referenceEquals(Bridge.box(dt, Date, $box_.Date.toString), mdt));
             Bridge.Test.Assert.areEqual(2011, mdt.getFullYear());
             Bridge.Test.Assert.areEqual(7, mdt.getMonth());
             Bridge.Test.Assert.areEqual(12, mdt.getDate());
@@ -16219,10 +16217,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true(System.Int64(Bridge.getHashCode(new Date(3000, 1 - 1, 1))).lt(System.Int64([-1,0])));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(0).toNumber()/10000)));
-            Bridge.Test.Assert.false(Bridge.equals(new Date(System.Int64(10000).toNumber()/10000), new Date(System.Int64(0).toNumber()/10000)));
-            Bridge.Test.Assert.false(Bridge.equals(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(10000).toNumber()/10000)));
-            Bridge.Test.Assert.true(Bridge.equals(new Date(System.Int64(10000).toNumber()/10000), new Date(System.Int64(10000).toNumber()/10000)));
+            Bridge.Test.Assert.true(Bridge.equals(new Date(System.Int64(0).toNumber()/10000), Bridge.unbox(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString))));
+            Bridge.Test.Assert.false(Bridge.equals(new Date(System.Int64(10000).toNumber()/10000), Bridge.unbox(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString))));
+            Bridge.Test.Assert.false(Bridge.equals(new Date(System.Int64(0).toNumber()/10000), Bridge.unbox(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString))));
+            Bridge.Test.Assert.true(Bridge.equals(new Date(System.Int64(10000).toNumber()/10000), Bridge.unbox(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString))));
         },
         iEquatableEqualsWorks_SPI_1608: function () {
             Bridge.Test.Assert.true(Bridge.equalsT(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(0).toNumber()/10000)));
@@ -16230,10 +16228,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.false(Bridge.equalsT(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(10000).toNumber()/10000)));
             Bridge.Test.Assert.true(Bridge.equalsT(new Date(System.Int64(10000).toNumber()/10000), new Date(System.Int64(10000).toNumber()/10000)));
 
-            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(new Date(System.Int64(0).toNumber()/10000), System.IEquatable$1(Date)), new Date(System.Int64(0).toNumber()/10000), Date));
-            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(new Date(System.Int64(10000).toNumber()/10000), System.IEquatable$1(Date)), new Date(System.Int64(0).toNumber()/10000), Date));
-            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(new Date(System.Int64(0).toNumber()/10000), System.IEquatable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), Date));
-            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(new Date(System.Int64(10000).toNumber()/10000), System.IEquatable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), Date));
+            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString), System.IEquatable$1(Date)), new Date(System.Int64(0).toNumber()/10000), Date));
+            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString), System.IEquatable$1(Date)), new Date(System.Int64(0).toNumber()/10000), Date));
+            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString), System.IEquatable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), Date));
+            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString), System.IEquatable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), Date));
         },
         staticEqualsWorks: function () {
             Bridge.Test.Assert.true(Bridge.equalsT(new Date(System.Int64(0).toNumber()/10000), new Date(System.Int64(0).toNumber()/10000)));
@@ -16253,9 +16251,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         iComparableCompareToWorks_SPI_1609: function () {
             // #1609
-            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(new Date(System.Int64(0).toNumber()/10000), System.IComparable$1(Date)), new Date(System.Int64(0).toNumber()/10000), false, Date) === 0);
-            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(new Date(System.Int64(10000).toNumber()/10000), System.IComparable$1(Date)), new Date(System.Int64(0).toNumber()/10000), false, Date) > 0);
-            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(new Date(System.Int64(0).toNumber()/10000), System.IComparable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), false, Date) < 0);
+            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString), System.IComparable$1(Date)), new Date(System.Int64(0).toNumber()/10000), false, Date) === 0);
+            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(Bridge.box(new Date(System.Int64(10000).toNumber()/10000), Date, $box_.Date.toString), System.IComparable$1(Date)), new Date(System.Int64(0).toNumber()/10000), false, Date) > 0);
+            Bridge.Test.Assert.true(Bridge.compare(Bridge.cast(Bridge.box(new Date(System.Int64(0).toNumber()/10000), Date, $box_.Date.toString), System.IComparable$1(Date)), new Date(System.Int64(10000).toNumber()/10000), false, Date) < 0);
         },
         datePropertyWorks: function () {
             var dt = new Date(2012, 8 - 1, 12, 13, 14, 15, 16);
@@ -16381,13 +16379,13 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.DecimalTests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(System.Decimal(0.5), System.Decimal));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(System.Decimal(0.5), System.Decimal, $box_.System.Decimal.toString), System.Decimal));
             Bridge.Test.Assert.areEqual("System.Decimal", Bridge.Reflection.getTypeFullName(System.Decimal));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.Decimal));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.Decimal), System.Decimal));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.Decimal), System.Decimal));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.Decimal));
-            var d = System.Decimal(0.0);
+            var d = Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString);
             Bridge.Test.Assert.true(Bridge.is(d, System.Decimal));
             Bridge.Test.Assert.true(Bridge.is(d, System.IComparable$1(System.Decimal)));
             Bridge.Test.Assert.true(Bridge.is(d, System.IEquatable$1(System.Decimal)));
@@ -16411,37 +16409,37 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areStrictEqual(s, v.toString());
         },
         defaultValueIsDecimal0: function () {
-            this.assertIsDecimalAndEqualTo(this.getDefaultValue(System.Decimal), 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(this.getDefaultValue(System.Decimal), System.Decimal, $box_.System.Decimal.toString), 0);
         },
         creatingInstanceReturnsZero: function () {
-            this.assertIsDecimalAndEqualTo(Bridge.createInstance(System.Decimal), 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(Bridge.createInstance(System.Decimal), System.Decimal, $box_.System.Decimal.toString), 0);
         },
         literalDecimalsWork_SPI_1590: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(1.0), 1);
-            this.assertIsDecimalAndEqualTo(System.Decimal(-1.0), -1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(1.0), System.Decimal, $box_.System.Decimal.toString), 1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-1.0), System.Decimal, $box_.System.Decimal.toString), -1);
 
             // #1590
-            this.assertIsDecimalAndEqualTo$1(System.Decimal("7922816251426433759354395033"), "7922816251426433759354395033");
-            this.assertIsDecimalAndEqualTo$1(System.Decimal("-7922816251426433759354395033"), "-7922816251426433759354395033");
+            this.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal("7922816251426433759354395033"), System.Decimal, $box_.System.Decimal.toString), "7922816251426433759354395033");
+            this.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal("-7922816251426433759354395033"), System.Decimal, $box_.System.Decimal.toString), "-7922816251426433759354395033");
         },
         constantsWork_SPI_1590: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.One, 1);
-            this.assertIsDecimalAndEqualTo(System.Decimal.Zero, 0);
-            this.assertIsDecimalAndEqualTo(System.Decimal.MinusOne, -1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.One, System.Decimal, $box_.System.Decimal.toString), 1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.Zero, System.Decimal, $box_.System.Decimal.toString), 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.MinusOne, System.Decimal, $box_.System.Decimal.toString), -1);
             // #1590
-            this.assertIsDecimalAndEqualTo$1(System.Decimal.MinValue, "-79228162514264337593543950335");
-            this.assertIsDecimalAndEqualTo$1(System.Decimal.MaxValue, "79228162514264337593543950335");
+            this.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.MinValue, System.Decimal, $box_.System.Decimal.toString), "-79228162514264337593543950335");
+            this.assertIsDecimalAndEqualTo$1(Bridge.box(System.Decimal.MaxValue, System.Decimal, $box_.System.Decimal.toString), "79228162514264337593543950335");
         },
         defaultConstructorReturnsZero: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(0), 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(0), System.Decimal, $box_.System.Decimal.toString), 0);
         },
         convertingConstructorsWork: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(0.5), 0.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal(1.5), 1.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal(2), 2);
-            this.assertIsDecimalAndEqualTo(System.Decimal(System.Int64(3)), 3);
-            this.assertIsDecimalAndEqualTo(System.Decimal(4), 4);
-            this.assertIsDecimalAndEqualTo(System.Decimal(System.UInt64(5)), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(0.5), System.Decimal, $box_.System.Decimal.toString), 0.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(1.5), System.Decimal, $box_.System.Decimal.toString), 1.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(2), System.Decimal, $box_.System.Decimal.toString), 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(System.Int64(3)), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(4), System.Decimal, $box_.System.Decimal.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(System.UInt64(5)), System.Decimal, $box_.System.Decimal.toString), 5);
         },
         formatWorks: function () {
             Bridge.Test.Assert.areEqual("123", Bridge.Int.format(System.Decimal(291.0), "x"));
@@ -16456,21 +16454,21 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual("291", Bridge.format(System.Decimal(291.0), "", System.Globalization.CultureInfo.invariantCulture));
         },
         toStringWithoutRadixWorks: function () {
-            Bridge.Test.Assert.areEqual("123", System.Decimal(123.0).toString());
+            Bridge.Test.Assert.areEqual("123", Bridge.box(System.Decimal(123.0), System.Decimal, $box_.System.Decimal.toString).toString());
         },
         conversionsToDecimalWork_SPI_1580: function () {
             var x = 0;
-            this.assertIsDecimalAndEqualTo(System.Decimal(Bridge.Int.sxb(((((x + 1) | 0))) & 255)), 1);
-            this.assertIsDecimalAndEqualTo(System.Decimal((((((x + 2) | 0))) & 255)), 2);
-            this.assertIsDecimalAndEqualTo(System.Decimal(Bridge.Int.sxs(((((x + 3) | 0))) & 65535)), 3);
-            this.assertIsDecimalAndEqualTo(System.Decimal((((((x + 4) | 0))) & 65535)), 4);
-            this.assertIsDecimalAndEqualTo(System.Decimal((((((x + 5) | 0))) & 65535)), 5);
-            this.assertIsDecimalAndEqualTo(System.Decimal((((x + 6) | 0))), 6);
-            this.assertIsDecimalAndEqualTo(System.Decimal((((((x + 7) | 0))) >>> 0)), 7);
-            this.assertIsDecimalAndEqualTo(System.Decimal(System.Int64((((x + 8) | 0)))), 8);
-            this.assertIsDecimalAndEqualTo(System.Decimal(Bridge.Int.clipu64((((x + 9) | 0)))), 9);
-            this.assertIsDecimalAndEqualTo(System.Decimal((x + 10.5), null, System.Single), 10.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal((x + 11.5), null, System.Double), 11.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(Bridge.Int.sxb(((((x + 1) | 0))) & 255)), System.Decimal, $box_.System.Decimal.toString), 1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal((((((x + 2) | 0))) & 255)), System.Decimal, $box_.System.Decimal.toString), 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(Bridge.Int.sxs(((((x + 3) | 0))) & 65535)), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal((((((x + 4) | 0))) & 65535)), System.Decimal, $box_.System.Decimal.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal((((((x + 5) | 0))) & 65535)), System.Decimal, $box_.System.Decimal.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal((((x + 6) | 0))), System.Decimal, $box_.System.Decimal.toString), 6);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal((((((x + 7) | 0))) >>> 0)), System.Decimal, $box_.System.Decimal.toString), 7);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(System.Int64((((x + 8) | 0)))), System.Decimal, $box_.System.Decimal.toString), 8);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(Bridge.Int.clipu64((((x + 9) | 0)))), System.Decimal, $box_.System.Decimal.toString), 9);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal((x + 10.5), null, System.Single), System.Decimal, $box_.System.Decimal.toString), 10.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal((x + 11.5), null, System.Double), System.Decimal, $box_.System.Decimal.toString), 11.5);
 
             // #1580
             Bridge.Test.Assert.throws$6(System.OverflowException, function () {
@@ -16488,17 +16486,17 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         nullableConversionsToDecimalWork_SPI_1580_1581_1587: function () {
             var x1 = 0, x2 = null;
-            this.assertIsDecimalAndEqualTo(System.Decimal.lift(Bridge.Int.clip8(Bridge.Int.clip32(System.Nullable.add(x1, 1)))), 1);
-            this.assertIsDecimalAndEqualTo(System.Decimal.lift(Bridge.Int.clipu8(Bridge.Int.clip32(System.Nullable.add(x1, 2)))), 2);
-            this.assertIsDecimalAndEqualTo(System.Decimal.lift(Bridge.Int.clip16(Bridge.Int.clip32(System.Nullable.add(x1, 3)))), 3);
-            this.assertIsDecimalAndEqualTo(System.Decimal.lift(Bridge.Int.clipu16(Bridge.Int.clip32(System.Nullable.add(x1, 4)))), 4);
-            this.assertIsDecimalAndEqualTo(System.Decimal.lift(Bridge.Int.clipu16(Bridge.Int.clip32(System.Nullable.add(x1, 5)))), 5);
-            this.assertIsDecimalAndEqualTo(System.Decimal.lift((Bridge.Int.clip32(System.Nullable.add(x1, 6)))), 6);
-            this.assertIsDecimalAndEqualTo(System.Decimal.lift(Bridge.Int.clipu32(Bridge.Int.clip32(System.Nullable.add(x1, 7)))), 7);
-            this.assertIsDecimalAndEqualTo(System.Decimal.lift(System.Int64.lift((Bridge.Int.clip32(System.Nullable.add(x1, 8))))), 8);
-            this.assertIsDecimalAndEqualTo(System.Decimal.lift(Bridge.Int.clipu64(Bridge.Int.clip32(System.Nullable.add(x1, 9)))), 9);
-            this.assertIsDecimalAndEqualTo(System.Decimal((System.Nullable.add(x1, 10.5)), null, System.Nullable$1(System.Single)), 10.5);
-            this.assertIsDecimalAndEqualTo(System.Decimal((System.Nullable.add(x1, 11.5)), null, System.Nullable$1(System.Double)), 11.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.lift(Bridge.Int.clip8(Bridge.Int.clip32(System.Nullable.add(x1, 1)))), System.Decimal, $box_.System.Nullable$1.toString), 1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.lift(Bridge.Int.clipu8(Bridge.Int.clip32(System.Nullable.add(x1, 2)))), System.Decimal, $box_.System.Nullable$1.toString), 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.lift(Bridge.Int.clip16(Bridge.Int.clip32(System.Nullable.add(x1, 3)))), System.Decimal, $box_.System.Nullable$1.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.lift(Bridge.Int.clipu16(Bridge.Int.clip32(System.Nullable.add(x1, 4)))), System.Decimal, $box_.System.Nullable$1.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.lift(Bridge.Int.clipu16(Bridge.Int.clip32(System.Nullable.add(x1, 5)))), System.Decimal, $box_.System.Nullable$1.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.lift((Bridge.Int.clip32(System.Nullable.add(x1, 6)))), System.Decimal, $box_.System.Nullable$1.toString), 6);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.lift(Bridge.Int.clipu32(Bridge.Int.clip32(System.Nullable.add(x1, 7)))), System.Decimal, $box_.System.Nullable$1.toString), 7);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.lift(System.Int64.lift((Bridge.Int.clip32(System.Nullable.add(x1, 8))))), System.Decimal, $box_.System.Nullable$1.toString), 8);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.lift(Bridge.Int.clipu64(Bridge.Int.clip32(System.Nullable.add(x1, 9)))), System.Decimal, $box_.System.Nullable$1.toString), 9);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal((System.Nullable.add(x1, 10.5)), null, System.Nullable$1(System.Single)), System.Decimal, $box_.System.Nullable$1.toString), 10.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal((System.Nullable.add(x1, 11.5)), null, System.Nullable$1(System.Double)), System.Decimal, $box_.System.Nullable$1.toString), 11.5);
             Bridge.Test.Assert.areEqual(null, System.Decimal.lift(Bridge.Int.clip8(x2)));
             Bridge.Test.Assert.areEqual(null, System.Decimal.lift(Bridge.Int.clipu8(x2)));
             Bridge.Test.Assert.areEqual(null, System.Decimal.lift(Bridge.Int.clip16(x2)));
@@ -17003,26 +17001,26 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         operatorsWork_SPI_1583: function () {
             var $t;
             var x = System.Decimal(3);
-            this.assertIsDecimalAndEqualTo(x.clone(), 3);
-            this.assertIsDecimalAndEqualTo(x.neg(), -3);
-            this.assertIsDecimalAndEqualTo(x.add(System.Decimal(4.0)), 7);
-            this.assertIsDecimalAndEqualTo(x.sub(System.Decimal(2.0)), 1);
-            this.assertIsDecimalAndEqualTo(($t = x, x = x.inc(), $t), 3);
-            this.assertIsDecimalAndEqualTo(x, 4);
-            this.assertIsDecimalAndEqualTo((x = x.inc()), 5);
-            this.assertIsDecimalAndEqualTo(x, 5);
-            this.assertIsDecimalAndEqualTo(($t = x, x = x.dec(), $t), 5);
-            this.assertIsDecimalAndEqualTo(x, 4);
-            this.assertIsDecimalAndEqualTo((x = x.dec()), 3);
-            this.assertIsDecimalAndEqualTo(x, 3);
-            this.assertIsDecimalAndEqualTo(x.mul(System.Decimal(3.0)), 9);
-            this.assertIsDecimalAndEqualTo(x.div(System.Decimal(2.0)), 1.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.clone(), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.neg(), System.Decimal, $box_.System.Decimal.toString), -3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.add(System.Decimal(4.0)), System.Decimal, $box_.System.Decimal.toString), 7);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.sub(System.Decimal(2.0)), System.Decimal, $box_.System.Decimal.toString), 1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(($t = x, x = x.inc(), $t), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x, System.Decimal, $box_.System.Decimal.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box((x = x.inc()), System.Decimal, $box_.System.Decimal.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x, System.Decimal, $box_.System.Decimal.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(($t = x, x = x.dec(), $t), System.Decimal, $box_.System.Decimal.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x, System.Decimal, $box_.System.Decimal.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box((x = x.dec()), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x, System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.mul(System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), 9);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x.div(System.Decimal(2.0)), System.Decimal, $box_.System.Decimal.toString), 1.5);
 
             // #1583
             Bridge.Test.Assert.throws$6(System.DivideByZeroException, function () {
                 var _ = x.div(System.Decimal(0.0));
             });
-            this.assertIsDecimalAndEqualTo(System.Decimal(14.0).mod(x), 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(14.0).mod(x), System.Decimal, $box_.System.Decimal.toString), 2);
             Bridge.Test.Assert.throws$6(System.DivideByZeroException, function () {
                 var _ = x.mod(System.Decimal(0.0));
             });
@@ -17043,26 +17041,26 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         liftedOperatorsWork_SPI_1583: function () {
             var $t;
             var x1 = System.Decimal(3), x2 = System.Decimal.lift(null);
-            this.assertIsDecimalAndEqualTo(System.Nullable.lift1("clone", x1), 3);
-            this.assertIsDecimalAndEqualTo(System.Nullable.lift1("neg", x1), -3);
-            this.assertIsDecimalAndEqualTo(System.Nullable.lift2("add", x1, System.Decimal(4.0)), 7);
-            this.assertIsDecimalAndEqualTo(System.Nullable.lift2("sub", x1, System.Decimal(2.0)), 1);
-            this.assertIsDecimalAndEqualTo(Bridge.hasValue(x1) ? ($t = x1, x1 = System.Nullable.lift1('inc', x1), $t) : null, 3);
-            this.assertIsDecimalAndEqualTo(x1, 4);
-            this.assertIsDecimalAndEqualTo(Bridge.hasValue(x1) ? (x1 = System.Nullable.lift1('inc', x1)) : null, 5);
-            this.assertIsDecimalAndEqualTo(x1, 5);
-            this.assertIsDecimalAndEqualTo(Bridge.hasValue(x1) ? ($t = x1, x1 = System.Nullable.lift1('dec', x1), $t) : null, 5);
-            this.assertIsDecimalAndEqualTo(x1, 4);
-            this.assertIsDecimalAndEqualTo(Bridge.hasValue(x1) ? (x1 = System.Nullable.lift1('dec', x1)) : null, 3);
-            this.assertIsDecimalAndEqualTo(x1, 3);
-            this.assertIsDecimalAndEqualTo(System.Nullable.lift2("mul", x1, System.Decimal(3.0)), 9);
-            this.assertIsDecimalAndEqualTo(System.Nullable.lift2("div", x1, System.Decimal(2.0)), 1.5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Nullable.lift1("clone", x1), System.Decimal, $box_.System.Nullable$1.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Nullable.lift1("neg", x1), System.Decimal, $box_.System.Nullable$1.toString), -3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Nullable.lift2("add", x1, System.Decimal(4.0)), System.Decimal, $box_.System.Nullable$1.toString), 7);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Nullable.lift2("sub", x1, System.Decimal(2.0)), System.Decimal, $box_.System.Nullable$1.toString), 1);
+            this.assertIsDecimalAndEqualTo(Bridge.box(Bridge.hasValue(x1) ? ($t = x1, x1 = System.Nullable.lift1('inc', x1), $t) : null, System.Decimal, $box_.System.Nullable$1.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x1, System.Decimal, $box_.System.Nullable$1.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(Bridge.hasValue(x1) ? (x1 = System.Nullable.lift1('inc', x1)) : null, System.Decimal, $box_.System.Nullable$1.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x1, System.Decimal, $box_.System.Nullable$1.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(Bridge.hasValue(x1) ? ($t = x1, x1 = System.Nullable.lift1('dec', x1), $t) : null, System.Decimal, $box_.System.Nullable$1.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x1, System.Decimal, $box_.System.Nullable$1.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(Bridge.hasValue(x1) ? (x1 = System.Nullable.lift1('dec', x1)) : null, System.Decimal, $box_.System.Nullable$1.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(x1, System.Decimal, $box_.System.Nullable$1.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Nullable.lift2("mul", x1, System.Decimal(3.0)), System.Decimal, $box_.System.Nullable$1.toString), 9);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Nullable.lift2("div", x1, System.Decimal(2.0)), System.Decimal, $box_.System.Nullable$1.toString), 1.5);
 
             // #1583
             Bridge.Test.Assert.throws$6(System.DivideByZeroException, function () {
                 var _ = System.Nullable.lift2("div", x1, System.Decimal(0.0));
             });
-            this.assertIsDecimalAndEqualTo(System.Nullable.lift2("mod", System.Decimal(14.0), x1), 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Nullable.lift2("mod", System.Decimal(14.0), x1), System.Decimal, $box_.System.Nullable$1.toString), 2);
             Bridge.Test.Assert.throws$6(System.DivideByZeroException, function () {
                 var _ = System.Nullable.lift2("mod", x1, System.Decimal(0.0));
             });
@@ -17127,36 +17125,36 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.false(System.Nullable.liftcmp("lte", x2, System.Decimal.lift(null)));
         },
         addWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).add(System.Decimal(4.0)), 7);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).add(System.Decimal(4.0)), System.Decimal, $box_.System.Decimal.toString), 7);
         },
         ceilingWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.1).ceil(), 4);
-            this.assertIsDecimalAndEqualTo(System.Decimal(-3.9).ceil(), -3);
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).ceil(), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.1).ceil(), System.Decimal, $box_.System.Decimal.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-3.9).ceil(), System.Decimal, $box_.System.Decimal.toString), -3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).ceil(), System.Decimal, $box_.System.Decimal.toString), 3);
         },
         divideWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).div(System.Decimal(4.0)), 0.75);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).div(System.Decimal(4.0)), System.Decimal, $box_.System.Decimal.toString), 0.75);
         },
         floorWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.9).floor(), 3);
-            this.assertIsDecimalAndEqualTo(System.Decimal(-3.1).floor(), -4);
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).floor(), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.9).floor(), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-3.1).floor(), System.Decimal, $box_.System.Decimal.toString), -4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).floor(), System.Decimal, $box_.System.Decimal.toString), 3);
         },
         remainderWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(14.0).mod(System.Decimal(3.0)), 2);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(14.0).mod(System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), 2);
         },
         multiplyWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).mul(System.Decimal(2.0)), 6);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).mul(System.Decimal(2.0)), System.Decimal, $box_.System.Decimal.toString), 6);
         },
         negateWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(0).sub(System.Decimal(3.0)), -3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(0).sub(System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), -3);
         },
         parseWorks_SPI_1586: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal("123"), 123);
-            this.assertIsDecimalAndEqualTo(System.Decimal("0.123"), 0.123);
-            this.assertIsDecimalAndEqualTo(System.Decimal(".123"), 0.123);
-            this.assertIsDecimalAndEqualTo(System.Decimal("123.456"), 123.456);
-            this.assertIsDecimalAndEqualTo(System.Decimal("-123.456"), -123.456);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal("123"), System.Decimal, $box_.System.Decimal.toString), 123);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal("0.123"), System.Decimal, $box_.System.Decimal.toString), 0.123);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(".123"), System.Decimal, $box_.System.Decimal.toString), 0.123);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal("123.456"), System.Decimal, $box_.System.Decimal.toString), 123.456);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal("-123.456"), System.Decimal, $box_.System.Decimal.toString), -123.456);
 
             // #1586
             // Test restructure to keep assertion count correct (prevent uncaught test exception)
@@ -17164,12 +17162,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.ClientTest.Batch4.TestHelper.safe(function () {
                 d1 = System.Decimal("+123.456");
             });
-            this.assertIsDecimalAndEqualTo(d1, 123.456);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d1, System.Decimal, $box_.System.Decimal.toString), 123.456);
             var d2 = System.Decimal(0);
             Bridge.ClientTest.Batch4.TestHelper.safe(function () {
                 d2 = System.Decimal("  +123.456  ");
             });
-            this.assertIsDecimalAndEqualTo(d2, 123.456);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d2, System.Decimal, $box_.System.Decimal.toString), 123.456);
 
             Bridge.Test.Assert.throws$6(System.FormatException, $_.Bridge.ClientTest.Batch4.SimpleTypes.DecimalTests.f1);
             Bridge.Test.Assert.throws$6(System.FormatException, $_.Bridge.ClientTest.Batch4.SimpleTypes.DecimalTests.f2);
@@ -17181,81 +17179,81 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var b;
             b = System.Decimal.tryParse("123", null, d);
             Bridge.Test.Assert.true(b);
-            this.assertIsDecimalAndEqualTo(d.v, 123);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), 123);
 
             b = System.Decimal.tryParse("0.123", null, d);
             Bridge.Test.Assert.true(b);
-            this.assertIsDecimalAndEqualTo(d.v, 0.123);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), 0.123);
 
             b = System.Decimal.tryParse(".123", null, d);
             Bridge.Test.Assert.true(b);
-            this.assertIsDecimalAndEqualTo(d.v, 0.123);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), 0.123);
 
             b = System.Decimal.tryParse("123.456", null, d);
             Bridge.Test.Assert.true(b);
-            this.assertIsDecimalAndEqualTo(d.v, 123.456);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), 123.456);
 
             b = System.Decimal.tryParse("-123.456", null, d);
             Bridge.Test.Assert.true(b);
-            this.assertIsDecimalAndEqualTo(d.v, -123.456);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), -123.456);
 
             // #1586
             b = System.Decimal.tryParse("+123.456", null, d);
             Bridge.Test.Assert.true(b);
-            this.assertIsDecimalAndEqualTo(d.v, 123.456);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), 123.456);
 
             b = System.Decimal.tryParse("  +123.456  ", null, d);
             Bridge.Test.Assert.true(b);
-            this.assertIsDecimalAndEqualTo(d.v, 123.456);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), 123.456);
 
             b = System.Decimal.tryParse("A123", null, d);
             Bridge.Test.Assert.false(b);
-            this.assertIsDecimalAndEqualTo(d.v, 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), 0);
 
             b = System.Decimal.tryParse("12.34.56", null, d);
             Bridge.Test.Assert.false(b);
-            this.assertIsDecimalAndEqualTo(d.v, 0);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), 0);
 
             b = System.Decimal.tryParse("12.", null, d);
             Bridge.Test.Assert.true(b);
-            this.assertIsDecimalAndEqualTo(d.v, 12);
+            this.assertIsDecimalAndEqualTo(Bridge.box(d.v, System.Decimal, $box_.System.Decimal.toString), 12);
 
             //b = decimal.TryParse("999999999999999999999999999999", out d);
             //Assert.False(b);
             //AssertIsDecimalAndEqualTo(d, 0);
         },
         roundWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(3.2), 6), 3);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(4.5), 6), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(3.2), 6), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(4.5), 6), System.Decimal, $box_.System.Decimal.toString), 4);
         },
         roundWithDecimalsWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.2209), 2, 6), 3.22);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(0.2209), 2, 6), 0.22);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(3.225), 2, 6), 3.22);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.2209), 2, 6), System.Decimal, $box_.System.Decimal.toString), 3.22);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(0.2209), 2, 6), System.Decimal, $box_.System.Decimal.toString), 0.22);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(3.225), 2, 6), System.Decimal, $box_.System.Decimal.toString), 3.22);
         },
         roundWithMidpointRoundingWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(4.5), 4), 5);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-4.5), 4), -5);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(4.5), 6), 4);
-            this.assertIsDecimalAndEqualTo(System.Decimal.round(System.Decimal(-4.5), 6), -4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(4.5), 4), System.Decimal, $box_.System.Decimal.toString), 5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-4.5), 4), System.Decimal, $box_.System.Decimal.toString), -5);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(4.5), 6), System.Decimal, $box_.System.Decimal.toString), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.round(System.Decimal(-4.5), 6), System.Decimal, $box_.System.Decimal.toString), -4);
         },
         roundWithDecimalsAndMidpointRoundingWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(4.225), 2, 4), 4.23);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-4.225), 2, 4), -4.23);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(4.2249), 2, 4), 4.22);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-4.2249), 2, 4), -4.22);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(4.225), 2, 6), 4.22);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-4.225), 2, 6), -4.22);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(4.2251), 2, 6), 4.23);
-            this.assertIsDecimalAndEqualTo(System.Decimal.toDecimalPlaces(System.Decimal(-4.2251), 2, 6), -4.23);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(4.225), 2, 4), System.Decimal, $box_.System.Decimal.toString), 4.23);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-4.225), 2, 4), System.Decimal, $box_.System.Decimal.toString), -4.23);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(4.2249), 2, 4), System.Decimal, $box_.System.Decimal.toString), 4.22);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-4.2249), 2, 4), System.Decimal, $box_.System.Decimal.toString), -4.22);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(4.225), 2, 6), System.Decimal, $box_.System.Decimal.toString), 4.22);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-4.225), 2, 6), System.Decimal, $box_.System.Decimal.toString), -4.22);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(4.2251), 2, 6), System.Decimal, $box_.System.Decimal.toString), 4.23);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal.toDecimalPlaces(System.Decimal(-4.2251), 2, 6), System.Decimal, $box_.System.Decimal.toString), -4.23);
         },
         truncateWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.9).trunc(), 3);
-            this.assertIsDecimalAndEqualTo(System.Decimal(-3.9).trunc(), -3);
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).trunc(), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.9).trunc(), System.Decimal, $box_.System.Decimal.toString), 3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(-3.9).trunc(), System.Decimal, $box_.System.Decimal.toString), -3);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(3.0).trunc(), System.Decimal, $box_.System.Decimal.toString), 3);
         },
         subtractWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(7.0).sub(System.Decimal(3.0)), 4);
+            this.assertIsDecimalAndEqualTo(Bridge.box(System.Decimal(7.0).sub(System.Decimal(3.0)), System.Decimal, $box_.System.Decimal.toString), 4);
         },
         getHashCodeWorks: function () {
             Bridge.Test.Assert.areEqual(Bridge.getHashCode((System.Decimal(0.0))), Bridge.getHashCode((System.Decimal(0.0))));
@@ -17264,10 +17262,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((System.Decimal(0.5))), Bridge.getHashCode((System.Decimal(0.0))));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((System.Decimal(0.0)), System.Decimal(0.0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(1.0)), System.Decimal(0.0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(0.0)), System.Decimal(0.5)));
-            Bridge.Test.Assert.true(Bridge.equals((System.Decimal(1.0)), System.Decimal(1.0)));
+            Bridge.Test.Assert.true(Bridge.equals((System.Decimal(0.0)), Bridge.unbox(Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(1.0)), Bridge.unbox(Bridge.box(System.Decimal(0.0), System.Decimal, $box_.System.Decimal.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((System.Decimal(0.0)), Bridge.unbox(Bridge.box(System.Decimal(0.5), System.Decimal, $box_.System.Decimal.toString))));
+            Bridge.Test.Assert.true(Bridge.equals((System.Decimal(1.0)), Bridge.unbox(Bridge.box(System.Decimal(1.0), System.Decimal, $box_.System.Decimal.toString))));
         },
         staticEqualsWorks: function () {
             Bridge.Test.Assert.true(System.Decimal(0).equals(System.Decimal(0)));
@@ -17940,13 +17938,13 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.DoubleTests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(0.5, System.Double));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Double));
             Bridge.Test.Assert.areEqual("System.Double", Bridge.Reflection.getTypeFullName(System.Double));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.Double));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.Double), System.Double));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.Double), System.Double));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.Double));
-            var d = 0.0;
+            var d = Bridge.box(0.0, System.Double, $box_.System.Double.toString);
             Bridge.Test.Assert.true(Bridge.is(d, System.Double));
             Bridge.Test.Assert.true(Bridge.is(d, System.IComparable$1(System.Double)));
             Bridge.Test.Assert.true(Bridge.is(d, System.IEquatable$1(System.Double)));
@@ -17969,8 +17967,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         constantsWork: function () {
             var zero = 0;
-            Bridge.Test.Assert.true$1(System.Double.min < System.Nullable.getValue(Bridge.cast(-1.7E+308, System.Double)), "MinValue should be correct");
-            Bridge.Test.Assert.true$1(System.Double.max > System.Nullable.getValue(Bridge.cast(1.7E+308, System.Double)), "MaxValue should be correct");
+            Bridge.Test.Assert.true$1(System.Double.min < System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(-1.7E+308, System.Double, $box_.System.Double.toString)), System.Double)), "MinValue should be correct");
+            Bridge.Test.Assert.true$1(System.Double.max > System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(1.7E+308, System.Double, $box_.System.Double.toString)), System.Double)), "MaxValue should be correct");
             // Not C# API
             //Assert.AreEqual(double.JsMinValue, 5e-324, "MinValue should be correct");
             Bridge.Test.Assert.areEqual$1(4.94065645841247E-324, 4.94065645841247E-324, "MinValue should be correct");
@@ -18056,10 +18054,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((0.5)), Bridge.getHashCode((0.0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0.0), 0.0));
-            Bridge.Test.Assert.false(Bridge.equals((1.0), 0.0));
-            Bridge.Test.Assert.false(Bridge.equals((0.0), 0.5));
-            Bridge.Test.Assert.true(Bridge.equals((1.0), 1.0));
+            Bridge.Test.Assert.true(Bridge.equals((0.0), Bridge.unbox(Bridge.box(0.0, System.Double, $box_.System.Double.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((1.0), Bridge.unbox(Bridge.box(0.0, System.Double, $box_.System.Double.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((0.0), Bridge.unbox(Bridge.box(0.5, System.Double, $box_.System.Double.toString))));
+            Bridge.Test.Assert.true(Bridge.equals((1.0), Bridge.unbox(Bridge.box(1.0, System.Double, $box_.System.Double.toString))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0.0) === 0.0);
@@ -18094,7 +18092,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.false(Bridge.Reflection.isFlags(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum));
             Bridge.Test.Assert.true(Bridge.Reflection.isEnum(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum));
             Bridge.Test.Assert.true(Bridge.Reflection.isFlags(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum));
-            Bridge.Test.Assert.true(Bridge.is(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.FirstValue, System.Int32));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.FirstValue, Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum, $box_.Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.toString), System.Int32));
 
             var interfaces = Bridge.Reflection.getInterfaces(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum);
             Bridge.Test.Assert.areEqual(0, interfaces.length);
@@ -18122,8 +18120,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.FirstValue, 0);
         },
         parseWorks: function () {
-            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.FirstValue, System.Nullable.getValue(Bridge.cast(System.Enum.parse(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum, "FirstValue"), System.Int32)));
-            Bridge.Test.Assert.areEqual(5, System.Nullable.getValue(Bridge.cast(System.Enum.parse(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum, "FirstValue, ThirdValue"), System.Int32)));
+            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.FirstValue, System.Nullable.getValue(Bridge.cast(Bridge.unbox(System.Enum.parse(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum, "FirstValue")), System.Int32)));
+            Bridge.Test.Assert.areEqual(5, System.Nullable.getValue(Bridge.cast(Bridge.unbox(System.Enum.parse(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum, "FirstValue, ThirdValue")), System.Int32)));
         },
         staticToStringWorks: function () {
             Bridge.Test.Assert.areEqual("FirstValue", System.Enum.toString(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum, Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.FirstValue));
@@ -18138,23 +18136,23 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.false(Bridge.equals(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.FirstValue, Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.SecondValue));
         },
         conversionsToEnumAreTreatedAsConversionsToTheUnderlyingType_SPI_1596: function () {
-            Bridge.Test.Assert.areEqual(0, System.Nullable.getValue(Bridge.cast(0, System.Int32)));
+            Bridge.Test.Assert.areEqual(0, System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(0, System.Int32)), System.Int32)));
             // #1596
             Bridge.Test.Assert.throws$6(System.InvalidCastException, $_.Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.f1);
         },
         getValuesWorks: function () {
             var values = System.Enum.getValues(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum);
             Bridge.Test.Assert.areEqual(3, values.length);
-            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.FirstValue, System.Array.get(values, 0));
-            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.SecondValue, System.Array.get(values, 1));
-            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.ThirdValue, System.Array.get(values, 2));
+            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.FirstValue, Bridge.unbox(System.Array.get(values, 0)));
+            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.SecondValue, Bridge.unbox(System.Array.get(values, 1)));
+            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum.ThirdValue, Bridge.unbox(System.Array.get(values, 2)));
 
             values = System.Enum.getValues(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum);
             Bridge.Test.Assert.areEqual(4, values.length);
-            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum.None, System.Array.get(values, 0));
-            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum.FirstValue, System.Array.get(values, 1));
-            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum.SecondValue, System.Array.get(values, 2));
-            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum.ThirdValue, System.Array.get(values, 3));
+            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum.None, Bridge.unbox(System.Array.get(values, 0)));
+            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum.FirstValue, Bridge.unbox(System.Array.get(values, 1)));
+            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum.SecondValue, Bridge.unbox(System.Array.get(values, 2)));
+            Bridge.Test.Assert.areEqual(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.FlagsEnum.ThirdValue, Bridge.unbox(System.Array.get(values, 3)));
         }
     });
 
@@ -18162,7 +18160,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.apply($_.Bridge.ClientTest.Batch4.SimpleTypes.EnumTests, {
         f1: function () {
-            var _ = System.Nullable.getValue(Bridge.cast(0.5, System.Int32));
+            var _ = System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(0.5, System.Double, $box_.System.Double.toString)), System.Int32));
         }
     });
 
@@ -18188,16 +18186,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.Int16Tests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.Int16));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Int16));
-            Bridge.Test.Assert.false(Bridge.is(-32769, System.Int16));
-            Bridge.Test.Assert.false(Bridge.is(32768, System.Int16));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.Int16), System.Int16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Int16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-32769, System.Int32), System.Int16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(32768, System.Int32), System.Int16));
             Bridge.Test.Assert.areEqual("System.Int16", Bridge.Reflection.getTypeFullName(System.Int16));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.Int16));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.Int16), System.Int16));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.Int16), System.Int16));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.Int16));
-            var s = 0;
+            var s = Bridge.box(0, System.Int16);
             Bridge.Test.Assert.true(Bridge.is(s, System.Int16));
             Bridge.Test.Assert.true(Bridge.is(s, System.IComparable$1(System.Int16)));
             Bridge.Test.Assert.true(Bridge.is(s, System.IEquatable$1(System.Int16)));
@@ -18329,10 +18327,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.Int16))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.Int16))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.Int16))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.Int16))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -18382,16 +18380,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.Int32Tests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.Int32));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Int32));
-            Bridge.Test.Assert.false(Bridge.is(System.Int64([2147483647,-1]), System.Int32));
-            Bridge.Test.Assert.false(Bridge.is(2147483648, System.Int32));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.Int32), System.Int32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Int32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(System.Int64([2147483647,-1]), System.Int64), System.Int32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(2147483648, System.UInt32), System.Int32));
             Bridge.Test.Assert.areEqual("System.Int32", Bridge.Reflection.getTypeFullName(System.Int32));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.Int32));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.Int32), System.Int32));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.Int32), System.Int32));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.Int32));
-            var i = 0;
+            var i = Bridge.box(0, System.Int32);
             Bridge.Test.Assert.true(Bridge.is(i, System.Int32));
             Bridge.Test.Assert.true(Bridge.is(i, System.IComparable$1(System.Int32)));
             Bridge.Test.Assert.true(Bridge.is(i, System.IEquatable$1(System.Int32)));
@@ -18443,29 +18441,29 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         typeIsWorksForInt32: function () {
             Bridge.Test.Assert.false(Bridge.is(null, System.Int32));
-            Bridge.Test.Assert.false(Bridge.is(1.5, System.Int32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(1.5, System.Double, $box_.System.Double.toString), System.Int32));
             Bridge.Test.Assert.false(Bridge.is({  }, System.Int32));
-            Bridge.Test.Assert.true(Bridge.is(1, System.Int32));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(1, System.Int32), System.Int32));
         },
         typeAsWorksForInt32: function () {
             Bridge.Test.Assert.false((null) != null);
             Bridge.Test.Assert.false((Bridge.as({  }, System.Int32, true)) != null);
-            Bridge.Test.Assert.false((Bridge.as(1.5, System.Int32, true)) != null);
+            Bridge.Test.Assert.false((Bridge.as(Bridge.box(1.5, System.Double, $box_.System.Double.toString), System.Int32, true)) != null);
             Bridge.Test.Assert.true((Bridge.as(1, System.Int32, true)) != null);
         },
         unboxingWorksForInt32: function () {
             var _null = null;
             var o = {  };
-            var d = 1.5;
-            var i = 1;
-            Bridge.Test.Assert.areEqual(null, Bridge.cast(_null, System.Int32, true));
+            var d = Bridge.box(1.5, System.Double, $box_.System.Double.toString);
+            var i = Bridge.box(1, System.Int32);
+            Bridge.Test.Assert.areEqual(null, Bridge.cast(Bridge.unbox(_null), System.Int32, true));
             Bridge.Test.Assert.throws(function () {
-                var _ = Bridge.cast(o, System.Int32, true);
+                var _ = Bridge.cast(Bridge.unbox(o), System.Int32, true);
             });
             Bridge.Test.Assert.throws(function () {
-                var _ = Bridge.cast(d, System.Int32, true);
+                var _ = Bridge.cast(Bridge.unbox(d), System.Int32, true);
             });
-            Bridge.Test.Assert.areEqual(1, Bridge.cast(i, System.Int32, true));
+            Bridge.Test.Assert.areEqual(1, Bridge.cast(Bridge.unbox(i), System.Int32, true));
         },
         getDefaultValue: function (T) {
             return Bridge.getDefaultValue(T);
@@ -18545,10 +18543,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.Int32))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.Int32))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.Int32))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.Int32))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -18637,15 +18635,15 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.Int64Tests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(System.Int64(0), System.Int64));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.Int64));
-            Bridge.Test.Assert.false(Bridge.is(1E+100, System.Int64));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(System.Int64(0), System.Int64), System.Int64));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.Int64));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(1E+100, System.Double, $box_.System.Double.toString), System.Int64));
             Bridge.Test.Assert.areEqual("System.Int64", Bridge.Reflection.getTypeFullName(System.Int64));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.Int64));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.Int64), System.Int64));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.Int64), System.Int64));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.Int64));
-            var l = System.Int64(0);
+            var l = Bridge.box(System.Int64(0), System.Int64);
             Bridge.Test.Assert.true(Bridge.is(l, System.Int64));
             Bridge.Test.Assert.true(Bridge.is(l, System.IComparable$1(System.Int64)));
             Bridge.Test.Assert.true(Bridge.is(l, System.IEquatable$1(System.Int64)));
@@ -18775,10 +18773,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true(System.Int64(Bridge.getHashCode(System.Int64([0,1]))).lte(System.Int64([-1,0])));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((System.Int64(0)), System.Int64(0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.Int64(1)), System.Int64(0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.Int64(0)), System.Int64(1)));
-            Bridge.Test.Assert.true(Bridge.equals((System.Int64(1)), System.Int64(1)));
+            Bridge.Test.Assert.true(Bridge.equals((System.Int64(0)), Bridge.unbox(Bridge.box(System.Int64(0), System.Int64))));
+            Bridge.Test.Assert.false(Bridge.equals((System.Int64(1)), Bridge.unbox(Bridge.box(System.Int64(0), System.Int64))));
+            Bridge.Test.Assert.false(Bridge.equals((System.Int64(0)), Bridge.unbox(Bridge.box(System.Int64(1), System.Int64))));
+            Bridge.Test.Assert.true(Bridge.equals((System.Int64(1)), Bridge.unbox(Bridge.box(System.Int64(1), System.Int64))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((System.Int64(0)).equalsT(System.Int64(0)));
@@ -18835,7 +18833,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         canGetHashCodeForObject: function () {
             var o = {  };
             var c = Bridge.getHashCode(o);
-            Bridge.Test.Assert.true(Bridge.is(c, System.Int32));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(c, System.Int32), System.Int32));
         },
         repeatedCallsToGetHashCodeReturnsSameValue: function () {
             var o = {  };
@@ -18843,27 +18841,27 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         objectIsEqualToItself: function () {
             var o = {  };
-            Bridge.Test.Assert.true(Bridge.equals(o, o));
+            Bridge.Test.Assert.true(Bridge.equals(o, Bridge.unbox(o)));
         },
         objectIsNotEqualToOtherObject: function () {
-            Bridge.Test.Assert.false(Bridge.equals({  }, {  }));
+            Bridge.Test.Assert.false(Bridge.equals({  }, Bridge.unbox({  })));
         },
         staticEqualsWorks: function () {
             var o1 = {  }, o2 = {  };
             Bridge.Test.Assert.true(Bridge.equals(null, null));
-            Bridge.Test.Assert.false(Bridge.equals(null, o1));
-            Bridge.Test.Assert.false(Bridge.equals(o1, null));
-            Bridge.Test.Assert.true(Bridge.equals(o1, o1));
-            Bridge.Test.Assert.false(Bridge.equals(o1, o2));
+            Bridge.Test.Assert.false(Bridge.equals(null, Bridge.unbox(o1)));
+            Bridge.Test.Assert.false(Bridge.equals(Bridge.unbox(o1), null));
+            Bridge.Test.Assert.true(Bridge.equals(Bridge.unbox(o1), Bridge.unbox(o1)));
+            Bridge.Test.Assert.false(Bridge.equals(Bridge.unbox(o1), Bridge.unbox(o2)));
         },
         referenceEqualsWorks: function () {
             var o1 = {  }, o2 = {  }, n = null;
-            Bridge.Test.Assert.true(Bridge.referenceEquals(n, n));
-            Bridge.Test.Assert.true(Bridge.referenceEquals(n, undefined));
-            Bridge.Test.Assert.false(Bridge.referenceEquals(o1, o2));
-            Bridge.Test.Assert.false(Bridge.referenceEquals(o1, n));
-            Bridge.Test.Assert.false(Bridge.referenceEquals(o1, undefined));
-            Bridge.Test.Assert.true(Bridge.referenceEquals(o1, o1));
+            Bridge.Test.Assert.true(Bridge.referenceEquals(Bridge.unbox(n), Bridge.unbox(n)));
+            Bridge.Test.Assert.true(Bridge.referenceEquals(Bridge.unbox(n), Bridge.unbox(undefined)));
+            Bridge.Test.Assert.false(Bridge.referenceEquals(Bridge.unbox(o1), Bridge.unbox(o2)));
+            Bridge.Test.Assert.false(Bridge.referenceEquals(Bridge.unbox(o1), Bridge.unbox(n)));
+            Bridge.Test.Assert.false(Bridge.referenceEquals(Bridge.unbox(o1), Bridge.unbox(undefined)));
+            Bridge.Test.Assert.true(Bridge.referenceEquals(Bridge.unbox(o1), Bridge.unbox(o1)));
         },
         toStringOverride: function () {
             var c1 = new Bridge.ClientTest.Batch4.SimpleTypes.ObjectTests.C1(), c2 = new Bridge.ClientTest.Batch4.SimpleTypes.ObjectTests.C2();
@@ -18880,16 +18878,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.SByteTests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.SByte));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.SByte));
-            Bridge.Test.Assert.false(Bridge.is(-129, System.SByte));
-            Bridge.Test.Assert.false(Bridge.is(128, System.SByte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0, System.Byte), System.SByte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.SByte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-129, System.Int32), System.SByte));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(128, System.Int32), System.SByte));
             Bridge.Test.Assert.areEqual("System.SByte", Bridge.Reflection.getTypeFullName(System.SByte));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.SByte));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.SByte), System.SByte));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.SByte), System.SByte));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.SByte));
-            var b = 0;
+            var b = Bridge.box(0, System.SByte);
             Bridge.Test.Assert.true(Bridge.is(b, System.SByte));
             Bridge.Test.Assert.true(Bridge.is(b, System.IComparable$1(System.SByte)));
             Bridge.Test.Assert.true(Bridge.is(b, System.IEquatable$1(System.SByte)));
@@ -19020,10 +19018,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.SByte))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.SByte))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.SByte))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.SByte))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -19070,13 +19068,13 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.SingleTests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(0.5, System.Single));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0.5, System.Single, $box_.System.Single.toString), System.Single));
             Bridge.Test.Assert.areEqual("System.Single", Bridge.Reflection.getTypeFullName(System.Single));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.Single));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.Single), System.Single));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.Single), System.Single));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.Single));
-            var f = 0.0;
+            var f = Bridge.box(0.0, System.Single, $box_.System.Single.toString);
             Bridge.Test.Assert.true(Bridge.is(f, System.Single));
             Bridge.Test.Assert.true(Bridge.is(f, System.IComparable$1(System.Single)));
             Bridge.Test.Assert.true(Bridge.is(f, System.IEquatable$1(System.Single)));
@@ -19099,8 +19097,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         constantsWork: function () {
             var zero = 0;
-            Bridge.Test.Assert.true$1(System.Nullable.getValue(Bridge.cast(-3.40282347E+38, System.Single)) < -3.4E+38 && System.Nullable.getValue(Bridge.cast(-3.40282347E+38, System.Single)) > -3.5E+38, "MinValue should be correct");
-            Bridge.Test.Assert.true$1(System.Nullable.getValue(Bridge.cast(3.40282347E+38, System.Single)) > 3.4E+38 && System.Nullable.getValue(Bridge.cast(3.40282347E+38, System.Single)) < 3.5E+38, "MaxValue should be correct");
+            Bridge.Test.Assert.true$1(System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(-3.40282347E+38, System.Single, $box_.System.Single.toString)), System.Single)) < -3.4E+38 && System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(-3.40282347E+38, System.Single, $box_.System.Single.toString)), System.Single)) > -3.5E+38, "MinValue should be correct");
+            Bridge.Test.Assert.true$1(System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(3.40282347E+38, System.Single, $box_.System.Single.toString)), System.Single)) > 3.4E+38 && System.Nullable.getValue(Bridge.cast(Bridge.unbox(Bridge.box(3.40282347E+38, System.Single, $box_.System.Single.toString)), System.Single)) < 3.5E+38, "MaxValue should be correct");
             Bridge.Test.Assert.areEqual$1(1.401298E-45, 1.401298E-45, "Epsilon should be correct");
             Bridge.Test.Assert.true$1(isNaN(Number.NaN), "NaN should be correct");
             Bridge.Test.Assert.areStrictEqual$1(1 / zero, Number.POSITIVE_INFINITY, "PositiveInfinity should be correct");
@@ -19184,10 +19182,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((0.5)), Bridge.getHashCode((0.0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0.0), 0.0));
-            Bridge.Test.Assert.false(Bridge.equals((1.0), 0.0));
-            Bridge.Test.Assert.false(Bridge.equals((0.0), 0.5));
-            Bridge.Test.Assert.true(Bridge.equals((1.0), 1.0));
+            Bridge.Test.Assert.true(Bridge.equals((0.0), Bridge.unbox(Bridge.box(0.0, System.Single, $box_.System.Single.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((1.0), Bridge.unbox(Bridge.box(0.0, System.Single, $box_.System.Single.toString))));
+            Bridge.Test.Assert.false(Bridge.equals((0.0), Bridge.unbox(Bridge.box(0.5, System.Single, $box_.System.Single.toString))));
+            Bridge.Test.Assert.true(Bridge.equals((1.0), Bridge.unbox(Bridge.box(1.0, System.Single, $box_.System.Single.toString))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0.0) === 0.0);
@@ -19352,12 +19350,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual("xabcd", System.String.format.apply(System.String, ["x{0}{1}{2}{3}"].concat(arr4)));
         },
         formatWorksWithIFormattable_SPI_1598: function () {
-            Bridge.Test.Assert.areEqual("3.14", System.String.format("{0:F2}", 3.1428571428571428));
+            Bridge.Test.Assert.areEqual("3.14", System.String.format("{0:F2}", Bridge.box(3.1428571428571428, System.Double, $box_.System.Double.toString)));
             // #1598
             Bridge.Test.Assert.areEqual("Formatted: FMT, null formatProvider", System.String.format("{0:FMT}", new Bridge.ClientTest.Batch4.SimpleTypes.StringTests.MyFormattable()));
         },
         formatWorksWithIFormattableAndFormatProvider_SPI_1598: function () {
-            Bridge.Test.Assert.areEqual("3.14", System.String.formatProvider(new Bridge.ClientTest.Batch4.SimpleTypes.StringTests.MyFormatProvider(), "{0:F2}", 3.1428571428571428));
+            Bridge.Test.Assert.areEqual("3.14", System.String.formatProvider(new Bridge.ClientTest.Batch4.SimpleTypes.StringTests.MyFormatProvider(), "{0:F2}", Bridge.box(3.1428571428571428, System.Double, $box_.System.Double.toString)));
             // #1598
             Bridge.Test.Assert.areEqual("Formatted: FMT, StringTests$MyFormatProvider", System.String.formatProvider(new Bridge.ClientTest.Batch4.SimpleTypes.StringTests.MyFormatProvider(), "{0:FMT}", new Bridge.ClientTest.Batch4.SimpleTypes.StringTests.MyFormattable()));
         },
@@ -19637,12 +19635,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.true(System.Int64(Bridge.getHashCode(("abcdefghijklmnopq"))).lt(System.Int64([-1,0])));
         },
         instanceEqualsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals(("a"), "a"));
-            Bridge.Test.Assert.false(Bridge.equals(("b"), "a"));
-            Bridge.Test.Assert.false(Bridge.equals(("a"), "b"));
-            Bridge.Test.Assert.true(Bridge.equals(("b"), "b"));
-            Bridge.Test.Assert.false(Bridge.equals(("a"), "A"));
-            Bridge.Test.Assert.false(Bridge.equals(("a"), "ab"));
+            Bridge.Test.Assert.true(Bridge.equals(("a"), Bridge.unbox("a")));
+            Bridge.Test.Assert.false(Bridge.equals(("b"), Bridge.unbox("a")));
+            Bridge.Test.Assert.false(Bridge.equals(("a"), Bridge.unbox("b")));
+            Bridge.Test.Assert.true(Bridge.equals(("b"), Bridge.unbox("b")));
+            Bridge.Test.Assert.false(Bridge.equals(("a"), Bridge.unbox("A")));
+            Bridge.Test.Assert.false(Bridge.equals(("a"), Bridge.unbox("ab")));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true(System.String.equals(("a"), "a"));
@@ -19687,7 +19685,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual("a, ab, abc, abcd", Bridge.toArray(stringValues).join(", "));
 
             // TODO: c# makes it False but js false
-            Bridge.Test.Assert.areEqual("a, 1, abc, false", ["a", 1, "abc", false].join(", ")); // False");
+            Bridge.Test.Assert.areEqual("a, 1, abc, false", ["a", Bridge.box(1, System.Int32), "abc", Bridge.box(false, Boolean, $box_.Boolean.toString)].join(", ")); // False");
         },
         containsWorks: function () {
             var text = "Lorem ipsum dolor sit amet";
@@ -19759,7 +19757,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.TimeSpan));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.TimeSpan), System.TimeSpan));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.TimeSpan), System.TimeSpan));
-            var d = new System.TimeSpan();
+            var d = Bridge.box(new System.TimeSpan(), System.TimeSpan);
             Bridge.Test.Assert.true(Bridge.is(d, System.TimeSpan));
             Bridge.Test.Assert.true(Bridge.is(d, System.IComparable$1(System.TimeSpan)));
             Bridge.Test.Assert.true(Bridge.is(d, System.IEquatable$1(System.TimeSpan)));
@@ -19787,44 +19785,44 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         parameterConstructorsWorks: function () {
             var time = new System.TimeSpan(System.Int64(34567));
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "ticks type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "ticks type");
             Bridge.Test.Assert.areEqual$1(System.Int64(34567), time.getTicks(), "ticks value");
 
             time = new System.TimeSpan(10, 20, 5);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "h, m, s type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "h, m, s type");
             Bridge.Test.Assert.areEqual$1(System.Int64([-1612154752,86]), time.getTicks(), "h, m, s value");
 
             time = new System.TimeSpan(15, 10, 20, 5);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "d, h, m, s type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "d, h, m, s type");
             Bridge.Test.Assert.areEqual$1(System.Int64([471513216,3104]), time.getTicks(), "d, h, m, s value");
 
             time = new System.TimeSpan(15, 10, 20, 5, 14);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "full type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "full type");
             Bridge.Test.Assert.areEqual$1(System.Int64([471653216,3104]), time.getTicks(), "full value");
         },
         factoryMethodsWork: function () {
             var time = System.TimeSpan.fromDays(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromDays type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromDays type");
             Bridge.Test.Assert.areEqual$1(System.Int64([2134720512,603]), time.getTicks(), "FromDays value");
 
             time = System.TimeSpan.fromHours(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromHours type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromHours type");
             Bridge.Test.Assert.areEqual$1(System.Int64([625817600,25]), time.getTicks(), "FromHours value");
 
             time = System.TimeSpan.fromMinutes(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromMinutes type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromMinutes type");
             Bridge.Test.Assert.areEqual$1(System.Int64(1800000000), time.getTicks(), "FromMinutes value");
 
             time = System.TimeSpan.fromSeconds(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromSeconds type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromSeconds type");
             Bridge.Test.Assert.areEqual$1(System.Int64(30000000), time.getTicks(), "FromSeconds value");
 
             time = System.TimeSpan.fromMilliseconds(3);
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromMilliseconds type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromMilliseconds type");
             Bridge.Test.Assert.areEqual$1(System.Int64(30000), time.getTicks(), "FromMilliseconds value");
 
             time = System.TimeSpan.fromTicks(System.Int64(3));
-            Bridge.Test.Assert.true$1(Bridge.is(time, System.TimeSpan), "FromTicks type");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time, System.TimeSpan), System.TimeSpan), "FromTicks type");
             Bridge.Test.Assert.areEqual$1(System.Int64(3), time.getTicks(), "FromTicks value");
         },
         propertiesWork: function () {
@@ -19882,8 +19880,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var time2 = new System.TimeSpan(14, 10, 20, 5, 14);
             var time3 = new System.TimeSpan(15, 10, 20, 5, 14);
 
-            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(time1, System.IEquatable$1(System.TimeSpan)), time2, System.TimeSpan));
-            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(time1, System.IEquatable$1(System.TimeSpan)), time3, System.TimeSpan));
+            Bridge.Test.Assert.false(Bridge.equalsT(Bridge.cast(Bridge.box(time1, System.TimeSpan), System.IEquatable$1(System.TimeSpan)), time2, System.TimeSpan));
+            Bridge.Test.Assert.true(Bridge.equalsT(Bridge.cast(Bridge.box(time1, System.TimeSpan), System.IEquatable$1(System.TimeSpan)), time3, System.TimeSpan));
         },
         toStringWorks: function () {
             var time1 = new System.TimeSpan(15, 10, 20, 5, 14);
@@ -19899,14 +19897,14 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var time1 = new System.TimeSpan(2, 3, 4, 5, 6);
             var time2 = new System.TimeSpan(3, 4, 5, 6, 7);
             var actual = time1.add(time2);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(457751013, actual.getTotalMilliseconds(), "TotalMilliseconds should be correct");
         },
         subtractWorks: function () {
             var time1 = new System.TimeSpan(4, 3, 7, 2, 6);
             var time2 = new System.TimeSpan(3, 4, 5, 6, 7);
             var actual = time1.subtract(time2);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(82915999, actual.getTotalMilliseconds(), "TotalMilliseconds should be correct");
         },
         durationWorks: function () {
@@ -19914,14 +19912,14 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var time2 = new System.TimeSpan(2, 1, 5, 4, 3);
             var actual1 = time1.duration();
             var actual2 = time2.duration();
-            Bridge.Test.Assert.true$1(Bridge.is(time1, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(time1, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(266465004, actual1.getTotalMilliseconds(), "Negative should be negated");
             Bridge.Test.Assert.areEqual$1(176704003, actual2.getTotalMilliseconds(), "Positive should be preserved");
         },
         negateWorks: function () {
             var time = new System.TimeSpan(-3, 2, -1, 5, -4);
             var actual = time.negate();
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(252055004, actual.getTotalMilliseconds(), "Ticks should be correct");
         },
         assertAlmostEqual: function (d1, d2) {
@@ -19967,26 +19965,26 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var time1 = new System.TimeSpan(2, 3, 4, 5, 6);
             var time2 = new System.TimeSpan(3, 4, 5, 6, 7);
             var actual = System.TimeSpan.add(time1, time2);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(457751013, actual.getTotalMilliseconds(), "TotalMilliseconds should be correct");
         },
         subtractionOperatorWorks: function () {
             var time1 = new System.TimeSpan(4, 3, 7, 2, 6);
             var time2 = new System.TimeSpan(3, 4, 5, 6, 7);
             var actual = System.TimeSpan.sub(time1, time2);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(82915999, actual.getTotalMilliseconds(), "TotalMilliseconds should be correct");
         },
         unaryPlusWorks: function () {
             var time = new System.TimeSpan(-3, 2, -1, 5, -4);
             var actual = System.TimeSpan.plus(time);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(-252055004, actual.getTotalMilliseconds(), "Ticks should be correct");
         },
         unaryMinusWorks: function () {
             var time = new System.TimeSpan(-3, 2, -1, 5, -4);
             var actual = System.TimeSpan.neg(time);
-            Bridge.Test.Assert.true$1(Bridge.is(actual, System.TimeSpan), "Should be TimeSpan");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(actual, System.TimeSpan), System.TimeSpan), "Should be TimeSpan");
             Bridge.Test.Assert.areEqual$1(252055004, actual.getTotalMilliseconds(), "Ticks should be correct");
         }
     });
@@ -20072,16 +20070,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.UInt16Tests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.UInt16));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.UInt16));
-            Bridge.Test.Assert.false(Bridge.is(-1, System.UInt16));
-            Bridge.Test.Assert.false(Bridge.is(65536, System.UInt16));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.UInt16), System.UInt16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.UInt16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-1, System.Int32), System.UInt16));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(65536, System.Int32), System.UInt16));
             Bridge.Test.Assert.areEqual("System.UInt16", Bridge.Reflection.getTypeFullName(System.UInt16));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.UInt16));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.UInt16), System.UInt16));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.UInt16), System.UInt16));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.UInt16));
-            var s = 0;
+            var s = Bridge.box(0, System.UInt16);
             Bridge.Test.Assert.true(Bridge.is(s, System.UInt16));
             Bridge.Test.Assert.true(Bridge.is(s, System.IComparable$1(System.UInt16)));
             Bridge.Test.Assert.true(Bridge.is(s, System.IEquatable$1(System.UInt16)));
@@ -20212,10 +20210,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.UInt16))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.UInt16))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.UInt16))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.UInt16))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -20265,16 +20263,16 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.UInt32Tests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(0, System.UInt32));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.UInt32));
-            Bridge.Test.Assert.false(Bridge.is(-1, System.UInt32));
-            Bridge.Test.Assert.false(Bridge.is(System.Int64([0,1]), System.UInt32));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(0, System.Int32), System.UInt32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.UInt32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(-1, System.Int32), System.UInt32));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(System.Int64([0,1]), System.Int64), System.UInt32));
             Bridge.Test.Assert.areEqual("System.UInt32", Bridge.Reflection.getTypeFullName(System.UInt32));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.UInt32));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.UInt32), System.UInt32));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.UInt32), System.UInt32));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.UInt32));
-            var i = 0;
+            var i = Bridge.box(0, System.UInt32);
             Bridge.Test.Assert.true(Bridge.is(i, System.UInt32));
             Bridge.Test.Assert.true(Bridge.is(i, System.IComparable$1(System.UInt32)));
             Bridge.Test.Assert.true(Bridge.is(i, System.IEquatable$1(System.UInt32)));
@@ -20401,10 +20399,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((1)), Bridge.getHashCode((0)));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((0), 0));
-            Bridge.Test.Assert.false(Bridge.equals((1), 0));
-            Bridge.Test.Assert.false(Bridge.equals((0), 1));
-            Bridge.Test.Assert.true(Bridge.equals((1), 1));
+            Bridge.Test.Assert.true(Bridge.equals((0), Bridge.unbox(Bridge.box(0, System.UInt32))));
+            Bridge.Test.Assert.false(Bridge.equals((1), Bridge.unbox(Bridge.box(0, System.UInt32))));
+            Bridge.Test.Assert.false(Bridge.equals((0), Bridge.unbox(Bridge.box(1, System.UInt32))));
+            Bridge.Test.Assert.true(Bridge.equals((1), Bridge.unbox(Bridge.box(1, System.UInt32))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((0) === 0);
@@ -20454,14 +20452,14 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.SimpleTypes.UInt64Tests", {
         typePropertiesAreCorrect_SPI_1717: function () {
-            Bridge.Test.Assert.true(Bridge.is(System.UInt64(0), System.UInt64));
-            Bridge.Test.Assert.false(Bridge.is(0.5, System.UInt64));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(System.UInt64(0), System.UInt64), System.UInt64));
+            Bridge.Test.Assert.false(Bridge.is(Bridge.box(0.5, System.Double, $box_.System.Double.toString), System.UInt64));
             Bridge.Test.Assert.areEqual("System.UInt64", Bridge.Reflection.getTypeFullName(System.UInt64));
             Bridge.Test.Assert.false(Bridge.Reflection.isClass(System.UInt64));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IComparable$1(System.UInt64), System.UInt64));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IEquatable$1(System.UInt64), System.UInt64));
             Bridge.Test.Assert.true(Bridge.Reflection.isAssignableFrom(System.IFormattable, System.UInt64));
-            var l = System.UInt64(0);
+            var l = Bridge.box(System.UInt64(0), System.UInt64);
             Bridge.Test.Assert.true(Bridge.is(l, System.UInt64));
             Bridge.Test.Assert.true(Bridge.is(l, System.IComparable$1(System.UInt64)));
             Bridge.Test.Assert.true(Bridge.is(l, System.IEquatable$1(System.UInt64)));
@@ -20592,10 +20590,10 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areNotEqual(Bridge.getHashCode((System.UInt64(1))), Bridge.getHashCode((System.UInt64(0))));
         },
         equalsWorks: function () {
-            Bridge.Test.Assert.true(Bridge.equals((System.UInt64(0)), System.UInt64(0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.UInt64(1)), System.UInt64(0)));
-            Bridge.Test.Assert.false(Bridge.equals((System.UInt64(0)), System.UInt64(1)));
-            Bridge.Test.Assert.true(Bridge.equals((System.UInt64(1)), System.UInt64(1)));
+            Bridge.Test.Assert.true(Bridge.equals((System.UInt64(0)), Bridge.unbox(Bridge.box(System.UInt64(0), System.UInt64))));
+            Bridge.Test.Assert.false(Bridge.equals((System.UInt64(1)), Bridge.unbox(Bridge.box(System.UInt64(0), System.UInt64))));
+            Bridge.Test.Assert.false(Bridge.equals((System.UInt64(0)), Bridge.unbox(Bridge.box(System.UInt64(1), System.UInt64))));
+            Bridge.Test.Assert.true(Bridge.equals((System.UInt64(1)), Bridge.unbox(Bridge.box(System.UInt64(1), System.UInt64))));
         },
         iEquatableEqualsWorks: function () {
             Bridge.Test.Assert.true((System.UInt64(0)).equalsT(System.UInt64(0)));
@@ -20696,7 +20694,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         getTimestampWorks: function () {
             var t1 = System.Diagnostics.Stopwatch.getTimestamp();
-            Bridge.Test.Assert.true$1(Bridge.is(t1, System.Int64), "is long");
+            Bridge.Test.Assert.true$1(Bridge.is(Bridge.box(t1, System.Int64), System.Int64), "is long");
 
             var before = new Date();
             while ((Bridge.Date.subdd(new Date(), before)).getMilliseconds() < 50) {
@@ -21325,7 +21323,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         typePropertiesForCancellationTokenRegistrationAreCorrect: function () {
             Bridge.Test.Assert.areEqual$1("System.Threading.CancellationTokenRegistration", Bridge.Reflection.getTypeFullName(System.Threading.CancellationTokenRegistration), "FullName");
 
-            var ctr = new System.Threading.CancellationTokenRegistration();
+            var ctr = Bridge.box(new System.Threading.CancellationTokenRegistration(), System.Threading.CancellationTokenRegistration);
             Bridge.Test.Assert.true$1(Bridge.is(ctr, System.Threading.CancellationTokenRegistration), "CancellationTokenRegistration");
             Bridge.Test.Assert.true$1(Bridge.is(ctr, System.IDisposable), "IDisposable");
             Bridge.Test.Assert.true$1(Bridge.is(ctr, System.IEquatable$1(System.Threading.CancellationTokenRegistration)), "IEquatable<CancellationTokenRegistration>");
@@ -21522,9 +21520,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             cts.cancel();
             var state = 0;
             cts.token.register(function (c) {
-                Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                 state = 1;
-            }, context);
+            }, Bridge.unbox(context));
             Bridge.Test.Assert.areEqual(1, state);
         },
         registerOnACancelledSourceWithoutContextRethrowsAThrownException: function () {
@@ -21549,9 +21547,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             cts.cancel();
             try {
                 cts.token.register(function (c) {
-                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                     throw ex1;
-                }, context);
+                }, Bridge.unbox(context));
                 Bridge.Test.Assert.fail$1("Should have thrown");
             }
             catch (ex) {
@@ -21571,13 +21569,13 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 Bridge.identity(numCalled, (numCalled = (numCalled + 1) | 0));
             }, false);
             cts.token.register(function (c) {
-                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                     numCalled = (numCalled + 1) | 0;
-                }, context);
+                }, Bridge.unbox(context));
             cts.token.register(function (c) {
-                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                    Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                     numCalled = (numCalled + 1) | 0;
-                }, context);
+                }, Bridge.unbox(context));
             Bridge.Test.Assert.areEqual(4, numCalled);
         },
         cancellationTokenSourceCanBeDisposed: function () {
@@ -21606,9 +21604,9 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             });
             Bridge.Test.Assert.areEqual$1(1, state, "state 1");
             ct.register(function (c) {
-                Bridge.Test.Assert.true$1(Bridge.referenceEquals(context, c), "context");
+                Bridge.Test.Assert.true$1(Bridge.referenceEquals(Bridge.unbox(context), Bridge.unbox(c)), "context");
                 state = 2;
-            }, context);
+            }, Bridge.unbox(context));
             Bridge.Test.Assert.areEqual$1(2, state, "state 2");
         },
         duplicateCancelDoesNotCauseCallbacksToBeCalledTwice: function () {
@@ -21629,8 +21627,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
             Bridge.Test.Assert.true$1(ctr1.equalsT(ctr1), "#1");
             Bridge.Test.Assert.false$1(ctr1.equalsT(ctr2), "#2");
-            Bridge.Test.Assert.true$1(Bridge.equals(ctr1, ctr1), "#3");
-            Bridge.Test.Assert.false$1(Bridge.equals(ctr1, ctr2), "#4");
+            Bridge.Test.Assert.true$1(Bridge.equals(ctr1, Bridge.unbox(Bridge.box(ctr1, System.Threading.CancellationTokenRegistration))), "#3");
+            Bridge.Test.Assert.false$1(Bridge.equals(ctr1, Bridge.unbox(Bridge.box(ctr2, System.Threading.CancellationTokenRegistration))), "#4");
 
             Bridge.Test.Assert.true$1(Bridge.equals(ctr1, ctr1), "#5");
             Bridge.Test.Assert.false$1(Bridge.equals(ctr1, ctr2), "#6");
@@ -21755,12 +21753,12 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early.");
             Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, task.status, "Task should be running before promise is completed.");
-            promise.resolve([42, "result 123", 101]);
+            promise.resolve([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
 
             task1.continueWith(function (x) {
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.ranToCompletion, task.status, "Task should be completed after promise");
                 Bridge.Test.Assert.true$1(continuationRun, "Continuation should have been run after promise was completed.");
-                Bridge.Test.Assert.areDeepEqual$1([42, "result 123", 101], task.getResult(), "The result should be correct");
+                Bridge.Test.Assert.areDeepEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], task.getResult(), "The result should be correct");
 
                 completeAsync();
             });
@@ -21784,7 +21782,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early.");
             Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, task.status, "Task should be running before promise is completed.");
-            promise.resolve([42, "result 123", 101]);
+            promise.resolve([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
 
             task1.continueWith(function (x) {
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.ranToCompletion, task.status, "Task should be completed after promise");
@@ -21815,7 +21813,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early.");
             Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, task.status, "Task should be running before promise is completed.");
-            promise.reject([42, "result 123", 101]);
+            promise.reject([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
 
             task1.continueWith(function (x) {
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.faulted, task.status, "Task should have faulted after the promise was rejected.");
@@ -21823,7 +21821,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 Bridge.Test.Assert.true$1(Bridge.is(task.exception, System.AggregateException), "Exception should be an AggregateException");
                 Bridge.Test.Assert.areEqual$1(1, task.exception.innerExceptions.getCount(), "Exception should have one inner exception");
                 Bridge.Test.Assert.true$1(Bridge.is(task.exception.innerExceptions.get(0), Bridge.PromiseException), "Inner exception should be a PromiseException");
-                Bridge.Test.Assert.areDeepEqual$1([42, "result 123", 101], Bridge.cast(task.exception.innerExceptions.get(0), Bridge.PromiseException).arguments, "The PromiseException arguments should be correct");
+                Bridge.Test.Assert.areDeepEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], Bridge.cast(task.exception.innerExceptions.get(0), Bridge.PromiseException).arguments, "The PromiseException arguments should be correct");
 
                 completeAsync();
             });
@@ -21849,7 +21847,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
                                     task = System.Threading.Tasks.Task.run(function () {
                                         Bridge.Test.Assert.true$1(result == null, "Await should not finish too early (a).");
-                                        promise.resolve([42, "result 123", 101]);
+                                        promise.resolve([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
                                     });
 
                                     Bridge.Test.Assert.true$1(result == null, "Await should not finish too early (b).");
@@ -21863,7 +21861,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                                 $taskResult1 = $task1.getAwaitedResult();
                                 result = $taskResult1;
 
-                                    Bridge.Test.Assert.areEqual$1([42, "result 123", 101], result, "The result should be correct");
+                                    Bridge.Test.Assert.areEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], result, "The result should be correct");
                                     completeAsync();
                                 return;
                             }
@@ -21904,7 +21902,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
                                         task = System.Threading.Tasks.Task.run(function () {
                                             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early (a).");
-                                            promise.reject([42, "result 123", 101]);
+                                            promise.reject([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
                                         });
                                     $step = 1;
                                     continue;
@@ -21925,7 +21923,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                                 }
                                 case 3: {
                                     continuationRun = true;
-                                        Bridge.Test.Assert.areEqual$1([42, "result 123", 101], ex.arguments, "The PromiseException arguments should be correct");
+                                        Bridge.Test.Assert.areEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], ex.arguments, "The PromiseException arguments should be correct");
                                         $async_e = null;
                                     $step = 5;
                                     continue;
@@ -21971,7 +21969,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         },
         handleProgress: function (args) {
             if (args === void 0) { args = []; }
-            var i = System.Nullable.getValue(Bridge.cast(args[0], System.Int32));
+            var i = System.Nullable.getValue(Bridge.cast(Bridge.unbox(args[0]), System.Int32));
             this.setPromiseProgress(i);
         },
         taskFromPromiseWithProgressWithoutResultFactoryWorksWhenPromiseProgressesAndCompletes: function () {
@@ -21994,17 +21992,17 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.false$1(continuationRun, "Continuation should not be run too early.");
             Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, task.status, "Task should be running before promise is completed.");
 
-            promise.progress([20]);
+            promise.progress([Bridge.box(20, System.Int32)]);
             Bridge.Test.Assert.areEqual$1(20, this.getPromiseProgress(), "Progress 20");
 
             // Resolve will set Progress to 100%
-            promise.resolve([42, "result 123", 101]);
+            promise.resolve([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)]);
             Bridge.Test.Assert.areEqual$1(100, this.getPromiseProgress(), "Progress 100");
 
             task1.continueWith(function (x) {
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.ranToCompletion, task.status, "Task should be completed after promise");
                 Bridge.Test.Assert.true$1(continuationRun, "Continuation should have been run after promise was completed.");
-                Bridge.Test.Assert.areDeepEqual$1([42, "result 123", 101], task.getResult(), "The result should be correct");
+                Bridge.Test.Assert.areDeepEqual$1([Bridge.box(42, System.Int32), "result 123", Bridge.box(101, System.Int32)], task.getResult(), "The result should be correct");
 
                 completeAsync();
             });
@@ -22093,7 +22091,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 }
 
                 if (!Bridge.staticEquals(aThen.getProgress(), null)) {
-                    aThen.getProgress()([100]);
+                    aThen.getProgress()([Bridge.box(100, System.Int32)]);
                 }
 
                 i = (i + 1) | 0;
@@ -22668,7 +22666,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 Bridge.Test.Assert.areEqual$1(null, task.exception, "task should not have an exception");
                 Bridge.Test.Assert.areEqual$1(System.Threading.Tasks.TaskStatus.running, continuedTask.status, "continuedTask should be running at point 2");
 
-                return t.getResult() + "_";
+                return Bridge.box(t.getResult(), System.Int32) + "_";
             });
 
             Bridge.Test.Assert.false$1(Bridge.referenceEquals(task, continuedTask), "task and continuedTask should not be the same");
@@ -23551,7 +23549,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(0, s2.i, "I");
             Bridge.Test.Assert.areEqual$1(0, s2.d, "D");
             Bridge.Test.Assert.areEqual$1(Bridge.getDefaultValue(Date), s2.DT, "DT");
-            Bridge.Test.Assert.null$1(s2.o, "O");
+            Bridge.Test.Assert.null$1(Bridge.unbox(s2.o), "O");
             Bridge.Test.Assert.areEqual$1(0, s2.t, "T");
         },
         defaultConstructorOfStructReturnsInstanceWithAllMembersInitializedGeneric: function () {
@@ -23559,7 +23557,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(0, s2.i, "I");
             Bridge.Test.Assert.areEqual$1(0, s2.d, "D");
             Bridge.Test.Assert.areEqual$1(Bridge.getDefaultValue(Date), s2.DT, "DT");
-            Bridge.Test.Assert.null$1(s2.o, "O");
+            Bridge.Test.Assert.null$1(Bridge.unbox(s2.o), "O");
             Bridge.Test.Assert.areEqual$1(0, s2.t, "T");
         },
         defaultValueOfStructIsInstanceWithAllMembersInitialized: function () {
@@ -23567,7 +23565,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(0, s2.i, "I");
             Bridge.Test.Assert.areEqual$1(0, s2.d, "D");
             Bridge.Test.Assert.areEqual$1(Bridge.getDefaultValue(Date), s2.DT, "DT");
-            Bridge.Test.Assert.null$1(s2.o, "O");
+            Bridge.Test.Assert.null$1(Bridge.unbox(s2.o), "O");
             Bridge.Test.Assert.areEqual$1(0, s2.t, "T");
         },
         defaultValueOfStructIsInstanceWithAllMembersInitializedGeneric: function () {
@@ -23575,7 +23573,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(0, s2.i, "I");
             Bridge.Test.Assert.areEqual$1(0, s2.d, "D");
             Bridge.Test.Assert.areEqual$1(Bridge.getDefaultValue(Date), s2.DT, "DT");
-            Bridge.Test.Assert.null$1(s2.o, "O");
+            Bridge.Test.Assert.null$1(Bridge.unbox(s2.o), "O");
             Bridge.Test.Assert.areEqual$1(0, s2.t, "T");
         },
         defaultValueOfStructIsInstanceWithAllMembersInitializedIndirect: function () {
@@ -23583,7 +23581,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(0, s2.i, "I");
             Bridge.Test.Assert.areEqual$1(0, s2.d, "D");
             Bridge.Test.Assert.areEqual$1(Bridge.getDefaultValue(Date), s2.DT, "DT");
-            Bridge.Test.Assert.null$1(s2.o, "O");
+            Bridge.Test.Assert.null$1(Bridge.unbox(s2.o), "O");
             Bridge.Test.Assert.areEqual$1(0, s2.t, "T");
         },
         defaultValueOfStructIsInstanceWithAllMembersInitializedIndirectGeneric: function () {
@@ -23591,7 +23589,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1(0, s2.i, "I");
             Bridge.Test.Assert.areEqual$1(0, s2.d, "D");
             Bridge.Test.Assert.areEqual$1(Bridge.getDefaultValue(Date), s2.DT, "DT");
-            Bridge.Test.Assert.null$1(s2.o, "O");
+            Bridge.Test.Assert.null$1(Bridge.unbox(s2.o), "O");
             Bridge.Test.Assert.areEqual$1(Bridge.getDefaultValue(Date), s2.t, "T");
         },
         defaultValueOfStructWithInlineCodeDefaultConstructorWorks_SPI_1610: function () {
@@ -23644,8 +23642,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var s1 = new Bridge.ClientTest.Batch4.UserDefinedStructTests.S5.$ctor1(42);
             var s2 = new Bridge.ClientTest.Batch4.UserDefinedStructTests.S5.$ctor1(43);
             var s3 = new Bridge.ClientTest.Batch4.UserDefinedStructTests.S5.$ctor1(44);
-            Bridge.Test.Assert.true$1(s1.equals(s2), "#1");
-            Bridge.Test.Assert.false$1(s1.equals(s3), "#2");
+            Bridge.Test.Assert.true$1(s1.equals(Bridge.box(s2, Bridge.ClientTest.Batch4.UserDefinedStructTests.S5)), "#1");
+            Bridge.Test.Assert.false$1(s1.equals(Bridge.box(s3, Bridge.ClientTest.Batch4.UserDefinedStructTests.S5)), "#2");
         },
         canLiftUserDefinedBinaryOperator: function () {
             var a = new Bridge.ClientTest.Batch4.UserDefinedStructTests.S7.$ctor1(42), b = new Bridge.ClientTest.Batch4.UserDefinedStructTests.S7.$ctor1(32), c = null;
@@ -23677,7 +23675,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 i: 42
             } );
             var s2 = s1.$clone();
-            Bridge.Test.Assert.true(Bridge.is(s2, Bridge.ClientTest.Batch4.UserDefinedStructTests.MS1));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(s2, Bridge.ClientTest.Batch4.UserDefinedStructTests.MS1), Bridge.ClientTest.Batch4.UserDefinedStructTests.MS1));
         },
         fieldsAreClonedWhenValueTypeIsCopied: function () {
             var s1 = Bridge.merge(new Bridge.ClientTest.Batch4.UserDefinedStructTests.MS1(), {
@@ -23747,7 +23745,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var s2 = s1.$clone();
             Bridge.Test.Assert.areEqual(42, s2.t);
             s2.t = 43;
-            Bridge.Test.Assert.true(Bridge.is(s2, Bridge.ClientTest.Batch4.UserDefinedStructTests.MS3$1(System.Int32)));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(s2, Bridge.ClientTest.Batch4.UserDefinedStructTests.MS3$1(System.Int32)), Bridge.ClientTest.Batch4.UserDefinedStructTests.MS3$1(System.Int32)));
             Bridge.Test.Assert.areEqual(42, s1.t);
             Bridge.Test.Assert.areEqual(43, s2.t);
         },
@@ -23758,7 +23756,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             var s2 = s1.$clone();
             s1.i = 10;
             Bridge.Test.Assert.areEqual(42, s2.i);
-            Bridge.Test.Assert.true(Bridge.is(s2, Bridge.ClientTest.Batch4.UserDefinedStructTests.MS1));
+            Bridge.Test.Assert.true(Bridge.is(Bridge.box(s2, Bridge.ClientTest.Batch4.UserDefinedStructTests.MS1), Bridge.ClientTest.Batch4.UserDefinedStructTests.MS1));
         },
         cloningNullableValueTypesWorks: function () {
             var s1 = null;
@@ -24089,7 +24087,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             return ((this.i + 1) | 0);
         },
         equals: function (o) {
-            return Math.abs(((System.Nullable.getValue(Bridge.cast(o, Bridge.ClientTest.Batch4.UserDefinedStructTests.S5)).i - this.i) | 0)) <= 1;
+            return Math.abs(((System.Nullable.getValue(Bridge.cast(Bridge.unbox(o), Bridge.ClientTest.Batch4.UserDefinedStructTests.S5)).i - this.i) | 0)) <= 1;
         },
         $clone: function (to) {
             var s = to || new Bridge.ClientTest.Batch4.UserDefinedStructTests.S5();
@@ -24472,7 +24470,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         ctor: function (x, y) {
             this.$initialize();
             Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.BaseNamedConstructorWithArgumentsTypes.B.ctor.call(this, ((x + 1) | 0), ((y + 1) | 0));
-            this.messageD = x + " " + y;
+            this.messageD = Bridge.box(x, System.Int32) + " " + Bridge.box(y, System.Int32);
         }
     });
 
@@ -24492,7 +24490,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         ctor: function (x, y) {
             this.$initialize();
             Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.BaseUnnamedConstructorWithArgumentsTypes.B.ctor.call(this, ((x + 1) | 0), ((y + 1) | 0));
-            this.messageD = x + " " + y;
+            this.messageD = Bridge.box(x, System.Int32) + " " + Bridge.box(y, System.Int32);
         }
     });
 
@@ -24619,7 +24617,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             return ((((x - y) | 0) - this.m) | 0);
         },
         g: function (T, x, y) {
-            return System.String.concat(((((x - y) | 0) - this.m) | 0), Bridge.Reflection.getTypeName(T));
+            return System.String.concat(Bridge.box(((((x - y) | 0) - this.m) | 0), System.Int32), Bridge.Reflection.getTypeName(T));
         },
         getF: function () {
             return Bridge.fn.bind(this, Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.MethodGroupConversionTypes.B.prototype.f);
@@ -24947,6 +24945,91 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
 
     Bridge.define("Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.Y3X2X2", {
         inherits: [Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.Y3$2(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.X2,Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.IsAssignableFromTypes.X2)]
+    });
+
+    var $box_ = {};
+
+    Bridge.ns("System.Single", $box_);
+
+    Bridge.apply($box_.System.Single, {
+        toString: function(obj) {return System.Single.format(obj, 'G');}
+    });
+
+
+    Bridge.ns("System.Double", $box_);
+
+    Bridge.apply($box_.System.Double, {
+        toString: function(obj) {return System.Double.format(obj, 'G');}
+    });
+
+
+    Bridge.ns("System.Decimal", $box_);
+
+    Bridge.apply($box_.System.Decimal, {
+        toString: function(obj) {return Bridge.Int.format(obj, 'G');}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E2", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E2, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E2, obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests.E1, obj);}
+    });
+
+
+    Bridge.ns("Boolean", $box_);
+
+    Bridge.apply($box_.Boolean, {
+        toString: function(obj) {return System.Boolean.toString(obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.NamedValuesEnum, obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.ImportedNamedValuesEnum", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.ImportedNamedValuesEnum, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Batch4.Reflection.TypeSystemTests.ImportedNamedValuesEnum, obj);}
+    });
+
+
+    Bridge.ns("Date", $box_);
+
+    Bridge.apply($box_.Date, {
+        toString: function(obj) {return Bridge.Date.format(obj);}
+    });
+
+
+    Bridge.ns("System.Nullable$1", $box_);
+
+    Bridge.apply($box_.System.Nullable$1, {
+        toString: function(obj) {return System.Nullable.toString(obj);}
+    });
+
+
+    Bridge.ns("Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum", $box_);
+
+    Bridge.apply($box_.Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum, {
+        toString: function(obj) {return System.Enum.toString(Bridge.ClientTest.Batch4.SimpleTypes.EnumTests.TestEnum, obj);}
     });
 
     var $m = Bridge.setMetadata,

--- a/Tests/Runner/ClientTestHelper/code.js
+++ b/Tests/Runner/ClientTestHelper/code.js
@@ -9,7 +9,7 @@ Bridge.assembly("Bridge.ClientTestHelper", function ($asm, globals) {
     Bridge.define("Bridge.ClientTestHelper.Internal.ClassLibraryTest", {
         statics: {
             test: function (item) {
-                item.Bridge$ClientTestHelper$Internal$IWriteableItem$setValue(2);
+                item.Bridge$ClientTestHelper$Internal$IWriteableItem$setValue(Bridge.box(2, System.Int32));
             }
         }
     });

--- a/Tests/Runner/TypeScript/App1/basicTypes.js
+++ b/Tests/Runner/TypeScript/App1/basicTypes.js
@@ -19,7 +19,7 @@ Bridge.assembly("TypeScriptTest", function ($asm, globals) {
         twoDimensionalArray: null,
         colorValue: 1,
         anyValueString: "AnyValueString",
-        anyValueInteger: 1,
+        anyValueInteger: Bridge.box(1, System.Int32),
         dynamicValueInteger: 7,
         undefinedValue: null,
         config: {

--- a/Tests/Runner/TypeScript/App1/functions.js
+++ b/Tests/Runner/TypeScript/App1/functions.js
@@ -22,7 +22,7 @@
             if (numbers === void 0) { numbers = []; }
             var s = "";
             for (var i = 0; i < numbers.length; i = (i + 1) | 0) {
-                s = System.String.concat(s, numbers[i]);
+                s = System.String.concat(s, Bridge.box(numbers[i], System.Int32));
             }
 
             return s;

--- a/Tests/Runner/TypeScript/App1/generics.js
+++ b/Tests/Runner/TypeScript/App1/generics.js
@@ -69,7 +69,7 @@
                     this.simpleDoubleGenericIntString = new (Generics.SimpleDoubleGeneric$2(System.Int32,String)).ctor();
                     this.genericINamedEntity = new (Generics.GenericINamedEntity$1(Generics.INamedEntity))(new Generics.NamedEntity());
                     this.genericNamedEntity = new (Generics.GenericNamedEntity$1(Generics.NamedEntity))(new Generics.NamedEntity());
-                    this.genericClassObject = new (Generics.GenericClass$1(Object))(2);
+                    this.genericClassObject = new (Generics.GenericClass$1(Object))(Bridge.box(2, System.Int32));
                     this.genericClassNamedEntity = new (Generics.GenericClass$1(Generics.NamedEntity))(new Generics.NamedEntity());
                     this.genericNew = new (Generics.GenericNew$1(Generics.NewClass))(new Generics.NewClass());
                     this.genericNewAndClass = new (Generics.GenericNewAndClass$1(Generics.NewClass))(new Generics.NewClass());

--- a/Tests/Runner/TypeScript/App1/interfaces.js
+++ b/Tests/Runner/TypeScript/App1/interfaces.js
@@ -65,11 +65,11 @@
             s.v = System.String.concat(s.v, "Method8");
         },
         method9: function (i, s) {
-            s.v = System.String.concat(s.v, i);
+            s.v = System.String.concat(s.v, Bridge.box(i, System.Int32));
         },
         method10: function (i, b, s) {
             b.v = true;
-            s.v = System.String.concat(s.v, i);
+            s.v = System.String.concat(s.v, Bridge.box(i, System.Int32));
         }
     });
 

--- a/Tests/Runner/TypeScript/Batch1/1_BasicTypes.js
+++ b/Tests/Runner/TypeScript/Batch1/1_BasicTypes.js
@@ -13,7 +13,7 @@ QUnit.test("Fields of basic types", function (assert) {
     assert.deepEqual(instance.colorArray, [BasicTypes.Color.Blue, BasicTypes.Color.Green, BasicTypes.Color.Red], "colorArray");
     assert.deepEqual(instance.colorValue, BasicTypes.Color.Green, "colorValue");
     assert.deepEqual(instance.anyValueString, "AnyValueString", "anyValueString");
-    assert.deepEqual(instance.anyValueInteger, 1, "anyValueInteger");
+    assert.deepEqual(Bridge.unbox(instance.anyValueInteger), 1, "anyValueInteger");
     assert.deepEqual(instance.dynamicValueInteger, 7, "dynamicValueInteger");
     assert.deepEqual(instance.voidFunction(), instance.undefinedValue, "Void and undefined values");
 });

--- a/Tests/TypeScript/Batch1/1_BasicTypes.ts
+++ b/Tests/TypeScript/Batch1/1_BasicTypes.ts
@@ -15,7 +15,7 @@ QUnit.test("Fields of basic types", function (assert) {
     assert.deepEqual(instance.colorArray, [BasicTypes.Color.Blue, BasicTypes.Color.Green, BasicTypes.Color.Red], "colorArray");
     assert.deepEqual(instance.colorValue, BasicTypes.Color.Green, "colorValue");
     assert.deepEqual(instance.anyValueString, "AnyValueString", "anyValueString");
-    assert.deepEqual(instance.anyValueInteger, 1, "anyValueInteger");
+    assert.deepEqual(Bridge.unbox(instance.anyValueInteger), 1, "anyValueInteger");
     assert.deepEqual(instance.dynamicValueInteger, 7, "dynamicValueInteger");
     assert.deepEqual(instance.voidFunction(), instance.undefinedValue, "Void and undefined values");
 });


### PR DESCRIPTION
Addresses:
- #2077 Support boxing/unboxing operations
- #2065 Boxed enum types are treated as regular numbers
- #2055 GetType() returns wrong type due to lack of proper boxing
- #1357 Boxed value types and String(s) should not be equal (numbers only)
- #1292 Char (s) give incorrect types when stored as objects.
- #1248 Doubles marked as objects don't give good types
- #1301 Ushort (s), short (s), uint (s), byte (s) give incorrect types
- #1290 Chars don't give correct ToString when stored as object

If class/method is marked as external then Bridge will unbox an argument automatically (if parameter type is object) because Bridge assumes that external libraries cannot work with boxed arguments. If such behaviour must be changed for some external classes/methods (if your external method can handle boxed arguments correctly) then apply attribute `Unbox(false)`

Format of boxed value:
```
{
   $boxed: true,
   v: value,
   type: T,
   constructor: T,
   getHashCode: function(),
   equals: function (o),
   valueOf: function(),
   toString: function ()
}
```