### PR TITLE
[2116] Add implicit operators from Any to Union (and back)

### DIFF
--- a/Bridge/Bridge/Any.cs
+++ b/Bridge/Bridge/Any.cs
@@ -18,6 +18,10 @@ namespace Bridge
         public static extern explicit operator T1(Any<T1, T2> value);
 
         public static extern explicit operator T2(Any<T1, T2> value);
+
+        // Make the transition from Any to Union easier until Any is finally removed
+        public static extern implicit operator Union<T1, T2>(Any<T1, T2> value);
+        public static extern implicit operator Any<T1, T2>(Union<T1, T2> value);
     }
 
     [External]
@@ -40,6 +44,10 @@ namespace Bridge
         public static extern explicit operator T2(Any<T1, T2, T3> value);
 
         public static extern explicit operator T3(Any<T1, T2, T3> value);
+
+        // Make the transition from Any to Union easier until Any is finally removed
+        public static extern implicit operator Union<T1, T2, T3>(Any<T1, T2, T3> value);
+        public static extern implicit operator Any<T1, T2, T3>(Union<T1, T2, T3> value);
     }
 
     [External]
@@ -66,6 +74,10 @@ namespace Bridge
         public static extern explicit operator T3(Any<T1, T2, T3, T4> value);
 
         public static extern explicit operator T4(Any<T1, T2, T3, T4> value);
+
+        // Make the transition from Any to Union easier until Any is finally removed
+        public static extern implicit operator Union<T1, T2, T3, T4>(Any<T1, T2, T3, T4> value);
+        public static extern implicit operator Any<T1, T2, T3, T4>(Union<T1, T2, T3, T4> value);
     }
 
     [External]
@@ -96,6 +108,10 @@ namespace Bridge
         public static extern explicit operator T4(Any<T1, T2, T3, T4, T5> value);
 
         public static extern explicit operator T5(Any<T1, T2, T3, T4, T5> value);
+
+        // Make the transition from Any to Union easier until Any is finally removed
+        public static extern implicit operator Union<T1, T2, T3, T4, T5>(Any<T1, T2, T3, T4, T5> value);
+        public static extern implicit operator Any<T1, T2, T3, T4, T5>(Union<T1, T2, T3, T4, T5> value);
     }
 
     [External]
@@ -130,6 +146,10 @@ namespace Bridge
         public static extern explicit operator T5(Any<T1, T2, T3, T4, T5, T6> value);
 
         public static extern explicit operator T6(Any<T1, T2, T3, T4, T5, T6> value);
+
+        // Make the transition from Any to Union easier until Any is finally removed
+        public static extern implicit operator Union<T1, T2, T3, T4, T5, T6>(Any<T1, T2, T3, T4, T5, T6> value);
+        public static extern implicit operator Any<T1, T2, T3, T4, T5, T6>(Union<T1, T2, T3, T4, T5, T6> value);
     }
 
     [External]
@@ -168,6 +188,10 @@ namespace Bridge
         public static extern explicit operator T6(Any<T1, T2, T3, T4, T5, T6, T7> value);
 
         public static extern explicit operator T7(Any<T1, T2, T3, T4, T5, T6, T7> value);
+
+        // Make the transition from Any to Union easier until Any is finally removed
+        public static extern implicit operator Union<T1, T2, T3, T4, T5, T6, T7>(Any<T1, T2, T3, T4, T5, T6, T7> value);
+        public static extern implicit operator Any<T1, T2, T3, T4, T5, T6, T7>(Union<T1, T2, T3, T4, T5, T6, T7> value);
     }
 
     [External]
@@ -210,5 +234,9 @@ namespace Bridge
         public static extern explicit operator T7(Any<T1, T2, T3, T4, T5, T6, T7, T8> value);
 
         public static extern explicit operator T8(Any<T1, T2, T3, T4, T5, T6, T7, T8> value);
+
+        // Make the transition from Any to Union easier until Any is finally removed
+        public static extern implicit operator Union<T1, T2, T3, T4, T5, T6, T7, T8>(Any<T1, T2, T3, T4, T5, T6, T7, T8> value);
+        public static extern implicit operator Any<T1, T2, T3, T4, T5, T6, T7, T8>(Union<T1, T2, T3, T4, T5, T6, T7, T8> value);
     }
 }


### PR DESCRIPTION
Add implicit operators from `Any` to` Union` (and back) to make migration to `Union` (as` Any` is now obsolete) easier to do one piece at a time. Addresses #2116.

Changes proposed in this pull request:

I would like to start updating my projects and libraries to move away from `Any` to `Union` but it would be easier if I could update one project at a time and still have it build, which I could if `Any` and `Union` could be used interchangeably.