### PR TITLE
[2096] Output file name gets last segment cut when outputBy Project option is used

### DIFF
--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -140,7 +140,7 @@ namespace Bridge.Build
             {
                 ProjectLocation = this.ProjectPath,
                 OutputLocation = this.OutputPath,
-                DefaultFileName = Path.GetFileNameWithoutExtension(this.Assembly.ItemSpec),
+                DefaultFileName = Path.GetFileName(this.Assembly.ItemSpec),
                 BridgeLocation = Path.Combine(this.AssembliesPath, "Bridge.dll"),
                 Rebuild = false,
                 ExtractCore = !NoCore,

--- a/Compiler/Translator/Translator/Translator.cs
+++ b/Compiler/Translator/Translator/Translator.cs
@@ -296,7 +296,7 @@ namespace Bridge.Translator
 
                 if (fileName.Contains(Bridge.Translator.AssemblyInfo.DEFAULT_FILENAME))
                 {
-                    fileName = fileName.Replace(Bridge.Translator.AssemblyInfo.DEFAULT_FILENAME, Path.GetFileNameWithoutExtension(defaultFileName));
+                    fileName = fileName.Replace(Bridge.Translator.AssemblyInfo.DEFAULT_FILENAME, defaultFileName);
                 }
 
                 // Ensure filename contains no ":". It could be used like "c:/absolute/path"

--- a/Compiler/Translator/Translator/TranslatorProcessor.cs
+++ b/Compiler/Translator/Translator/TranslatorProcessor.cs
@@ -97,7 +97,7 @@ namespace Bridge.Translator
                 logger.Info("No extracting core scripts option enabled");
             }
 
-            var fileName = bridgeOptions.DefaultFileName;
+            var fileName = GetDefaultFileName(bridgeOptions);
 
             var files = translator.SaveTo(outputPath, fileName);
 
@@ -114,6 +114,16 @@ namespace Bridge.Translator
             logger.Info("Done post processing");
 
             return outputPath;
+        }
+
+        private string GetDefaultFileName(BridgeOptions bridgeOptions)
+        {
+            if (bridgeOptions.DefaultFileName == null)
+            {
+                return AssemblyInfo.DEFAULT_FILENAME;
+            }
+
+            return Path.GetFileNameWithoutExtension(bridgeOptions.DefaultFileName);
         }
 
         private string GetOutputFolder(bool basePathOnly = false, bool strict = false)

--- a/Compiler/TranslatorTests/OutputTest.cs
+++ b/Compiler/TranslatorTests/OutputTest.cs
@@ -79,7 +79,7 @@ namespace Bridge.Translator.Tests
             }
         }
 
-        [TestCase("02", false, true, "TestProject.js", TestName = "OutputTest 02 - using GenerateScript Task Bridge.json outputFormatting Formatted, autoPropertyToField, combineScripts")]
+        [TestCase("02", false, true, "TestProject.I2096.js", TestName = "OutputTest 02 - using GenerateScript Task Bridge.json outputFormatting Formatted, autoPropertyToField, combineScripts")]
         [TestCase("03", true, true, TestName = "OutputTest 03 - Bridge.json outputFormatting Minified")]
         [TestCase("04", true, true, TestName = "OutputTest 04 - Bridge.json outputBy Class ignoreCast fileNameCasing Lowercase")]
         [TestCase("05", true, true, TestName = "OutputTest 05 - Bridge.json outputBy Namespace ignoreCast default useTypedArrays default fileNameCasing CamelCase")]

--- a/Compiler/TranslatorTests/TestProjects/02/Bridge/reference/TestProject.I2096.js
+++ b/Compiler/TranslatorTests/TestProjects/02/Bridge/reference/TestProject.I2096.js
@@ -19,7 +19,7 @@ The text after the content marked will be compared
  * @copyright Copyright 2008-2015 Object.NET, Inc.
  * @compiler Bridge.NET 15.4.0
  */
-Bridge.assembly("TestProject", function ($asm, globals) {
+Bridge.assembly("TestProject.I2096", function ($asm, globals) {
     "use strict";
 
     Bridge.define("Test.BridgeIssues.N1193.TopShouldbBOverAssemblyDescription");

--- a/Compiler/TranslatorTests/TestProjects/02/test.csproj
+++ b/Compiler/TranslatorTests/TestProjects/02/test.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{16777B9C-A3B6-4E0B-B5A2-AA933A2F54D3}</ProjectGuid>
     <RootNamespace>TestProject</RootNamespace>
-    <AssemblyName>TestProject</AssemblyName>
+    <AssemblyName>TestProject.I2096</AssemblyName>
     <UseBridgeTask>true</UseBridgeTask>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Fixes #2096

The bug was it considered a file name as a file name with extention and were removing last segment.
Reproduced when building with Bridge Task (not Bridge.Builder.exe console).
