### PR TITLE
[2043] Implement Attribute.GetCustomAttributes: checks on null method arguments

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -11916,14 +11916,36 @@
 
 ﻿    Bridge.define("System.Attribute", {
         statics: {
-            getCustomAttributes: function (o, type, inherit) {
+            getCustomAttributes: function (o, t, b) {
+                if (o == null) {
+                    throw new System.ArgumentNullException("element");
+                }
+
+                if (t == null)
+                {
+                    throw new System.ArgumentNullException("attributeType");
+                }
+
                 var r = o.at || [];
 
-                if (!type) {
+                if (!t) {
                     return r;
                 }
 
-                return r.filter(function (a) { return Bridge.is(a, type); });
+                return r.filter(function (a) { return Bridge.is(a, t); });
+            },
+
+            getCustomAttributes$1: function (a, t, b) {
+                if (a == null) {
+                    throw new System.ArgumentNullException("element");
+                }
+
+                if (t == null)
+                {
+                    throw new System. ArgumentNullException("attributeType");
+                }
+
+                return a.getCustomAttributes(t || b);
             }
         }
     });

--- a/Bridge/Resources/Attribute.js
+++ b/Bridge/Resources/Attribute.js
@@ -1,13 +1,35 @@
 ﻿    Bridge.define("System.Attribute", {
         statics: {
-            getCustomAttributes: function (o, type, inherit) {
+            getCustomAttributes: function (o, t, b) {
+                if (o == null) {
+                    throw new System.ArgumentNullException("element");
+                }
+
+                if (t == null)
+                {
+                    throw new System.ArgumentNullException("attributeType");
+                }
+
                 var r = o.at || [];
 
-                if (!type) {
+                if (!t) {
                     return r;
                 }
 
-                return r.filter(function (a) { return Bridge.is(a, type); });
+                return r.filter(function (a) { return Bridge.is(a, t); });
+            },
+
+            getCustomAttributes$1: function (a, t, b) {
+                if (a == null) {
+                    throw new System.ArgumentNullException("element");
+                }
+
+                if (t == null)
+                {
+                    throw new System. ArgumentNullException("attributeType");
+                }
+
+                return a.getCustomAttributes(t || b);
             }
         }
     });

--- a/Bridge/System/Attribute.cs
+++ b/Bridge/System/Attribute.cs
@@ -14,7 +14,7 @@ namespace System
         /// </summary>
         /// <param name="element">An object derived from the Assembly class that describes a reusable collection of modules.</param>
         /// <returns>An Attribute array that contains the custom attributes applied to element, or an empty array if no such custom attributes exist.</returns>
-        [Template("{element}.getCustomAttributes()")]
+        [Template("System.Attribute.getCustomAttributes$1({element}, false)")]
         public static extern Attribute[] GetCustomAttributes(Assembly element);
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace System
         /// <param name="element">An object derived from the Assembly class that describes a reusable collection of modules.</param>
         /// <param name="inherit">This parameter is ignored, and does not affect the operation of this method.</param>
         /// <returns>An Attribute array that contains the custom attributes applied to element, or an empty array if no such custom attributes exist.</returns>
-        [Template("{element}.getCustomAttributes({inherit})")]
+        [Template("System.Attribute.getCustomAttributes$1({element}, false, {inherit})")]
         public static extern Attribute[] GetCustomAttributes(Assembly element, bool inherit);
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace System
         /// <param name="element">An object derived from the Assembly class that describes a reusable collection of modules.</param>
         /// <param name="attributeType">The type, or a base type, of the custom attribute to search for.</param>
         /// <returns>An Attribute array that contains the custom attributes of type attributeType applied to element, or an empty array if no such custom attributes exist.</returns>
-        [Template("{element}.getCustomAttributes({attributeType})")]
+        [Template("System.Attribute.getCustomAttributes$1({element}, {attributeType})")]
         public static extern Attribute[] GetCustomAttributes(Assembly element, Type attributeType);
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace System
         /// <param name="attributeType">The type, or a base type, of the custom attribute to search for.</param>
         /// <param name="inherit">This parameter is ignored, and does not affect the operation of this method.</param>
         /// <returns>An Attribute array that contains the custom attributes of type attributeType applied to element, or an empty array if no such custom attributes exist.</returns>
-        [Template("{element}.getCustomAttributes({attributeType}, {inherit})")]
+        [Template("System.Attribute.getCustomAttributes$1({element}, {attributeType}, {inherit})")]
         public static extern Attribute[] GetCustomAttributes(Assembly element, Type attributeType, bool inherit);
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace System
         /// </summary>
         /// <param name="element">An object derived from the MemberInfo class that describes a constructor, event, field, method, or property member of a class.</param>
         /// <returns>An Attribute array that contains the custom attributes applied to element, or an empty array if no such custom attributes exist.</returns>
-        [Template("System.Attribute.getCustomAttributes({element})")]
+        [Template("System.Attribute.getCustomAttributes({element}, false)")]
         public static extern Attribute[] GetCustomAttributes(MemberInfo element);
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace System
         /// <param name="element">An object derived from the MemberInfo class that describes a constructor, event, field, method, or property member of a class.</param>
         /// <param name="inherit">If true, specifies to also search the ancestors of element for custom attributes.</param>
         /// <returns>An Attribute array that contains the custom attributes applied to element, or an empty array if no such custom attributes exist.</returns>
-        [Template("System.Attribute.getCustomAttributes({element}, null, {inherit})")]
+        [Template("System.Attribute.getCustomAttributes({element}, false, {inherit})")]
         public static extern Attribute[] GetCustomAttributes(MemberInfo element, bool inherit);
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace System
         /// </summary>
         /// <param name="element">An object derived from the ParameterInfo class that describes a parameter of a member of a class.</param>
         /// <returns>An Attribute array that contains the custom attributes applied to element, or an empty array if no such custom attributes exist.</returns>
-        [Template("System.Attribute.getCustomAttributes({element})")]
+        [Template("System.Attribute.getCustomAttributes({element}, false)")]
         public static extern Attribute[] GetCustomAttributes(ParameterInfo element);
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace System
         /// <param name="element">An object derived from the ParameterInfo class that describes a parameter of a member of a class.</param>
         /// <param name="inherit">If true, specifies to also search the ancestors of element for custom attributes.</param>
         /// <returns>An Attribute array that contains the custom attributes applied to element, or an empty array if no such custom attributes exist.</returns>
-        [Template("System.Attribute.getCustomAttributes({element}, null, {inherit})")]
+        [Template("System.Attribute.getCustomAttributes({element}, false, {inherit})")]
         public static extern Attribute[] GetCustomAttributes(ParameterInfo element, bool inherit);
 
         /// <summary>

--- a/Bridge/System/Reflection/MemberInfo.cs
+++ b/Bridge/System/Reflection/MemberInfo.cs
@@ -98,7 +98,7 @@ namespace System.Reflection
         /// </summary>
         /// <param name="inherit">Ignored for members. Base members will never be considered.</param>
         /// <returns>An array that contains all the custom attributes applied to this member, or an array with zero elements if no attributes are defined. </returns>
-        [Template("System.Attribute.getCustomAttributes({this}, null, {inherit})")]
+        [Template("System.Attribute.getCustomAttributes({this}, false, {inherit})")]
         public extern object[] GetCustomAttributes(bool inherit);
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace System.Reflection
         /// Returns an array of all custom attributes applied to this member.
         /// </summary>
         /// <returns>An array that contains all the custom attributes applied to this member, or an array with zero elements if no attributes are defined. </returns>
-        [Template("System.Attribute.getCustomAttributes({this})")]
+        [Template("System.Attribute.getCustomAttributes({this}, false)")]
         public extern object[] GetCustomAttributes();
 
         /// <summary>

--- a/Bridge/System/Reflection/ParameterInfo.cs
+++ b/Bridge/System/Reflection/ParameterInfo.cs
@@ -76,7 +76,7 @@ namespace System.Reflection
 		/// </summary>
 		/// <param name="inherit">Ignored for members. Base members will never be considered.</param>
 		/// <returns>An array that contains all the custom attributes applied to this member, or an array with zero elements if no attributes are defined. </returns>
-		[Template("System.Attribute.getCustomAttributes({this}, null, {inherit})")]
+		[Template("System.Attribute.getCustomAttributes({this}, false, {inherit})")]
         public extern object[] GetCustomAttributes(bool inherit);
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace System.Reflection
         /// Returns an array of all custom attributes applied to this member.
         /// </summary>
         /// <returns>An array that contains all the custom attributes applied to this member, or an array with zero elements if no attributes are defined. </returns>
-        [Template("System.Attribute.getCustomAttributes({this})")]
+        [Template("System.Attribute.getCustomAttributes({this}, false)")]
         public extern object[] GetCustomAttributes();
 
         /// <summary>

--- a/Tests/Batch1/Reflection/AttributeTests.cs
+++ b/Tests/Batch1/Reflection/AttributeTests.cs
@@ -82,6 +82,16 @@ namespace Bridge.ClientTest.Batch1.Reflection
                 Assert.True(((AssemblyAttributes.A2Attribute)a[0]).X == 64);
                 Assert.True(((AssemblyAttributes.A2Attribute)a[0]).P == 23);
             }
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((Assembly)null); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((Assembly)null, true); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((Assembly)null, false); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((Assembly)null, null); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((Assembly)null, null, false); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((Assembly)null, null, true); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes(asm, null); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes(asm, null, false); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes(asm, null, true); });
         }
 
         [Test]
@@ -101,6 +111,8 @@ namespace Bridge.ClientTest.Batch1.Reflection
             Assert.NotNull(a3);
             Assert.AreEqual(1, a1.V);
             Assert.AreEqual(3, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((MemberInfo)null); });
         }
 
         [Test]
@@ -120,6 +132,8 @@ namespace Bridge.ClientTest.Batch1.Reflection
             Assert.NotNull(a3);
             Assert.AreEqual(1, a1.V);
             Assert.AreEqual(3, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((MemberInfo)null, true); });
         }
 
         [Test]
@@ -139,6 +153,8 @@ namespace Bridge.ClientTest.Batch1.Reflection
             Assert.NotNull(a3);
             Assert.AreEqual(1, a1.V);
             Assert.AreEqual(3, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((MemberInfo)null, false); });
         }
 
         [Test]
@@ -162,6 +178,9 @@ namespace Bridge.ClientTest.Batch1.Reflection
             Assert.AreEqual(attributes2.Length, 1);
             a2 = attributes2[0] as A2;
             Assert.NotNull(a2);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((MemberInfo)null, null); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes(member1, null); });
         }
 
         [Test]
@@ -190,6 +209,9 @@ namespace Bridge.ClientTest.Batch1.Reflection
             a3 = attributes2[0] as A3;
             Assert.NotNull(a3);
             Assert.AreEqual(3, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((MemberInfo)null, null, false); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes(member1, null, false); });
         }
 
         [Test]
@@ -218,6 +240,9 @@ namespace Bridge.ClientTest.Batch1.Reflection
             a3 = attributes2[0] as A3;
             Assert.NotNull(a3);
             Assert.AreEqual(3, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((MemberInfo)null, null, true); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes(member1, null, true); });
         }
 
         [Test]
@@ -239,6 +264,8 @@ namespace Bridge.ClientTest.Batch1.Reflection
             Assert.NotNull(a3);
             Assert.AreEqual(1000, a1.V);
             Assert.AreEqual(3000, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((ParameterInfo)null); });
         }
 
         [Test]
@@ -258,6 +285,8 @@ namespace Bridge.ClientTest.Batch1.Reflection
             Assert.NotNull(a3);
             Assert.AreEqual(1000, a1.V);
             Assert.AreEqual(3000, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((ParameterInfo)null, true); });
         }
 
         [Test]
@@ -277,6 +306,8 @@ namespace Bridge.ClientTest.Batch1.Reflection
             Assert.NotNull(a3);
             Assert.AreEqual(1000, a1.V);
             Assert.AreEqual(3000, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((ParameterInfo)null, false); });
         }
 
         [Test]
@@ -300,6 +331,9 @@ namespace Bridge.ClientTest.Batch1.Reflection
             Assert.AreEqual(attributes2.Length, 1);
             a2 = attributes2[0] as A2;
             Assert.NotNull(a2);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((ParameterInfo)null, null); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes(parameter1, null); });
         }
 
         [Test]
@@ -328,6 +362,9 @@ namespace Bridge.ClientTest.Batch1.Reflection
             a3 = attributes2[0] as A3;
             Assert.NotNull(a3);
             Assert.AreEqual(3000, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((ParameterInfo)null, null, false); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes(parameter1, null, false); });
         }
 
         [Test]
@@ -356,6 +393,9 @@ namespace Bridge.ClientTest.Batch1.Reflection
             a3 = attributes2[0] as A3;
             Assert.NotNull(a3);
             Assert.AreEqual(3000, a3.V);
+
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes((ParameterInfo)null, null, true); });
+            Assert.Throws<ArgumentNullException>(() => { Attribute.GetCustomAttributes(parameter1, null, true); });
         }
     }
 }

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -11916,14 +11916,36 @@
 
 ﻿    Bridge.define("System.Attribute", {
         statics: {
-            getCustomAttributes: function (o, type, inherit) {
+            getCustomAttributes: function (o, t, b) {
+                if (o == null) {
+                    throw new System.ArgumentNullException("element");
+                }
+
+                if (t == null)
+                {
+                    throw new System.ArgumentNullException("attributeType");
+                }
+
                 var r = o.at || [];
 
-                if (!type) {
+                if (!t) {
                     return r;
                 }
 
-                return r.filter(function (a) { return Bridge.is(a, type); });
+                return r.filter(function (a) { return Bridge.is(a, t); });
+            },
+
+            getCustomAttributes$1: function (a, t, b) {
+                if (a == null) {
+                    throw new System.ArgumentNullException("element");
+                }
+
+                if (t == null)
+                {
+                    throw new System. ArgumentNullException("attributeType");
+                }
+
+                return a.getCustomAttributes(t || b);
             }
         }
     });

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -3524,7 +3524,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         getCustomAttributesForAssemblyWorks: function () {
             var $t, $t1;
             var asm = $asm;
-            $t = Bridge.getEnumerator([asm.getCustomAttributes(), asm.getCustomAttributes(true), asm.getCustomAttributes(false)]);
+            $t = Bridge.getEnumerator([System.Attribute.getCustomAttributes$1(asm, false), System.Attribute.getCustomAttributes$1(asm, false, true), System.Attribute.getCustomAttributes$1(asm, false, false)]);
             while ($t.moveNext()) {
                 var a = $t.getCurrent();
                 Bridge.Test.Assert.false(a.some($asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f1));
@@ -3539,18 +3539,34 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Bridge.Test.Assert.true(Bridge.cast(a3[0], Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A3Attribute).getP() === 45);
             }
 
-            $t1 = Bridge.getEnumerator([asm.getCustomAttributes(Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A2Attribute), asm.getCustomAttributes(Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A2Attribute, true), asm.getCustomAttributes(Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A2Attribute, false)]);
+            $t1 = Bridge.getEnumerator([System.Attribute.getCustomAttributes$1(asm, Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A2Attribute), System.Attribute.getCustomAttributes$1(asm, Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A2Attribute, true), System.Attribute.getCustomAttributes$1(asm, Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A2Attribute, false)]);
             while ($t1.moveNext()) {
                 var a1 = $t1.getCurrent();
                 Bridge.Test.Assert.areEqual(a1.length, 1);
                 Bridge.Test.Assert.true(Bridge.cast(a1[0], Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A2Attribute).getX() === 64);
                 Bridge.Test.Assert.true(Bridge.cast(a1[0], Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A2Attribute).getP() === 23);
             }
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f4);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f5);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f6);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f7);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f8);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f9);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
+                System.Attribute.getCustomAttributes$1(asm, null);
+            });
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
+                System.Attribute.getCustomAttributes$1(asm, null, false);
+            });
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
+                System.Attribute.getCustomAttributes$1(asm, null, true);
+            });
         },
         getCustomAttributesForMemberInfoWorks: function () {
             var member1 = Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 31, 28, "DoSomething")[0];
 
-            var attributes1 = System.Attribute.getCustomAttributes(member1);
+            var attributes1 = System.Attribute.getCustomAttributes(member1, false);
 
             var a1 = null;
             var a3 = null;
@@ -3562,11 +3578,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(1, a1.getV());
             Bridge.Test.Assert.areEqual(3, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f10);
         },
         getCustomAttributesForMemberInfoInheritTrueWorks: function () {
             var member1 = Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 31, 28, "DoSomething")[0];
 
-            var attributes1 = System.Attribute.getCustomAttributes(member1, null, true);
+            var attributes1 = System.Attribute.getCustomAttributes(member1, false, true);
 
             var a1 = null;
             var a3 = null;
@@ -3578,11 +3596,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(1, a1.getV());
             Bridge.Test.Assert.areEqual(3, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f11);
         },
         getCustomAttributesForMemberInfoInheritFalseWorks: function () {
             var member1 = Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 31, 28, "DoSomething")[0];
 
-            var attributes1 = System.Attribute.getCustomAttributes(member1, null, false);
+            var attributes1 = System.Attribute.getCustomAttributes(member1, false, false);
 
             var a1 = null;
             var a3 = null;
@@ -3594,6 +3614,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(1, a1.getV());
             Bridge.Test.Assert.areEqual(3, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f12);
         },
         getCustomAttributesForMemberInfoTypeWorks: function () {
             var member1 = Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 31, 28, "KeepSomething")[0];
@@ -3614,6 +3636,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(attributes2.length, 1);
             a2 = Bridge.as(attributes2[0], Bridge.ClientTest.Batch1.Reflection.AttributeTests.A2);
             Bridge.Test.Assert.notNull(a2);
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f13);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
+                System.Attribute.getCustomAttributes(member1, null);
+            });
         },
         getCustomAttributesForMemberInfoTypeInheritFalseWorks: function () {
             var member1 = Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 31, 28, "DoSomething")[0];
@@ -3639,6 +3666,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             a3 = Bridge.as(attributes2[0], Bridge.ClientTest.Batch1.Reflection.AttributeTests.A3);
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(3, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f14);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
+                System.Attribute.getCustomAttributes(member1, null, false);
+            });
         },
         getCustomAttributesForMemberInfoTypeInheritTrueWorks: function () {
             var member1 = Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 31, 28, "DoSomething")[0];
@@ -3664,13 +3696,18 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             a3 = Bridge.as(attributes2[0], Bridge.ClientTest.Batch1.Reflection.AttributeTests.A3);
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(3, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f15);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
+                System.Attribute.getCustomAttributes(member1, null, true);
+            });
         },
         getCustomAttributesForParameterInfoWorks: function () {
             var t = Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1;
             var m = Bridge.Reflection.getMembers(t, 8, 284, "DoSomething");
             var parameter1 = (m.pi || [])[0];
 
-            var attributes1 = System.Attribute.getCustomAttributes(parameter1);
+            var attributes1 = System.Attribute.getCustomAttributes(parameter1, false);
 
             var a1 = null;
             var a3 = null;
@@ -3682,11 +3719,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(1000, a1.getV());
             Bridge.Test.Assert.areEqual(3000, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f10);
         },
         getCustomAttributesForParameterInfoInheritTrueWorks: function () {
             var parameter1 = (Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 8, 284, "DoSomething").pi || [])[0];
 
-            var attributes1 = System.Attribute.getCustomAttributes(parameter1, null, true);
+            var attributes1 = System.Attribute.getCustomAttributes(parameter1, false, true);
 
             var a1 = null;
             var a3 = null;
@@ -3698,11 +3737,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(1000, a1.getV());
             Bridge.Test.Assert.areEqual(3000, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f11);
         },
         getCustomAttributesForParameterInfoInheritFalseWorks: function () {
             var parameter1 = (Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 8, 284, "DoSomething").pi || [])[0];
 
-            var attributes1 = System.Attribute.getCustomAttributes(parameter1, null, false);
+            var attributes1 = System.Attribute.getCustomAttributes(parameter1, false, false);
 
             var a1 = null;
             var a3 = null;
@@ -3714,6 +3755,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(1000, a1.getV());
             Bridge.Test.Assert.areEqual(3000, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f12);
         },
         getCustomAttributesForParameterInfoTypeWorks: function () {
             var parameter1 = (Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 8, 284, "KeepSomething").pi || [])[0];
@@ -3734,6 +3777,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual(attributes2.length, 1);
             a2 = Bridge.as(attributes2[0], Bridge.ClientTest.Batch1.Reflection.AttributeTests.A2);
             Bridge.Test.Assert.notNull(a2);
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f13);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
+                System.Attribute.getCustomAttributes(parameter1, null);
+            });
         },
         getCustomAttributesForParameterInfoTypeInheritFalseWorks: function () {
             var parameter1 = (Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 8, 284, "DoSomething").pi || [])[0];
@@ -3759,6 +3807,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             a3 = Bridge.as(attributes2[0], Bridge.ClientTest.Batch1.Reflection.AttributeTests.A3);
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(3000, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f14);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
+                System.Attribute.getCustomAttributes(parameter1, null, false);
+            });
         },
         getCustomAttributesForParameterInfoTypeInheritTrueWorks: function () {
             var parameter1 = (Bridge.Reflection.getMembers(Bridge.getType(new Bridge.ClientTest.Batch1.Reflection.AttributeTests.C1()), 8, 284, "DoSomething").pi || [])[0];
@@ -3784,6 +3837,11 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             a3 = Bridge.as(attributes2[0], Bridge.ClientTest.Batch1.Reflection.AttributeTests.A3);
             Bridge.Test.Assert.notNull(a3);
             Bridge.Test.Assert.areEqual(3000, a3.getV());
+
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.Batch1.Reflection.AttributeTests.f15);
+            Bridge.Test.Assert.throws$6(System.ArgumentNullException, function () {
+                System.Attribute.getCustomAttributes(parameter1, null, true);
+            });
         }
     });
 
@@ -3798,6 +3856,42 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
         },
         f3: function (x) {
             return Bridge.is(x, Bridge.ClientTest.Batch1.Reflection.AssemblyAttributes.A3Attribute);
+        },
+        f4: function () {
+            System.Attribute.getCustomAttributes$1(null, false);
+        },
+        f5: function () {
+            System.Attribute.getCustomAttributes$1(null, false, true);
+        },
+        f6: function () {
+            System.Attribute.getCustomAttributes$1(null, false, false);
+        },
+        f7: function () {
+            System.Attribute.getCustomAttributes$1(null, null);
+        },
+        f8: function () {
+            System.Attribute.getCustomAttributes$1(null, null, false);
+        },
+        f9: function () {
+            System.Attribute.getCustomAttributes$1(null, null, true);
+        },
+        f10: function () {
+            System.Attribute.getCustomAttributes(null, false);
+        },
+        f11: function () {
+            System.Attribute.getCustomAttributes(null, false, true);
+        },
+        f12: function () {
+            System.Attribute.getCustomAttributes(null, false, false);
+        },
+        f13: function () {
+            System.Attribute.getCustomAttributes(null, null);
+        },
+        f14: function () {
+            System.Attribute.getCustomAttributes(null, null, false);
+        },
+        f15: function () {
+            System.Attribute.getCustomAttributes(null, null, true);
         }
     });
 
@@ -21850,13 +21944,13 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             Bridge.Test.Assert.areEqual$1(c15.v, "The_value", "Item.SetValue.value");
         },
         testMemberAttribute: function (member, expectedA1) {
-            var all = System.Attribute.getCustomAttributes(member);
+            var all = System.Attribute.getCustomAttributes(member, false);
             Bridge.Test.Assert.areEqual(all.length, 2);
             Bridge.Test.Assert.true(Bridge.is(all[0], Bridge.ClientTest.Reflection.ReflectionTests.A1Attribute) || Bridge.is(all[1], Bridge.ClientTest.Reflection.ReflectionTests.A1Attribute));
             Bridge.Test.Assert.true(Bridge.is(all[0], Bridge.ClientTest.Reflection.ReflectionTests.A3Attribute) || Bridge.is(all[1], Bridge.ClientTest.Reflection.ReflectionTests.A3Attribute));
             Bridge.Test.Assert.areEqual(Bridge.cast((Bridge.is(all[0], Bridge.ClientTest.Reflection.ReflectionTests.A1Attribute) ? all[0] : all[1]), Bridge.ClientTest.Reflection.ReflectionTests.A1Attribute).getX(), expectedA1);
 
-            all = System.Attribute.getCustomAttributes(member, null, true);
+            all = System.Attribute.getCustomAttributes(member, false, true);
             Bridge.Test.Assert.areEqual(all.length, 2);
             Bridge.Test.Assert.true(Bridge.is(all[0], Bridge.ClientTest.Reflection.ReflectionTests.A1Attribute) || Bridge.is(all[1], Bridge.ClientTest.Reflection.ReflectionTests.A1Attribute));
             Bridge.Test.Assert.true(Bridge.is(all[0], Bridge.ClientTest.Reflection.ReflectionTests.A3Attribute) || Bridge.is(all[1], Bridge.ClientTest.Reflection.ReflectionTests.A3Attribute));
@@ -21886,7 +21980,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             this.testMemberAttribute(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C18, 2, 284, "E").ad, 8);
             this.testMemberAttribute(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C18, 2, 284, "E").r, 9);
 
-            Bridge.Test.Assert.areEqual(System.Attribute.getCustomAttributes(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C2, 8, 284, "M1")).length, 0);
+            Bridge.Test.Assert.areEqual(System.Attribute.getCustomAttributes(Bridge.Reflection.getMembers(Bridge.ClientTest.Reflection.ReflectionTests.C2, 8, 284, "M1"), false).length, 0);
         },
         membersReflectableAttributeWorks: function () {
             var c25 = Bridge.ClientTest.Reflection.ReflectionTests.C25;

--- a/Tests/Runner/Batch1/test.js
+++ b/Tests/Runner/Batch1/test.js
@@ -3848,84 +3848,84 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
             getCustomAttributesForMemberInfoWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForMemberInfoWorks()",
-                    line: "87"
+                    line: "97"
                 } ));
                 t.getFixture().getCustomAttributesForMemberInfoWorks();
             },
             getCustomAttributesForMemberInfoInheritTrueWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForMemberInfoInheritTrueWorks()",
-                    line: "106"
+                    line: "118"
                 } ));
                 t.getFixture().getCustomAttributesForMemberInfoInheritTrueWorks();
             },
             getCustomAttributesForMemberInfoInheritFalseWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForMemberInfoInheritFalseWorks()",
-                    line: "125"
+                    line: "139"
                 } ));
                 t.getFixture().getCustomAttributesForMemberInfoInheritFalseWorks();
             },
             getCustomAttributesForMemberInfoTypeWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForMemberInfoTypeWorks()",
-                    line: "144"
+                    line: "160"
                 } ));
                 t.getFixture().getCustomAttributesForMemberInfoTypeWorks();
             },
             getCustomAttributesForMemberInfoTypeInheritFalseWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForMemberInfoTypeInheritFalseWorks()",
-                    line: "167"
+                    line: "186"
                 } ));
                 t.getFixture().getCustomAttributesForMemberInfoTypeInheritFalseWorks();
             },
             getCustomAttributesForMemberInfoTypeInheritTrueWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForMemberInfoTypeInheritTrueWorks()",
-                    line: "195"
+                    line: "217"
                 } ));
                 t.getFixture().getCustomAttributesForMemberInfoTypeInheritTrueWorks();
             },
             getCustomAttributesForParameterInfoWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForParameterInfoWorks()",
-                    line: "223"
+                    line: "248"
                 } ));
                 t.getFixture().getCustomAttributesForParameterInfoWorks();
             },
             getCustomAttributesForParameterInfoInheritTrueWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForParameterInfoInheritTrueWorks()",
-                    line: "244"
+                    line: "271"
                 } ));
                 t.getFixture().getCustomAttributesForParameterInfoInheritTrueWorks();
             },
             getCustomAttributesForParameterInfoInheritFalseWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForParameterInfoInheritFalseWorks()",
-                    line: "263"
+                    line: "292"
                 } ));
                 t.getFixture().getCustomAttributesForParameterInfoInheritFalseWorks();
             },
             getCustomAttributesForParameterInfoTypeWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForParameterInfoTypeWorks()",
-                    line: "282"
+                    line: "313"
                 } ));
                 t.getFixture().getCustomAttributesForParameterInfoTypeWorks();
             },
             getCustomAttributesForParameterInfoTypeInheritFalseWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForParameterInfoTypeInheritFalseWorks()",
-                    line: "305"
+                    line: "339"
                 } ));
                 t.getFixture().getCustomAttributesForParameterInfoTypeInheritFalseWorks();
             },
             getCustomAttributesForParameterInfoTypeInheritTrueWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch1.Reflection.AttributeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_Batch1_Reflection_AttributeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "GetCustomAttributesForParameterInfoTypeInheritTrueWorks()",
-                    line: "333"
+                    line: "370"
                 } ));
                 t.getFixture().getCustomAttributesForParameterInfoTypeInheritTrueWorks();
             }

--- a/Tests/Runner/Batch4/code.js
+++ b/Tests/Runner/Batch4/code.js
@@ -12461,13 +12461,13 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             Bridge.Test.Assert.areEqual$1("The_value", c15.v, "Item.SetValue.value");
         },
         testMemberAttribute: function (member, expectedA1) {
-            var all = System.Attribute.getCustomAttributes(member);
+            var all = System.Attribute.getCustomAttributes(member, false);
             Bridge.Test.Assert.areEqual(2, all.length);
             Bridge.Test.Assert.true(Bridge.is(all[0], Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A1Attribute) || Bridge.is(all[1], Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A1Attribute));
             Bridge.Test.Assert.true(Bridge.is(all[0], Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A3Attribute) || Bridge.is(all[1], Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A3Attribute));
             Bridge.Test.Assert.areEqual(expectedA1, Bridge.cast((Bridge.is(all[0], Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A1Attribute) ? all[0] : all[1]), Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A1Attribute).getX());
 
-            all = System.Attribute.getCustomAttributes(member, null, true);
+            all = System.Attribute.getCustomAttributes(member, false, true);
             Bridge.Test.Assert.areEqual(2, all.length);
             Bridge.Test.Assert.true(Bridge.is(all[0], Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A1Attribute) || Bridge.is(all[1], Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A1Attribute));
             Bridge.Test.Assert.true(Bridge.is(all[0], Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A3Attribute) || Bridge.is(all[1], Bridge.ClientTest.Batch4.Reflection.ReflectionTests.A3Attribute));
@@ -12497,7 +12497,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             this.testMemberAttribute(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C18, 2, 284, "E").ad, 8);
             this.testMemberAttribute(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C18, 2, 284, "E").r, 9);
 
-            Bridge.Test.Assert.areEqual(0, System.Attribute.getCustomAttributes(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C2, 8, 284, "M1")).length);
+            Bridge.Test.Assert.areEqual(0, System.Attribute.getCustomAttributes(Bridge.Reflection.getMembers(Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C2, 8, 284, "M1"), false).length);
         },
         membersReflectableAttributeWorks: function () {
             var c25 = Bridge.ClientTest.Batch4.Reflection.ReflectionTests.C25;


### PR DESCRIPTION
Fixes #2043  .

Changes proposed in this pull request:
- Add checks on `null` arguments for `Attributes.GetCustomAttributes()` methods