### PR TITLE
[2112] Fixes for parsing numbers

### DIFF
--- a/Bridge/Resources/Integer.js
+++ b/Bridge/Resources/Integer.js
@@ -558,6 +558,67 @@
                     throw new System.ArgumentNullException("str");
                 }
 
+                var stringContains = function (str, value) {
+                    for (var i = 0; i < str.length; i++) {
+                        if (str[i] === value) {
+                            return false;
+                        }
+                    }
+                    return true;
+                };
+
+                if (!provider) {
+
+                    var containsWhitespace = stringContains(str, " ");
+
+                    if (containsWhitespace) {
+                        throw new System.FormatException("Input string was not in a correct format.");
+                    }
+
+                    var containsDot = stringContains(str, ".");
+                    var containsComma = stringContains(str, ",");
+
+                    var containsDotWithComma = containsDot && containsComma;
+
+                    if (containsDotWithComma) {
+                        // dot before comma is not allowed
+                        // double.Parse("10,2.5") -> 102.5
+                        // double.Parse("10.2,5") -> FormatException
+                        if (str.indexOf(".") < str.indexOf(",")) {
+                            throw new System.FormatException("Input string was not in a correct format.");
+                        }
+                    }
+
+                    if (containsDot)
+                    {
+                        var dotCount = 0;
+                        for (var i = 0; i < str.length; i++) {
+                            if (str[i] === ".") {
+                                dotCount += 1;
+                            }
+                        }
+
+                        // only one dot is allowed
+                        if (dotCount > 1) {
+                            throw new System.FormatException("Input string was not in a correct format.");
+                        }
+                    }
+
+                    var strWithNoCommas = "";
+
+                    for (var i = 0; i < str.length; i++) {
+                        if (str[i] !== ",") {
+                            strWithNoCommas += str[i];
+                        }
+                    }
+
+                    // mutiple comma's are allowed, so we remove them before going furthur
+                    // double.Parse("1,1,1") -> 111
+                    // double.Parse("10,00") -> 1000
+                    // double.Parse("10,10,2.5") -> 10102.5
+                    str = strWithNoCommas;
+                }
+
                 var nfInfo = (provider || System.Globalization.CultureInfo.getCurrentCulture()).getFormat(System.Globalization.NumberFormatInfo),
                     result = parseFloat(str.replace(nfInfo.numberDecimalSeparator, "."));
 

--- a/Bridge/Resources/Integer.js
+++ b/Bridge/Resources/Integer.js
@@ -638,7 +638,7 @@
 
 
                     for (var i = 0; i < str.length; i++) {
-                        if (isLetetr(str[i])) {
+                        if (isLetter(str[i])) {
                             if (str[i].toLowerCase() === "e" && tokenCount(str.toLowerCase(), "e") === 1) {
                                 continue;
                             }

--- a/Bridge/Resources/Integer.js
+++ b/Bridge/Resources/Integer.js
@@ -567,6 +567,24 @@
                     return false;
                 };
 
+                var allLetters = "abcdefghijklmnopqrstuvwxyz";
+
+                var isLetter = function (value) {
+                    return stringContains(allLetters, value.toLowerCase());
+                };
+
+                var tokenCount = function (input, value) {
+                    var count = 0;
+                    for(var i = 0; i < input.length; i++)
+                    {
+                        if (input[i] === value)
+                        {
+                            count += 1;
+                        }
+                    }
+                    return count;
+                };
+
                 if (!provider) {
 
                     var containsWhitespace = stringContains(str, " ");
@@ -617,6 +635,19 @@
                     // double.Parse("10,00") -> 1000
                     // double.Parse("10,10,2.5") -> 10102.5
                     str = strWithNoCommas;
+
+
+                    for (var i = 0; i < str.length; i++) {
+                        if (isLetetr(str[i])) {
+                            if (str[i].toLowerCase() === "e" && tokenCount(str.toLowerCase(), "e") === 1) {
+                                continue;
+                            }
+                            else {
+                                throw new Exception("Input string was not in a correct format.");
+                            }
+                        }
+                    }
+
                 }
 
                 var nfInfo = (provider || System.Globalization.CultureInfo.getCurrentCulture()).getFormat(System.Globalization.NumberFormatInfo),

--- a/Bridge/Resources/Integer.js
+++ b/Bridge/Resources/Integer.js
@@ -561,10 +561,10 @@
                 var stringContains = function (str, value) {
                     for (var i = 0; i < str.length; i++) {
                         if (str[i] === value) {
-                            return false;
+                            return true;
                         }
                     }
-                    return true;
+                    return false;
                 };
 
                 if (!provider) {


### PR DESCRIPTION
Fixes #2112. 

Not only the issue should be fixed but other edge cases as well

by default, `double.Parse` handles string with multiple comma's and also combined with dots, all of the following examples are valid with .Net:

```csharp
double.Parse("10,10"); // 1010
double.Parse("10,2,10") // 10210
double.Parse("10,1,1,1,1,1") // 1011111
double.Parse("10,00") // 1000
double.Parse("10,10,2.5") // 10102.5
```

But with Bridge ([Deck](http://deck.net/0e1e8ee741801dd227a35f7dec9e78ac))
```csharp
double.Parse("10,10"); // 10
double.Parse("10,2,10") // 10
double.Parse("10,1,1,1,1,1") // 10
double.Parse("10,00") // 10
double.Parse("10,10,2.5") // 10
```

Now these should be parsed correctly when calling `double.Parse` from Bridge

No tests unfortunately, I didn't know where to put my tests (I was testing with another script and node). 

Script used for testing [JS Bin](https://jsbin.com/nehuheyuxu/edit?js,console)
