### PR TITLE
[1566] Add working and .NET-compatible implementation of Math.Log

### DIFF
--- a/Bridge/Resources/Math.js
+++ b/Bridge/Resources/Math.js
@@ -23,6 +23,50 @@
             return Math.round(n) / m;
         },
 
+        // according to this implementation https://referencesource.microsoft.com/#mscorlib/system/math.cs,506
+        logWithBase: function (x, newBase) { 
+
+            if (isNaN(x)) {
+                return x;
+            }
+
+            if (isNaN(newBase)) {
+                return newBase;
+            }
+
+            if (newBase === 1) {
+                return NaN
+            }
+
+            if (x !== 1 && (newBase === 0 || newBase === Number.POSITIVE_INFINITY)) {
+                return NaN;
+            }
+
+            return Math.log10(x) / Math.log10(newBase);
+        },
+
+        // according to https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L228
+        log: function (x) { 
+            if (x === 0.0) {
+                return Number.NEGATIVE_INFINITY;
+            }
+
+            if (x < 0.0 || isNaN(x)) {
+                return NaN;
+            }
+
+            if (x === Number.POSITIVE_INFINITY) {
+                return Number.POSITIVE_INFINITY;
+            }
+
+            if (x === Number.NEGATIVE_INFINITY) {
+                return NaN;
+            }
+
+            return Math.log(x);
+
+        },
+
         sinh: Math.sinh || function (x) {
             return (Math.exp(x) - Math.exp(-x)) / 2;
         },

--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -122,19 +122,20 @@ namespace System
         [Template("{x}.exponential()")]
         public static extern decimal Exp(decimal x);
 
-        [Template("{x}.ln()")]
-        public static extern decimal Ln(decimal x);
+        [Template("Bridge.Math.log({x})")]
+        public static extern double Log(double x);
 
-        [Template("{x}.log({logBase})")]
-        public static extern decimal Log(decimal x, decimal logBase);
+        [Template("Bridge.Math.logWithBase({x}, {logBase})")]
+        public static extern double Log(double x, double logBase);
+
+        [Template("Math.log10({x})")]
+        public static extern double Log10(double x);
 
         [Template("{x}.pow({y})")]
         public static extern decimal Pow(decimal x, decimal y);
 
         [Template("{x}.sqrt()")]
         public static extern decimal Sqrt(decimal x);
-
-        public static extern double Log(double x);
 
         public static extern double Pow(double x, double y);
 

--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -128,7 +128,7 @@ namespace System
         [Template("Bridge.Math.logWithBase({x}, {logBase})")]
         public static extern double Log(double x, double logBase);
 
-        [Template("Math.log10({x})")]
+        [Template("Bridge.Math.logWithBase({x}, 10.0)")]
         public static extern double Log10(double x);
 
         [Template("{x}.pow({y})")]


### PR DESCRIPTION
Addresses issue #1566

Changes proposed in this pull request:
- Remove Math.Log(decimal, decimal) 
    - Does not work, see [Deck](http://deck.net/c21ea83967c81ed00adfc97a76031422)
    - System.Math in .Net does not have such overload for decimal types
- Remove Math.Ln(decimal)
    - Does not exist in System.Math
    - It is an alias for Math.Log
- Add Math.Log(double, double) that is
    - Compatible with the implementation from .NET [(See code here)](https://referencesource.microsoft.com/#mscorlib/system/math.cs,506)
    - Compatible with tests from [HERE](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L239)
 - Add Math.Log10(double)


Script used to replicate the .NET tests from [JS Bin](http://jsbin.com/mevofadine/edit?js,console)
I Still can't seem to find Bridge.Test.dll which is why I am not able to test these changes
