### PR TITLE
[2137] CSharp6 Getter-only auto-properties cause too many closing braces emitted (not const in right-hand)

### DIFF
--- a/Compiler/Translator/Emitter/Blocks/FieldBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/FieldBlock.cs
@@ -97,7 +97,7 @@ namespace Bridge.Translator
 
             if (info.Properties.Count > 0)
             {
-                var hasProperties = this.WriteObject(JS.Fields.PROPERTIES, info.Properties, JS.Funcs.BRIDGE_PROPERTY + "(this, \"{0}\", {1});", JS.Funcs.BRIDGE_PROPERTY + "(this, {0}, {1});");
+                var hasProperties = this.WriteObject(JS.Fields.PROPERTIES, info.Properties, "this.{0} = {1};", "this[{0}] = {1};");
                 if (hasProperties)
                 {
                     this.Emitter.Comma = true;
@@ -478,9 +478,12 @@ namespace Bridge.Translator
                     return true;
                 }
 
-                if (!isPrimitive || (constValue is AstType && objectName != JS.Fields.PROPERTIES))
+                if (objectName != JS.Fields.PROPERTIES)
                 {
-                    continue;
+                    if (!isPrimitive || constValue is AstType)
+                    {
+                        continue;
+                    }
                 }
 
                 return true;

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -429,6 +429,7 @@
     <Compile Include="BridgeIssues\2100\N2114.cs" />
     <Compile Include="BridgeIssues\2100\N2106.cs" />
     <Compile Include="BridgeIssues\2100\N2121.cs" />
+    <Compile Include="BridgeIssues\2100\N2137.cs" />
     <Compile Include="BridgeIssues\2100\N2127.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />

--- a/Tests/Batch3/BridgeIssues/2100/N2137.cs
+++ b/Tests/Batch3/BridgeIssues/2100/N2137.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Globalization;
+using Bridge.Test;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#2137 - {0}")]
+    public class Bridge2137
+    {
+        public static object E1 { get; } = new string('E', 3);
+        public static object E2 { get; } = E1 + new string('E', 3);
+        public object E3 { get; } = "test" + E1;
+        public object E4 { get; }
+
+        public Bridge2137()
+        {
+            this.E4 = "_" + E3;
+        }
+
+        [Test]
+        public static void TestPropertiesWithNonPrimitiveInitializers()
+        {
+            var c = new Bridge2137();
+            Assert.AreEqual("EEE", E1);
+            Assert.AreEqual("EEEEEE", E2);
+            Assert.AreEqual("testEEE", c.E3);
+            Assert.AreEqual("_testEEE", c.E4);
+        }
+    }
+}

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -11340,8 +11340,8 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
                 Prop2: null
             },
             init: function () {
-                Bridge.property(this, "Prop1", Bridge.ClientTest.CSharp6.TestAutoProps.Customer.staticField);
-                Bridge.property(this, "Prop2", System.String.concat(Bridge.ClientTest.CSharp6.TestAutoProps.Customer.staticField, "2"));
+                this.Prop1 = Bridge.ClientTest.CSharp6.TestAutoProps.Customer.staticField;
+                this.Prop2 = System.String.concat(Bridge.ClientTest.CSharp6.TestAutoProps.Customer.staticField, "2");
             }
         },
         ctor: function (first, last) {

--- a/Tests/Runner/Batch1/test.js
+++ b/Tests/Runner/Batch1/test.js
@@ -2655,7 +2655,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ArgumentsTests",
-                    file: "Batch1\\ArgumentsTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/ArgumentsTests.cs"
                 } );
             }
             return this.context;
@@ -3064,7 +3064,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ArrayTests.ArrayTestsSet1",
-                    file: "Batch1\\ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -3228,7 +3228,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ArrayTests.ArrayTestsSet2",
-                    file: "Batch1\\ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -3266,7 +3266,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestAbstractClass",
-                    file: "Batch1\\BasicCSharp\\TestAbstractClass.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestAbstractClass.cs"
                 } );
             }
             return this.context;
@@ -3360,7 +3360,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestEnum",
-                    file: "Batch1\\BasicCSharp\\TestEnum.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestEnum.cs"
                 } );
             }
             return this.context;
@@ -3398,7 +3398,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestInheritance",
-                    file: "Batch1\\BasicCSharp\\TestInheritance.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestInheritance.cs"
                 } );
             }
             return this.context;
@@ -3436,7 +3436,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestInterfaces",
-                    file: "Batch1\\BasicCSharp\\TestInterfaces.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestInterfaces.cs"
                 } );
             }
             return this.context;
@@ -3460,7 +3460,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestMethodParametersClass",
-                    file: "Batch1\\BasicCSharp\\TestMethodParametersClass.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestMethodParametersClass.cs"
                 } );
             }
             return this.context;
@@ -3484,7 +3484,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestOverloadInstanceMethods",
-                    file: "Batch1\\BasicCSharp\\TestOverloadInstanceMethods.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestOverloadInstanceMethods.cs"
                 } );
             }
             return this.context;
@@ -3508,7 +3508,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestOverloadStaticMethods",
-                    file: "Batch1\\BasicCSharp\\TestOverloadStaticMethods.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestOverloadStaticMethods.cs"
                 } );
             }
             return this.context;
@@ -3546,7 +3546,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestReferenceTypes",
-                    file: "Batch1\\BasicCSharp\\TestReferenceTypes.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestReferenceTypes.cs"
                 } );
             }
             return this.context;
@@ -3598,7 +3598,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestTryCatchBlocks",
-                    file: "Batch1\\BasicCSharp\\TestTryCatchBlocks.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestTryCatchBlocks.cs"
                 } );
             }
             return this.context;
@@ -3636,7 +3636,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestTryCatchFinallyBlocks",
-                    file: "Batch1\\BasicCSharp\\TestTryCatchFinallyBlocks.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestTryCatchFinallyBlocks.cs"
                 } );
             }
             return this.context;
@@ -3667,7 +3667,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestValueTypes",
-                    file: "Batch1\\BasicCSharp\\TestValueTypes.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestValueTypes.cs"
                 } );
             }
             return this.context;
@@ -3691,7 +3691,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestVirtualMethods",
-                    file: "Batch1\\BasicCSharp\\TestVirtualMethods.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BasicCSharp/TestVirtualMethods.cs"
                 } );
             }
             return this.context;
@@ -3834,7 +3834,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Batch1.Reflection.AssemblyTests",
-                    file: "Batch1\\Reflection\\AssemblyTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Reflection/AssemblyTests.cs"
                 } );
             }
             return this.context;
@@ -3942,7 +3942,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Batch1.Reflection.AttributeTests",
-                    file: "Batch1\\Reflection\\AttributeTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Reflection/AttributeTests.cs"
                 } );
             }
             return this.context;
@@ -3966,7 +3966,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ObjectLiteralTests.Bridge1529",
-                    file: "Batch1\\ObjectLiteralTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/ObjectLiteralTests.cs"
                 } );
             }
             return this.context;
@@ -4043,7 +4043,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BridgeConsoleTests",
-                    file: "Batch1\\BridgeConsoleTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/BridgeConsoleTests.cs"
                 } );
             }
             return this.context;
@@ -4091,7 +4091,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.CheckedInsideUncheckedTests",
-                    file: "Batch1\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -4136,7 +4136,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.CheckedTests",
-                    file: "Batch1\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -4188,7 +4188,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.ComparerTests",
-                    file: "Batch1\\Collections\\Generic\\ComparerTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Generic/ComparerTests.cs"
                 } );
             }
             return this.context;
@@ -4247,7 +4247,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.EqualityComparerTests",
-                    file: "Batch1\\Collections\\Generic\\EqualityComparerTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Generic/EqualityComparerTests.cs"
                 } );
             }
             return this.context;
@@ -4404,7 +4404,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.GenericDictionaryTests",
-                    file: "Batch1\\Collections\\Generic\\GenericDictionaryTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Generic/GenericDictionaryTests.cs"
                 } );
             }
             return this.context;
@@ -4554,7 +4554,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.ICollectionTests",
-                    file: "Batch1\\Collections\\Generic\\ICollectionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Generic/ICollectionTests.cs"
                 } );
             }
             return this.context;
@@ -4655,7 +4655,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.IDictionaryTests",
-                    file: "Batch1\\Collections\\Generic\\IDictionaryTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Generic/IDictionaryTests.cs"
                 } );
             }
             return this.context;
@@ -4714,7 +4714,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.IEnumerableTests",
-                    file: "Batch1\\Collections\\Generic\\IEnumerableTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Generic/IEnumerableTests.cs"
                 } );
             }
             return this.context;
@@ -4878,7 +4878,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.IListTests",
-                    file: "Batch1\\Collections\\Generic\\IListTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Generic/IListTests.cs"
                 } );
             }
             return this.context;
@@ -4965,7 +4965,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.IteratorBlockTests",
-                    file: "Batch1\\Collections\\Generic\\IteratorBlockTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Generic/IteratorBlockTests.cs"
                 } );
             }
             return this.context;
@@ -5402,7 +5402,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.ListTests",
-                    file: "Batch1\\Collections\\Generic\\ListTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Generic/ListTests.cs"
                 } );
             }
             return this.context;
@@ -5615,7 +5615,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests",
-                    file: "Batch1\\Collections\\ObjectModel\\ReadOnlyCollectionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/ObjectModel/ReadOnlyCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -5639,7 +5639,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.WeakMapTests",
-                    file: "Batch1\\Collections\\Native\\WeakMapTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/WeakMapTests.cs"
                 } );
             }
             return this.context;
@@ -5677,7 +5677,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.ArrayBufferTests",
-                    file: "Batch1\\Collections\\Native\\ArrayBufferTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/ArrayBufferTests.cs"
                 } );
             }
             return this.context;
@@ -5834,7 +5834,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.DataViewTests",
-                    file: "Batch1\\Collections\\Native\\DataViewTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/DataViewTests.cs"
                 } );
             }
             return this.context;
@@ -6047,7 +6047,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Float32ArrayTests",
-                    file: "Batch1\\Collections\\Native\\Float32ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/Float32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -6260,7 +6260,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Float64ArrayTests",
-                    file: "Batch1\\Collections\\Native\\Float64ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/Float64ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -6473,7 +6473,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Int16ArrayTests",
-                    file: "Batch1\\Collections\\Native\\Int16ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/Int16ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -6686,7 +6686,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Int32ArrayTests",
-                    file: "Batch1\\Collections\\Native\\Int32ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/Int32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -6899,7 +6899,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Int8ArrayTests",
-                    file: "Batch1\\Collections\\Native\\Int8ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/Int8ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -7112,7 +7112,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Uint16ArrayTests",
-                    file: "Batch1\\Collections\\Native\\Uint16ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/Uint16ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -7325,7 +7325,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Uint32ArrayTests",
-                    file: "Batch1\\Collections\\Native\\Uint32ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/Uint32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -7538,7 +7538,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Uint8ArrayTests",
-                    file: "Batch1\\Collections\\Native\\Uint8ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/Uint8ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -7758,7 +7758,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Uint8ClampedArrayTests",
-                    file: "Batch1\\Collections\\Native\\Uint8ClampedArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Collections/Native/Uint8ClampedArrayTests.cs"
                 } );
             }
             return this.context;
@@ -7922,7 +7922,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertFromBase64Tests",
-                    file: "Batch1\\Convert\\ConvertFromBase64Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertFromBase64Tests.cs"
                 } );
             }
             return this.context;
@@ -7995,7 +7995,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToBase64CharArrayTests",
-                    file: "Batch1\\Convert\\ConvertToBase64CharArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToBase64CharArrayTests.cs"
                 } );
             }
             return this.context;
@@ -8047,7 +8047,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToBase64StringTests",
-                    file: "Batch1\\Convert\\ConvertToBase64StringTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToBase64StringTests.cs"
                 } );
             }
             return this.context;
@@ -8162,7 +8162,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToBooleanTests",
-                    file: "Batch1\\Convert\\ConvertToBooleanTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToBooleanTests.cs"
                 } );
             }
             return this.context;
@@ -8284,7 +8284,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToByteTests",
-                    file: "Batch1\\Convert\\ConvertToByteTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToByteTests.cs"
                 } );
             }
             return this.context;
@@ -8420,7 +8420,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToCharTests",
-                    file: "Batch1\\Convert\\ConvertToCharTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToCharTests.cs"
                 } );
             }
             return this.context;
@@ -8542,7 +8542,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToDateTimeTests",
-                    file: "Batch1\\Convert\\ConvertToDateTimeTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToDateTimeTests.cs"
                 } );
             }
             return this.context;
@@ -8657,7 +8657,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToDecimalTests",
-                    file: "Batch1\\Convert\\ConvertToDecimalTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToDecimalTests.cs"
                 } );
             }
             return this.context;
@@ -8772,7 +8772,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToDoubleTests",
-                    file: "Batch1\\Convert\\ConvertToDoubleTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToDoubleTests.cs"
                 } );
             }
             return this.context;
@@ -8901,7 +8901,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToInt16Tests",
-                    file: "Batch1\\Convert\\ConvertToInt16Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToInt16Tests.cs"
                 } );
             }
             return this.context;
@@ -9030,7 +9030,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToInt32Tests",
-                    file: "Batch1\\Convert\\ConvertToInt32Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToInt32Tests.cs"
                 } );
             }
             return this.context;
@@ -9159,7 +9159,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToInt64Tests",
-                    file: "Batch1\\Convert\\ConvertToInt64Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToInt64Tests.cs"
                 } );
             }
             return this.context;
@@ -9288,7 +9288,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToSByteTests",
-                    file: "Batch1\\Convert\\ConvertToSByteTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToSByteTests.cs"
                 } );
             }
             return this.context;
@@ -9403,7 +9403,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToSingleTests",
-                    file: "Batch1\\Convert\\ConvertToSingleTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToSingleTests.cs"
                 } );
             }
             return this.context;
@@ -9700,7 +9700,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToStringTests",
-                    file: "Batch1\\Convert\\ConvertToStringTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToStringTests.cs"
                 } );
             }
             return this.context;
@@ -9829,7 +9829,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToUInt16Tests",
-                    file: "Batch1\\Convert\\ConvertToUInt16Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToUInt16Tests.cs"
                 } );
             }
             return this.context;
@@ -9958,7 +9958,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToUInt32Tests",
-                    file: "Batch1\\Convert\\ConvertToUInt32Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToUInt32Tests.cs"
                 } );
             }
             return this.context;
@@ -10087,7 +10087,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToUInt64Tests",
-                    file: "Batch1\\Convert\\ConvertToUInt64Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Convert/ConvertToUInt64Tests.cs"
                 } );
             }
             return this.context;
@@ -10111,7 +10111,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ObjectLiteralTests.CreateAndInitializationModesTests",
-                    file: "Batch1\\ObjectLiteralTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/ObjectLiteralTests.cs"
                 } );
             }
             return this.context;
@@ -10135,7 +10135,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ObjectLiteralTests.CreateModeTests",
-                    file: "Batch1\\ObjectLiteralTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/ObjectLiteralTests.cs"
                 } );
             }
             return this.context;
@@ -10148,7 +10148,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
             testBasic: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.CSharp6.TestAutoProps).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_CSharp6_TestAutoProps, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "TestBasic()",
-                    line: "29"
+                    line: "33"
                 } ));
                 Bridge.ClientTest.CSharp6.TestAutoProps.testBasic();
             }
@@ -10159,7 +10159,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestAutoProps",
-                    file: "Batch1\\CSharp6\\TestAutoProps.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CSharp6/TestAutoProps.cs"
                 } );
             }
             return this.context;
@@ -10183,7 +10183,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestAwaitInCatchFinally",
-                    file: "Batch1\\CSharp6\\TestAwaitInCatchFinally.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CSharp6/TestAwaitInCatchFinally.cs"
                 } );
             }
             return this.context;
@@ -10207,7 +10207,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestConditionAccess",
-                    file: "Batch1\\CSharp6\\TestConditionalAccess.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CSharp6/TestConditionalAccess.cs"
                 } );
             }
             return this.context;
@@ -10238,7 +10238,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestExceptionFilter",
-                    file: "Batch1\\CSharp6\\TestExceptionFilter.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CSharp6/TestExceptionFilter.cs"
                 } );
             }
             return this.context;
@@ -10262,7 +10262,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestExpressionBodyFunction",
-                    file: "Batch1\\CSharp6\\TestExpressionBodyFunction.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CSharp6/TestExpressionBodyFunction.cs"
                 } );
             }
             return this.context;
@@ -10286,7 +10286,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestIndexInitializer",
-                    file: "Batch1\\CSharp6\\TestIndexInitializer.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CSharp6/TestIndexInitializer.cs"
                 } );
             }
             return this.context;
@@ -10299,7 +10299,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
             testBasic: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.CSharp6.TestInterpolatedStrings).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_CSharp6_TestInterpolatedStrings, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "TestBasic()",
-                    line: "35"
+                    line: "37"
                 } ));
                 Bridge.ClientTest.CSharp6.TestInterpolatedStrings.testBasic();
             }
@@ -10310,7 +10310,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestInterpolatedStrings",
-                    file: "Batch1\\CSharp6\\TestInterpolatedStrings.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CSharp6/TestInterpolatedStrings.cs"
                 } );
             }
             return this.context;
@@ -10334,7 +10334,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestNameOf",
-                    file: "Batch1\\CSharp6\\TestNameof.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CSharp6/TestNameof.cs"
                 } );
             }
             return this.context;
@@ -10358,7 +10358,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestUsingStatic",
-                    file: "Batch1\\CSharp6\\TestUsingStatic.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CSharp6/TestUsingStatic.cs"
                 } );
             }
             return this.context;
@@ -10396,7 +10396,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CultureInfoTests",
-                    file: "Batch1\\CultureInfoTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CultureInfoTests.cs"
                 } );
             }
             return this.context;
@@ -10497,7 +10497,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.DecimalMathTests",
-                    file: "Batch1\\DecimalMathTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/DecimalMathTests.cs"
                 } );
             }
             return this.context;
@@ -10598,7 +10598,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Diagnostics.Contracts.ContractTests",
-                    file: "Batch1\\Diagnostics\\Contracts\\ContractTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Diagnostics/Contracts/ContractTests.cs"
                 } );
             }
             return this.context;
@@ -10657,7 +10657,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Diagnostics.StopwatchTests",
-                    file: "Batch1\\Diagnostics\\StopwatchTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Diagnostics/StopwatchTests.cs"
                 } );
             }
             return this.context;
@@ -10681,7 +10681,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.EnvironmentTests",
-                    file: "Batch1\\EnvironmentTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/EnvironmentTests.cs"
                 } );
             }
             return this.context;
@@ -10754,7 +10754,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.AggregateExceptionTests",
-                    file: "Batch1\\Exceptions\\AggregateExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/AggregateExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -10799,7 +10799,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.AmbiguousMatchExceptionTests",
-                    file: "Batch1\\Exceptions\\AmbiguousMatchExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/AmbiguousMatchExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -10858,7 +10858,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ArgumentExceptionTests",
-                    file: "Batch1\\Exceptions\\ArgumentExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/ArgumentExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -10910,7 +10910,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ArgumentNullExceptionTests",
-                    file: "Batch1\\Exceptions\\ArgumentNullExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/ArgumentNullExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -10976,7 +10976,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ArgumentOutOfRangeExceptionTests",
-                    file: "Batch1\\Exceptions\\ArgumentOutOfRangeExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/ArgumentOutOfRangeExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11021,7 +11021,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ArithmeticExceptionTests",
-                    file: "Batch1\\Exceptions\\ArithmeticExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/ArithmeticExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11073,7 +11073,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.CommonExceptionTests",
-                    file: "Batch1\\Exceptions\\CommonExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/CommonExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11153,7 +11153,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.CultureNotFoundExceptionTests",
-                    file: "Batch1\\Exceptions\\CultureNotFoundExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/CultureNotFoundExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11198,7 +11198,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.DivideByZeroExceptionTests",
-                    file: "Batch1\\Exceptions\\DivideByZeroExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/DivideByZeroExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11257,7 +11257,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ExceptionTests",
-                    file: "Batch1\\Exceptions\\ExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/ExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11302,7 +11302,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.FormatExceptionTests",
-                    file: "Batch1\\Exceptions\\FormatExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/FormatExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11347,7 +11347,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.IndexOutOfRangeExceptionTests",
-                    file: "Batch1\\Exceptions\\IndexOutOfRangeExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/IndexOutOfRangeExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11392,7 +11392,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.InvalidCastExceptionTests",
-                    file: "Batch1\\Exceptions\\InvalidCastExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/InvalidCastExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11437,7 +11437,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.InvalidOperationExceptionTests",
-                    file: "Batch1\\Exceptions\\InvalidOperationExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/InvalidOperationExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11482,7 +11482,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.KeyNotFoundExceptionTests",
-                    file: "Batch1\\Exceptions\\KeyNotFoundExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/KeyNotFoundExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11527,7 +11527,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.NotImplementedExceptionTests",
-                    file: "Batch1\\Exceptions\\NotImplementedExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/NotImplementedExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11572,7 +11572,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.NotSupportedExceptionTests",
-                    file: "Batch1\\Exceptions\\NotSupportedExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/NotSupportedExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11624,7 +11624,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.NullReferenceExceptionTests",
-                    file: "Batch1\\Exceptions\\NullReferenceExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/NullReferenceExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11690,7 +11690,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.OperationCanceledExceptionTests",
-                    file: "Batch1\\Exceptions\\OperationCanceledExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/OperationCanceledExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11735,7 +11735,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.OutOfMemoryExceptionTests",
-                    file: "Batch1\\Exceptions\\OutOfMemoryExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/OutOfMemoryExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11780,7 +11780,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.OverflowExceptionTests",
-                    file: "Batch1\\Exceptions\\OverflowExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/OverflowExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11825,7 +11825,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.PromiseExceptionTests",
-                    file: "Batch1\\Exceptions\\PromiseExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/PromiseExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11863,7 +11863,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.RankExceptionTests",
-                    file: "Batch1\\Exceptions\\RankExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/RankExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11915,7 +11915,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.RegexMatchTimeoutExceptionTests",
-                    file: "Batch1\\Exceptions\\RegexMatchTimeoutExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/RegexMatchTimeoutExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11960,7 +11960,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.SystemExceptionTests",
-                    file: "Batch1\\Exceptions\\SystemExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/SystemExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -12012,7 +12012,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.TaskCanceledExceptionTests",
-                    file: "Batch1\\Exceptions\\TaskCanceledExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/TaskCanceledExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -12057,7 +12057,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.TimeoutExceptionTests",
-                    file: "Batch1\\Exceptions\\TimeoutExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Exceptions/TimeoutExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -12095,7 +12095,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Format.DateTimeFormatInfoTests",
-                    file: "Batch1\\Format\\DateTimeFormatInfoTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Format/DateTimeFormatInfoTests.cs"
                 } );
             }
             return this.context;
@@ -12133,7 +12133,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Format.NumberFormatInfoTests",
-                    file: "Batch1\\Format\\NumberFormatInfoTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Format/NumberFormatInfoTests.cs"
                 } );
             }
             return this.context;
@@ -12269,7 +12269,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Format.NumberFormatSpecifiersTests",
-                    file: "Batch1\\Format\\NumberFormatSpecifiersTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Format/NumberFormatSpecifiersTests.cs"
                 } );
             }
             return this.context;
@@ -12342,7 +12342,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Format.StringFormatTests",
-                    file: "Batch1\\Format\\StringFormatTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Format/StringFormatTests.cs"
                 } );
             }
             return this.context;
@@ -12415,7 +12415,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.FormattableStringTests",
-                    file: "Batch1\\FormattableStringTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/FormattableStringTests.cs"
                 } );
             }
             return this.context;
@@ -12453,7 +12453,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.FunctionTests",
-                    file: "Batch1\\FunctionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/FunctionTests.cs"
                 } );
             }
             return this.context;
@@ -12652,7 +12652,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.GuidTests",
-                    file: "Batch1\\GuidTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/GuidTests.cs"
                 } );
             }
             return this.context;
@@ -12676,7 +12676,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.IComparableTests",
-                    file: "Batch1\\IComparableTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/IComparableTests.cs"
                 } );
             }
             return this.context;
@@ -12700,7 +12700,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.IEquatableTests",
-                    file: "Batch1\\IEquatableTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/IEquatableTests.cs"
                 } );
             }
             return this.context;
@@ -12724,7 +12724,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ObjectLiteralTests.InitializationModeTests",
-                    file: "Batch1\\ObjectLiteralTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/ObjectLiteralTests.cs"
                 } );
             }
             return this.context;
@@ -12958,7 +12958,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.JsonTests",
-                    file: "Batch1\\Serialization\\JsonTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Serialization/JsonTests.cs"
                 } );
             }
             return this.context;
@@ -13290,7 +13290,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.Expressions.ExpressionTests",
-                    file: "Batch1\\Linq\\Expressions\\ExpressionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/Expressions/ExpressionTests.cs"
                 } );
             }
             return this.context;
@@ -13321,7 +13321,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqAggregateOperators",
-                    file: "Batch1\\Linq\\TestLinqAggregateOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqAggregateOperators.cs"
                 } );
             }
             return this.context;
@@ -13345,7 +13345,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqConversionOperators",
-                    file: "Batch1\\Linq\\TestLinqConversionOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqConversionOperators.cs"
                 } );
             }
             return this.context;
@@ -13369,7 +13369,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqElementOperators",
-                    file: "Batch1\\Linq\\TestLinqElementOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqElementOperators.cs"
                 } );
             }
             return this.context;
@@ -13393,7 +13393,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqGenerationOperators",
-                    file: "Batch1\\Linq\\TestLinqGenerationOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqGenerationOperators.cs"
                 } );
             }
             return this.context;
@@ -13431,7 +13431,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqGroupingOperators",
-                    file: "Batch1\\Linq\\TestLinqGroupingOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqGroupingOperators.cs"
                 } );
             }
             return this.context;
@@ -13455,7 +13455,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqJoinOperators",
-                    file: "Batch1\\Linq\\TestLinqJoinOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqJoinOperators.cs"
                 } );
             }
             return this.context;
@@ -13479,7 +13479,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqMiscellaneousOperators",
-                    file: "Batch1\\Linq\\TestLinqMiscellaneousOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqMiscellaneousOperators.cs"
                 } );
             }
             return this.context;
@@ -13503,7 +13503,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqOrderingOperators",
-                    file: "Batch1\\Linq\\TestLinqOrderingOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqOrderingOperators.cs"
                 } );
             }
             return this.context;
@@ -13527,7 +13527,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqPartitioningOperators",
-                    file: "Batch1\\Linq\\TestLinqPartitioningOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqPartitioningOperators.cs"
                 } );
             }
             return this.context;
@@ -13551,7 +13551,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqProjectionOperators",
-                    file: "Batch1\\Linq\\TestLinqProjectionOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqProjectionOperators.cs"
                 } );
             }
             return this.context;
@@ -13575,7 +13575,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqQuantifiers",
-                    file: "Batch1\\Linq\\TestLinqQuantifiers.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqQuantifiers.cs"
                 } );
             }
             return this.context;
@@ -13599,7 +13599,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqQueryExecution",
-                    file: "Batch1\\Linq\\TestLinqQueryExecution.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqQueryExecution.cs"
                 } );
             }
             return this.context;
@@ -13623,7 +13623,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqRestrictionOperators",
-                    file: "Batch1\\Linq\\TestLinqRestrictionOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqRestrictionOperators.cs"
                 } );
             }
             return this.context;
@@ -13647,7 +13647,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqSetOperators",
-                    file: "Batch1\\Linq\\TestLinqSetOperators.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Linq/TestLinqSetOperators.cs"
                 } );
             }
             return this.context;
@@ -14028,7 +14028,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.MathTests",
-                    file: "Batch1\\MathTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/MathTests.cs"
                 } );
             }
             return this.context;
@@ -14059,7 +14059,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.MixinTests",
-                    file: "Batch1\\MixinTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/MixinTests.cs"
                 } );
             }
             return this.context;
@@ -14181,7 +14181,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.MultidimArrayTests",
-                    file: "Batch1\\MultidimArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/MultidimArrayTests.cs"
                 } );
             }
             return this.context;
@@ -14205,7 +14205,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.MutationObserverTests",
-                    file: "Batch1\\MutationObserverTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/MutationObserverTests.cs"
                 } );
             }
             return this.context;
@@ -14453,7 +14453,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.NullableTests",
-                    file: "Batch1\\NullableTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/NullableTests.cs"
                 } );
             }
             return this.context;
@@ -14512,7 +14512,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.PropertyAccessorTests",
-                    file: "Batch1\\PropertyAccessorTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/PropertyAccessorTests.cs"
                 } );
             }
             return this.context;
@@ -14550,7 +14550,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.RandomTests",
-                    file: "Batch1\\RandomTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/RandomTests.cs"
                 } );
             }
             return this.context;
@@ -14763,7 +14763,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.GetMembersTests",
-                    file: "Batch1\\Reflection\\GetMembersTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Reflection/GetMembersTests.cs"
                 } );
             }
             return this.context;
@@ -15424,7 +15424,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.ReflectionTests",
-                    file: "Batch1\\Reflection\\ReflectionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Reflection/ReflectionTests.cs"
                 } );
             }
             return this.context;
@@ -15616,7 +15616,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.TypeAttributeTests",
-                    file: "Batch1\\Reflection\\TypeAttributeTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Reflection/TypeAttributeTests.cs"
                 } );
             }
             return this.context;
@@ -15682,7 +15682,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests",
-                    file: "Batch1\\Reflection\\TypeSystemLanguageSupportTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Reflection/TypeSystemLanguageSupportTests.cs"
                 } );
             }
             return this.context;
@@ -16063,7 +16063,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.TypeSystemTests",
-                    file: "Batch1\\Reflection\\TypeSystemTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Reflection/TypeSystemTests.cs"
                 } );
             }
             return this.context;
@@ -16220,7 +16220,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.BooleanTests",
-                    file: "Batch1\\SimpleTypes\\BooleanTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/BooleanTests.cs"
                 } );
             }
             return this.context;
@@ -16356,7 +16356,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.ByteTests",
-                    file: "Batch1\\SimpleTypes\\ByteTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/ByteTests.cs"
                 } );
             }
             return this.context;
@@ -16534,7 +16534,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.CharTests",
-                    file: "Batch1\\SimpleTypes\\CharTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/CharTests.cs"
                 } );
             }
             return this.context;
@@ -16761,7 +16761,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.DecimalTests",
-                    file: "Batch1\\SimpleTypes\\DecimalTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/DecimalTests.cs"
                 } );
             }
             return this.context;
@@ -17138,7 +17138,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.DoubleTests",
-                    file: "Batch1\\SimpleTypes\\DoubleTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/DoubleTests.cs"
                 } );
             }
             return this.context;
@@ -17189,7 +17189,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.EnumTests",
-                    file: "Batch1\\SimpleTypes\\EnumTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/EnumTests.cs"
                 } );
             }
             return this.context;
@@ -17325,7 +17325,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.Int16Tests",
-                    file: "Batch1\\SimpleTypes\\Int16Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/Int16Tests.cs"
                 } );
             }
             return this.context;
@@ -17510,7 +17510,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.Int32Tests",
-                    file: "Batch1\\SimpleTypes\\Int32Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/Int32Tests.cs"
                 } );
             }
             return this.context;
@@ -17681,7 +17681,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.Int64Tests",
-                    file: "Batch1\\SimpleTypes\\Int64Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/Int64Tests.cs"
                 } );
             }
             return this.context;
@@ -18118,7 +18118,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.JsDateTimeTests",
-                    file: "Batch1\\SimpleTypes\\JsDateTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/JsDateTests.cs"
                 } );
             }
             return this.context;
@@ -18191,7 +18191,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.ObjectTests",
-                    file: "Batch1\\SimpleTypes\\ObjectTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/ObjectTests.cs"
                 } );
             }
             return this.context;
@@ -18327,7 +18327,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.SByteTests",
-                    file: "Batch1\\SimpleTypes\\SByteTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/SByteTests.cs"
                 } );
             }
             return this.context;
@@ -18512,7 +18512,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.SingleTests",
-                    file: "Batch1\\SimpleTypes\\SingleTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/SingleTests.cs"
                 } );
             }
             return this.context;
@@ -19194,7 +19194,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.StringTests",
-                    file: "Batch1\\SimpleTypes\\StringTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/StringTests.cs"
                 } );
             }
             return this.context;
@@ -19253,7 +19253,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.TestVersion",
-                    file: "Batch1\\SimpleTypes\\TestVersion.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/TestVersion.cs"
                 } );
             }
             return this.context;
@@ -19431,7 +19431,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.TimeSpanTests",
-                    file: "Batch1\\SimpleTypes\\TimeSpanTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/TimeSpanTests.cs"
                 } );
             }
             return this.context;
@@ -19504,7 +19504,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.TupleTests",
-                    file: "Batch1\\SimpleTypes\\TupleTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/TupleTests.cs"
                 } );
             }
             return this.context;
@@ -19640,7 +19640,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.UInt16Tests",
-                    file: "Batch1\\SimpleTypes\\UInt16Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/UInt16Tests.cs"
                 } );
             }
             return this.context;
@@ -19776,7 +19776,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.UInt32Tests",
-                    file: "Batch1\\SimpleTypes\\UInt32Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/UInt32Tests.cs"
                 } );
             }
             return this.context;
@@ -19947,7 +19947,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.UInt64Tests",
-                    file: "Batch1\\SimpleTypes\\UInt64Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/SimpleTypes/UInt64Tests.cs"
                 } );
             }
             return this.context;
@@ -19999,7 +19999,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexCaptureCollectionTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexCaptureCollectionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexCaptureCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -20107,7 +20107,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexEntityTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexEntityTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexEntityTests.cs"
                 } );
             }
             return this.context;
@@ -20159,7 +20159,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexGroupCollectionTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexGroupCollectionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexGroupCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -20225,7 +20225,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexMatchCollectionTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexMatchCollectionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexMatchCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -20291,7 +20291,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexMatchEntityTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexMatchEntityTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexMatchEntityTests.cs"
                 } );
             }
             return this.context;
@@ -20343,7 +20343,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexMatchSparseTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexMatchSparseTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexMatchSparseTests.cs"
                 } );
             }
             return this.context;
@@ -20444,7 +20444,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.JavaScript.BridgeRegexTests",
-                    file: "Batch1\\Text\\RegularExpressions\\JavaScript\\BridgeRegexTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/JavaScript/BridgeRegexTests.cs"
                 } );
             }
             return this.context;
@@ -20489,7 +20489,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexEscapeTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexEscapeTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexEscapeTests.cs"
                 } );
             }
             return this.context;
@@ -20541,7 +20541,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexIsMatchTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexIsMatchTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexIsMatchTests.cs"
                 } );
             }
             return this.context;
@@ -20593,7 +20593,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexMatchesTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexMatchesTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexMatchesTests.cs"
                 } );
             }
             return this.context;
@@ -20652,7 +20652,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexMatchTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexMatchTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexMatchTests.cs"
                 } );
             }
             return this.context;
@@ -20760,7 +20760,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexReplaceTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexReplaceTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexReplaceTests.cs"
                 } );
             }
             return this.context;
@@ -20917,7 +20917,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexSplitTests",
-                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexSplitTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexSplitTests.cs"
                 } );
             }
             return this.context;
@@ -21235,7 +21235,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexAlternationTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexAlternationTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexAlternationTests.cs"
                 } );
             }
             return this.context;
@@ -21399,7 +21399,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexAnchorsTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexAnchorsTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexAnchorsTests.cs"
                 } );
             }
             return this.context;
@@ -21521,7 +21521,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexBackreferenceTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexBackreferenceTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexBackreferenceTests.cs"
                 } );
             }
             return this.context;
@@ -21615,7 +21615,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexBalancingGroupsTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexBalancingGroupsTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexBalancingGroupsTests.cs"
                 } );
             }
             return this.context;
@@ -21968,7 +21968,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexCharClassesTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexCharClassesTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexCharClassesTests.cs"
                 } );
             }
             return this.context;
@@ -22125,7 +22125,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexEscapesTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexEscapesTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexEscapesTests.cs"
                 } );
             }
             return this.context;
@@ -22198,7 +22198,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexExamplesTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexExamplesTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexExamplesTests.cs"
                 } );
             }
             return this.context;
@@ -22481,7 +22481,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexInlineOptionsTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexInlineOptionsTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexInlineOptionsTests.cs"
                 } );
             }
             return this.context;
@@ -22575,7 +22575,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexLookaheadTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexLookaheadTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexLookaheadTests.cs"
                 } );
             }
             return this.context;
@@ -22676,7 +22676,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexLookbehindTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexLookbehindTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexLookbehindTests.cs"
                 } );
             }
             return this.context;
@@ -22749,7 +22749,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexNonbacktrackingTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexNonbacktrackingTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexNonbacktrackingTests.cs"
                 } );
             }
             return this.context;
@@ -22885,7 +22885,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexOptionsTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexOptionsTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexOptionsTests.cs"
                 } );
             }
             return this.context;
@@ -23070,7 +23070,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexQuantifiersTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexQuantifiersTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexQuantifiersTests.cs"
                 } );
             }
             return this.context;
@@ -23178,7 +23178,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexTimeoutTests",
-                    file: "Batch1\\Text\\RegularExpressions\\RegexTimeoutTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/RegularExpressions/RegexTimeoutTests.cs"
                 } );
             }
             return this.context;
@@ -23321,7 +23321,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.StringBuilderTests",
-                    file: "Batch1\\Text\\StringBuilderTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Text/StringBuilderTests.cs"
                 } );
             }
             return this.context;
@@ -23380,7 +23380,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.AsyncTests",
-                    file: "Batch1\\Threading\\Tasks\\AsyncTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Threading/Tasks/AsyncTests.cs"
                 } );
             }
             return this.context;
@@ -23593,7 +23593,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.CancellationTokenTests",
-                    file: "Batch1\\Threading\\CancellationTokenTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Threading/CancellationTokenTests.cs"
                 } );
             }
             return this.context;
@@ -23652,7 +23652,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.PromiseTests",
-                    file: "Batch1\\Threading\\Tasks\\PromiseTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Threading/Tasks/PromiseTests.cs"
                 } );
             }
             return this.context;
@@ -23984,7 +23984,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.TaskTests",
-                    file: "Batch1\\Threading\\Tasks\\TaskTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Threading/Tasks/TaskTests.cs"
                 } );
             }
             return this.context;
@@ -24043,7 +24043,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.TimerTests",
-                    file: "Batch1\\Threading\\TimerTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/Threading/TimerTests.cs"
                 } );
             }
             return this.context;
@@ -24074,7 +24074,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.TypeSystemTests",
-                    file: "Batch1\\TypeSystemTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/TypeSystemTests.cs"
                 } );
             }
             return this.context;
@@ -24119,7 +24119,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.UncheckedInsideCheckedTests",
-                    file: "Batch1\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -24164,7 +24164,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.UncheckedTests",
-                    file: "Batch1\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -24209,7 +24209,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.WithNoUncheckedKeywordTests",
-                    file: "Batch1\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;

--- a/Tests/Runner/Batch2/test.js
+++ b/Tests/Runner/Batch2/test.js
@@ -100,7 +100,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.Bridge1385",
-                    file: "Batch2\\BridgeIssues\\N1385.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/BridgeIssues/N1385.cs"
                 } );
             }
             return this.context;
@@ -124,7 +124,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.Bridge1499",
-                    file: "Batch2\\BridgeIssues\\N1499.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/BridgeIssues/N1499.cs"
                 } );
             }
             return this.context;
@@ -155,7 +155,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.N1122",
-                    file: "Batch2\\BridgeIssues\\N1122.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/BridgeIssues/N1122.cs"
                 } );
             }
             return this.context;
@@ -179,7 +179,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.N1204",
-                    file: "Batch2\\BridgeIssues\\N1204.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/BridgeIssues/N1204.cs"
                 } );
             }
             return this.context;
@@ -546,7 +546,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.N772",
-                    file: "Batch2\\BridgeIssues\\N772.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/BridgeIssues/N772.cs"
                 } );
             }
             return this.context;
@@ -591,7 +591,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.CheckedInsideUncheckedTests",
-                    file: "Batch2\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -636,7 +636,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.CheckedTests",
-                    file: "Batch2\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -681,7 +681,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.UncheckedInsideCheckedTests",
-                    file: "Batch2\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -726,7 +726,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.UncheckedTests",
-                    file: "Batch2\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -771,7 +771,7 @@ Bridge.assembly("Bridge_ClientTest_Batch2_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.WithNoUncheckedKeywordTests",
-                    file: "Batch2\\CheckedUncheckedTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -7150,8 +7150,6 @@ Bridge.$N1391Result =                 r;
                                 done = Bridge.Test.Assert.async();
 
                                     foo = null; /// Async method lacks 'await' operators and will run synchronously
-
-
                                     bar = Bridge.fn.bind(this, function () {
                                         var $step = 0,
                                             $jumpFromFinally, 
@@ -7181,7 +7179,7 @@ Bridge.$N1391Result =                 r;
 
                                         $asyncBody();
                                         return $tcs.task;
-                                    });
+                                    }); /// Async method lacks 'await' operators and will run synchronously
                                     $task1 = bar();
                                     $step = 1;
                                     $task1.continueWith($asyncBody, true);
@@ -12000,6 +11998,41 @@ Bridge.$N1391Result =                 r;
 
                 Bridge.Test.Assert.areEqual("NaN", nanSymbol);
             }
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137", {
+        statics: {
+            config: {
+                properties: {
+                    E1: null,
+                    E2: null
+                },
+                init: function () {
+                    this.E1 = System.String.fromCharCount(69, 3);
+                    this.E2 = System.String.concat(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137.getE1(), System.String.fromCharCount(69, 3));
+                }
+            },
+            testPropertiesWithNonPrimitiveInitializers: function () {
+                var c = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137();
+                Bridge.Test.Assert.areEqual("EEE", Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137.getE1());
+                Bridge.Test.Assert.areEqual("EEEEEE", Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137.getE2());
+                Bridge.Test.Assert.areEqual("testEEE", c.getE3());
+                Bridge.Test.Assert.areEqual("_testEEE", c.getE4());
+            }
+        },
+        config: {
+            properties: {
+                E3: null,
+                E4: null
+            },
+            init: function () {
+                this.E3 = System.String.concat("test", Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137.getE1());
+            }
+        },
+        ctor: function () {
+            this.$initialize();
+            this.setE4(System.String.concat("_", this.getE3()));
         }
     });
 

--- a/Tests/Runner/Batch3/test.js
+++ b/Tests/Runner/Batch3/test.js
@@ -375,6 +375,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
             QUnit.test("#2114 - TestFieldTemplates", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2114.testFieldTemplates);
             QUnit.test("#2121 - TestLongAsDictionaryKey", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2121.testLongAsDictionaryKey);
             QUnit.test("#2127 - TestNumberFormatInfoNaNSymbol", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2127.testNumberFormatInfoNaNSymbol);
+            QUnit.test("#2137 - TestPropertiesWithNonPrimitiveInitializers", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2137.testPropertiesWithNonPrimitiveInitializers);
             QUnit.test("#381 - TestUseCase", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge381.testUseCase);
             QUnit.test("#447 - CheckInlineExpression", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge447.checkInlineExpression);
             QUnit.test("#447 - CheckInlineCalls", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge447.checkInlineCalls);
@@ -599,7 +600,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge069",
-                    file: "Batch3\\BridgeIssues\\0100\\N069.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0100/N069.cs"
                 } );
             }
             return this.context;
@@ -623,7 +624,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1000",
-                    file: "Batch3\\BridgeIssues\\1000\\N1000.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1000.cs"
                 } );
             }
             return this.context;
@@ -647,7 +648,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1001",
-                    file: "Batch3\\BridgeIssues\\1000\\N1001.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1001.cs"
                 } );
             }
             return this.context;
@@ -671,7 +672,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1003",
-                    file: "Batch3\\BridgeIssues\\1000\\N1003.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1003.cs"
                 } );
             }
             return this.context;
@@ -716,7 +717,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1012",
-                    file: "Batch3\\BridgeIssues\\1000\\N1012.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1012.cs"
                 } );
             }
             return this.context;
@@ -747,7 +748,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1020",
-                    file: "Batch3\\BridgeIssues\\1000\\N1020.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1020.cs"
                 } );
             }
             return this.context;
@@ -771,7 +772,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1024",
-                    file: "Batch3\\BridgeIssues\\1000\\N1024.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1024.cs"
                 } );
             }
             return this.context;
@@ -886,7 +887,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1025",
-                    file: "Batch3\\BridgeIssues\\1000\\N1025.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1025.cs"
                 } );
             }
             return this.context;
@@ -910,7 +911,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1026",
-                    file: "Batch3\\BridgeIssues\\1000\\N1026.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1026.cs"
                 } );
             }
             return this.context;
@@ -934,7 +935,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1027",
-                    file: "Batch3\\BridgeIssues\\1000\\N1027.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1027.cs"
                 } );
             }
             return this.context;
@@ -958,7 +959,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1029",
-                    file: "Batch3\\BridgeIssues\\1000\\N1029.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1029.cs"
                 } );
             }
             return this.context;
@@ -982,7 +983,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1039",
-                    file: "Batch3\\BridgeIssues\\1000\\N1039.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1039.cs"
                 } );
             }
             return this.context;
@@ -1027,7 +1028,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal",
-                    file: "Batch3\\BridgeIssues\\1000\\N1041.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1041.cs"
                 } );
             }
             return this.context;
@@ -1072,7 +1073,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Integer",
-                    file: "Batch3\\BridgeIssues\\1000\\N1041.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1041.cs"
                 } );
             }
             return this.context;
@@ -1096,7 +1097,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1051",
-                    file: "Batch3\\BridgeIssues\\1000\\N1051.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1051.cs"
                 } );
             }
             return this.context;
@@ -1120,7 +1121,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1053",
-                    file: "Batch3\\BridgeIssues\\1000\\N1053.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1053.cs"
                 } );
             }
             return this.context;
@@ -1151,7 +1152,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1058",
-                    file: "Batch3\\BridgeIssues\\1000\\N1058.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1058.cs"
                 } );
             }
             return this.context;
@@ -1175,7 +1176,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059",
-                    file: "Batch3\\BridgeIssues\\1000\\N1059.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1059.cs"
                 } );
             }
             return this.context;
@@ -1199,7 +1200,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1061",
-                    file: "Batch3\\BridgeIssues\\1000\\N1061.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1061.cs"
                 } );
             }
             return this.context;
@@ -1223,7 +1224,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1065",
-                    file: "Batch3\\BridgeIssues\\1000\\N1065.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1065.cs"
                 } );
             }
             return this.context;
@@ -1247,7 +1248,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1066",
-                    file: "Batch3\\BridgeIssues\\1000\\N1066.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1066.cs"
                 } );
             }
             return this.context;
@@ -1271,7 +1272,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1067",
-                    file: "Batch3\\BridgeIssues\\1000\\N1067.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1067.cs"
                 } );
             }
             return this.context;
@@ -1295,7 +1296,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1071",
-                    file: "Batch3\\BridgeIssues\\1000\\N1071.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1071.cs"
                 } );
             }
             return this.context;
@@ -1319,7 +1320,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1072",
-                    file: "Batch3\\BridgeIssues\\1100\\N1172.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1172.cs"
                 } );
             }
             return this.context;
@@ -1350,7 +1351,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1076",
-                    file: "Batch3\\BridgeIssues\\1000\\N1076.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1076.cs"
                 } );
             }
             return this.context;
@@ -1374,7 +1375,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1081",
-                    file: "Batch3\\BridgeIssues\\1000\\N1081.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1081.cs"
                 } );
             }
             return this.context;
@@ -1398,7 +1399,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1083",
-                    file: "Batch3\\BridgeIssues\\1000\\N1083.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1083.cs"
                 } );
             }
             return this.context;
@@ -1422,7 +1423,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1085",
-                    file: "Batch3\\BridgeIssues\\1000\\N1085.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1085.cs"
                 } );
             }
             return this.context;
@@ -1446,7 +1447,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1096",
-                    file: "Batch3\\BridgeIssues\\1000\\N1096.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1096.cs"
                 } );
             }
             return this.context;
@@ -1470,7 +1471,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1098",
-                    file: "Batch3\\BridgeIssues\\1000\\N1098.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1000/N1098.cs"
                 } );
             }
             return this.context;
@@ -1494,7 +1495,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1103",
-                    file: "Batch3\\BridgeIssues\\1100\\N1103.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1103.cs"
                 } );
             }
             return this.context;
@@ -1518,7 +1519,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1105",
-                    file: "Batch3\\BridgeIssues\\1100\\N1105.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1105.cs"
                 } );
             }
             return this.context;
@@ -1542,7 +1543,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1109",
-                    file: "Batch3\\BridgeIssues\\1100\\N1109.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1109.cs"
                 } );
             }
             return this.context;
@@ -1580,7 +1581,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1110",
-                    file: "Batch3\\BridgeIssues\\1100\\N1110.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1110.cs"
                 } );
             }
             return this.context;
@@ -1611,7 +1612,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1120",
-                    file: "Batch3\\BridgeIssues\\1100\\N1120.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1120.cs"
                 } );
             }
             return this.context;
@@ -1635,7 +1636,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1128",
-                    file: "Batch3\\BridgeIssues\\1100\\N1128.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1128.cs"
                 } );
             }
             return this.context;
@@ -1659,7 +1660,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1130",
-                    file: "Batch3\\BridgeIssues\\1100\\N1130.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1130.cs"
                 } );
             }
             return this.context;
@@ -1683,7 +1684,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1134",
-                    file: "Batch3\\BridgeIssues\\1100\\N1134.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1134.cs"
                 } );
             }
             return this.context;
@@ -1707,7 +1708,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1140",
-                    file: "Batch3\\BridgeIssues\\1100\\N1140.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1140.cs"
                 } );
             }
             return this.context;
@@ -1731,7 +1732,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1141",
-                    file: "Batch3\\BridgeIssues\\1100\\N1141.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1141.cs"
                 } );
             }
             return this.context;
@@ -1755,7 +1756,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1144",
-                    file: "Batch3\\BridgeIssues\\1100\\N1144.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1144.cs"
                 } );
             }
             return this.context;
@@ -1779,7 +1780,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1146",
-                    file: "Batch3\\BridgeIssues\\1100\\N1146.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1146.cs"
                 } );
             }
             return this.context;
@@ -1803,7 +1804,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1149",
-                    file: "Batch3\\BridgeIssues\\1100\\N1149.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1149.cs"
                 } );
             }
             return this.context;
@@ -1827,7 +1828,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1160",
-                    file: "Batch3\\BridgeIssues\\1100\\N1160.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1160.cs"
                 } );
             }
             return this.context;
@@ -1858,7 +1859,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1170",
-                    file: "Batch3\\BridgeIssues\\1100\\N1170.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1170.cs"
                 } );
             }
             return this.context;
@@ -1882,7 +1883,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1171",
-                    file: "Batch3\\BridgeIssues\\1100\\N1171.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1171.cs"
                 } );
             }
             return this.context;
@@ -1906,7 +1907,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1175",
-                    file: "Batch3\\BridgeIssues\\1100\\N1175.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1175.cs"
                 } );
             }
             return this.context;
@@ -1930,7 +1931,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1176",
-                    file: "Batch3\\BridgeIssues\\1100\\N1176.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1176.cs"
                 } );
             }
             return this.context;
@@ -1954,7 +1955,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1177",
-                    file: "Batch3\\BridgeIssues\\1100\\N1177.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1177.cs"
                 } );
             }
             return this.context;
@@ -1978,7 +1979,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1180",
-                    file: "Batch3\\BridgeIssues\\1100\\N1180.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1180.cs"
                 } );
             }
             return this.context;
@@ -2002,7 +2003,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1184",
-                    file: "Batch3\\BridgeIssues\\1100\\N1184.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1184.cs"
                 } );
             }
             return this.context;
@@ -2026,7 +2027,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1186",
-                    file: "Batch3\\BridgeIssues\\1100\\N1186.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1186.cs"
                 } );
             }
             return this.context;
@@ -2050,7 +2051,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1189",
-                    file: "Batch3\\BridgeIssues\\1100\\N1189.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1189.cs"
                 } );
             }
             return this.context;
@@ -2074,7 +2075,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1193",
-                    file: "Batch3\\BridgeIssues\\1100\\N1193.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1193.cs"
                 } );
             }
             return this.context;
@@ -2098,7 +2099,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1197",
-                    file: "Batch3\\BridgeIssues\\1100\\N1197.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1197.cs"
                 } );
             }
             return this.context;
@@ -2122,7 +2123,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1199",
-                    file: "Batch3\\BridgeIssues\\1100\\N1199.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1199.cs"
                 } );
             }
             return this.context;
@@ -2209,7 +2210,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1202",
-                    file: "Batch3\\BridgeIssues\\1200\\N1202.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1202.cs"
                 } );
             }
             return this.context;
@@ -2233,7 +2234,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1203",
-                    file: "Batch3\\BridgeIssues\\1200\\N1203.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1203.cs"
                 } );
             }
             return this.context;
@@ -2257,7 +2258,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1206",
-                    file: "Batch3\\BridgeIssues\\1200\\N1206.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1206.cs"
                 } );
             }
             return this.context;
@@ -2281,7 +2282,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1217",
-                    file: "Batch3\\BridgeIssues\\1200\\N1217.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1217.cs"
                 } );
             }
             return this.context;
@@ -2305,7 +2306,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1219",
-                    file: "Batch3\\BridgeIssues\\1200\\N1219.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1219.cs"
                 } );
             }
             return this.context;
@@ -2329,7 +2330,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge122",
-                    file: "Batch3\\BridgeIssues\\0100\\N122.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0100/N122.cs"
                 } );
             }
             return this.context;
@@ -2353,7 +2354,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1220",
-                    file: "Batch3\\BridgeIssues\\1200\\N1220.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1220.cs"
                 } );
             }
             return this.context;
@@ -2391,7 +2392,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1226",
-                    file: "Batch3\\BridgeIssues\\1200\\N1226.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1226.cs"
                 } );
             }
             return this.context;
@@ -2415,7 +2416,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1231",
-                    file: "Batch3\\BridgeIssues\\1200\\N1231.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1231.cs"
                 } );
             }
             return this.context;
@@ -2446,7 +2447,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1232",
-                    file: "Batch3\\BridgeIssues\\1200\\N1232.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1232.cs"
                 } );
             }
             return this.context;
@@ -2470,7 +2471,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1241",
-                    file: "Batch3\\BridgeIssues\\1200\\N1241.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1241.cs"
                 } );
             }
             return this.context;
@@ -2494,7 +2495,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1249",
-                    file: "Batch3\\BridgeIssues\\1200\\N1249.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1249.cs"
                 } );
             }
             return this.context;
@@ -2518,7 +2519,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1253",
-                    file: "Batch3\\BridgeIssues\\1200\\N1253.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1253.cs"
                 } );
             }
             return this.context;
@@ -2556,7 +2557,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1256",
-                    file: "Batch3\\BridgeIssues\\1200\\N1256.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1256.cs"
                 } );
             }
             return this.context;
@@ -2594,7 +2595,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1260",
-                    file: "Batch3\\BridgeIssues\\1200\\N1260.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1260.cs"
                 } );
             }
             return this.context;
@@ -2618,7 +2619,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1264",
-                    file: "Batch3\\BridgeIssues\\1200\\N1264.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1264.cs"
                 } );
             }
             return this.context;
@@ -2642,7 +2643,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1266",
-                    file: "Batch3\\BridgeIssues\\1200\\N1266.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1266.cs"
                 } );
             }
             return this.context;
@@ -2680,7 +2681,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1296",
-                    file: "Batch3\\BridgeIssues\\1200\\N1296.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1296.cs"
                 } );
             }
             return this.context;
@@ -2704,7 +2705,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1298",
-                    file: "Batch3\\BridgeIssues\\1200\\N1298.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1200/N1298.cs"
                 } );
             }
             return this.context;
@@ -2745,7 +2746,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304",
-                    file: "Batch3\\BridgeIssues\\1300\\N1304.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1304.cs"
                 } );
             }
             return this.context;
@@ -2789,7 +2790,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1305",
-                    file: "Batch3\\BridgeIssues\\1300\\N1305.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1305.cs"
                 } );
             }
             return this.context;
@@ -2813,7 +2814,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1311",
-                    file: "Batch3\\BridgeIssues\\1300\\N1311.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1311.cs"
                 } );
             }
             return this.context;
@@ -2844,7 +2845,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1313",
-                    file: "Batch3\\BridgeIssues\\1300\\N1313.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1313.cs"
                 } );
             }
             return this.context;
@@ -2889,7 +2890,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1316",
-                    file: "Batch3\\BridgeIssues\\1300\\N1316.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1316.cs"
                 } );
             }
             return this.context;
@@ -2920,7 +2921,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1328",
-                    file: "Batch3\\BridgeIssues\\1300\\N1328.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1328.cs"
                 } );
             }
             return this.context;
@@ -2944,7 +2945,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1339",
-                    file: "Batch3\\BridgeIssues\\1300\\N1339.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1339.cs"
                 } );
             }
             return this.context;
@@ -3066,7 +3067,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1340",
-                    file: "Batch3\\BridgeIssues\\1300\\N1340.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1340.cs"
                 } );
             }
             return this.context;
@@ -3146,7 +3147,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1341",
-                    file: "Batch3\\BridgeIssues\\1300\\N1341.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1341.cs"
                 } );
             }
             return this.context;
@@ -3177,7 +3178,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1343",
-                    file: "Batch3\\BridgeIssues\\1300\\N1343.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1343.cs"
                 } );
             }
             return this.context;
@@ -3201,7 +3202,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1344",
-                    file: "Batch3\\BridgeIssues\\1300\\N1344.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1344.cs"
                 } );
             }
             return this.context;
@@ -3225,7 +3226,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1348",
-                    file: "Batch3\\BridgeIssues\\1300\\N1348.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1348.cs"
                 } );
             }
             return this.context;
@@ -3249,7 +3250,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1355",
-                    file: "Batch3\\BridgeIssues\\1300\\N1355.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1355.cs"
                 } );
             }
             return this.context;
@@ -3301,7 +3302,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1374",
-                    file: "Batch3\\BridgeIssues\\1300\\N1374.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1374.cs"
                 } );
             }
             return this.context;
@@ -3360,7 +3361,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1378",
-                    file: "Batch3\\BridgeIssues\\1300\\N1378.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1378.cs"
                 } );
             }
             return this.context;
@@ -3384,7 +3385,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379",
-                    file: "Batch3\\BridgeIssues\\1300\\N1379.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1379.cs"
                 } );
             }
             return this.context;
@@ -3415,7 +3416,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1381",
-                    file: "Batch3\\BridgeIssues\\1300\\N1381.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1381.cs"
                 } );
             }
             return this.context;
@@ -3439,7 +3440,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1385",
-                    file: "Batch3\\BridgeIssues\\1300\\N1385.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1385.cs"
                 } );
             }
             return this.context;
@@ -3463,7 +3464,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1389",
-                    file: "Batch3\\BridgeIssues\\1300\\N1389.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1389.cs"
                 } );
             }
             return this.context;
@@ -3487,7 +3488,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1391",
-                    file: "Batch3\\BridgeIssues\\1300\\N1391.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1391.cs"
                 } );
             }
             return this.context;
@@ -3511,7 +3512,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1391Ready",
-                    file: "Batch3\\BridgeIssues\\1300\\N1391.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1300/N1391.cs"
                 } );
             }
             return this.context;
@@ -3535,7 +3536,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1402",
-                    file: "Batch3\\BridgeIssues\\1400\\N1402.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1402.cs"
                 } );
             }
             return this.context;
@@ -3573,7 +3574,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1410",
-                    file: "Batch3\\BridgeIssues\\1400\\N1410.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1410.cs"
                 } );
             }
             return this.context;
@@ -3611,7 +3612,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1411",
-                    file: "Batch3\\BridgeIssues\\1400\\N1411.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1411.cs"
                 } );
             }
             return this.context;
@@ -3635,7 +3636,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1428",
-                    file: "Batch3\\BridgeIssues\\1400\\N1428.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1428.cs"
                 } );
             }
             return this.context;
@@ -3659,7 +3660,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1429",
-                    file: "Batch3\\BridgeIssues\\1400\\N1429.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1429.cs"
                 } );
             }
             return this.context;
@@ -3690,7 +3691,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1438",
-                    file: "Batch3\\BridgeIssues\\1400\\N1438.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1438.cs"
                 } );
             }
             return this.context;
@@ -3728,7 +3729,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1448",
-                    file: "Batch3\\BridgeIssues\\1400\\N1448.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1448.cs"
                 } );
             }
             return this.context;
@@ -3757,7 +3758,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1458",
-                    file: "Batch3\\BridgeIssues\\1400\\N1458.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1458.cs"
                 } );
             }
             return this.context;
@@ -3787,7 +3788,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1459",
-                    file: "Batch3\\BridgeIssues\\1400\\N1459.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1459.cs"
                 } );
             }
             return this.context;
@@ -3811,7 +3812,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1467",
-                    file: "Batch3\\BridgeIssues\\1400\\N1467.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1467.cs"
                 } );
             }
             return this.context;
@@ -3842,7 +3843,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1472",
-                    file: "Batch3\\BridgeIssues\\1400\\N1472.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1472.cs"
                 } );
             }
             return this.context;
@@ -3866,7 +3867,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1476",
-                    file: "Batch3\\BridgeIssues\\1400\\N1476.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1476.cs"
                 } );
             }
             return this.context;
@@ -3890,7 +3891,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1480",
-                    file: "Batch3\\BridgeIssues\\1400\\N1480.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1480.cs"
                 } );
             }
             return this.context;
@@ -3914,7 +3915,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1485",
-                    file: "Batch3\\BridgeIssues\\1400\\N1485.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1485.cs"
                 } );
             }
             return this.context;
@@ -3959,7 +3960,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1486",
-                    file: "Batch3\\BridgeIssues\\1400\\N1486.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1486.cs"
                 } );
             }
             return this.context;
@@ -3990,7 +3991,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1489",
-                    file: "Batch3\\BridgeIssues\\1400\\N1489.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1489.cs"
                 } );
             }
             return this.context;
@@ -4014,7 +4015,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1490",
-                    file: "Batch3\\BridgeIssues\\1400\\N1490.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1490.cs"
                 } );
             }
             return this.context;
@@ -4038,7 +4039,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1492",
-                    file: "Batch3\\BridgeIssues\\1400\\N1492.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1492.cs"
                 } );
             }
             return this.context;
@@ -4062,7 +4063,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1493",
-                    file: "Batch3\\BridgeIssues\\1400\\N1493.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1493.cs"
                 } );
             }
             return this.context;
@@ -4086,7 +4087,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1499",
-                    file: "Batch3\\BridgeIssues\\1400\\N1499.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1400/N1499.cs"
                 } );
             }
             return this.context;
@@ -4110,7 +4111,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1501",
-                    file: "Batch3\\BridgeIssues\\1500\\N1501.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1501.cs"
                 } );
             }
             return this.context;
@@ -4134,7 +4135,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1509",
-                    file: "Batch3\\BridgeIssues\\1500\\N1509.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1509.cs"
                 } );
             }
             return this.context;
@@ -4158,7 +4159,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1510",
-                    file: "Batch3\\BridgeIssues\\1500\\N1510.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1510.cs"
                 } );
             }
             return this.context;
@@ -4182,7 +4183,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1511",
-                    file: "Batch3\\BridgeIssues\\1500\\N1511.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1511.cs"
                 } );
             }
             return this.context;
@@ -4206,7 +4207,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1512",
-                    file: "Batch3\\BridgeIssues\\1500\\N1512.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1512.cs"
                 } );
             }
             return this.context;
@@ -4237,7 +4238,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1517",
-                    file: "Batch3\\BridgeIssues\\1500\\N1517.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1517.cs"
                 } );
             }
             return this.context;
@@ -4261,7 +4262,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1518",
-                    file: "Batch3\\BridgeIssues\\1500\\N1518.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1518.cs"
                 } );
             }
             return this.context;
@@ -4285,7 +4286,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1519",
-                    file: "Batch3\\BridgeIssues\\1500\\N1519.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1519.cs"
                 } );
             }
             return this.context;
@@ -4323,7 +4324,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1520",
-                    file: "Batch3\\BridgeIssues\\1500\\N1520.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1520.cs"
                 } );
             }
             return this.context;
@@ -4347,7 +4348,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1521",
-                    file: "Batch3\\BridgeIssues\\1500\\N1521.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1521.cs"
                 } );
             }
             return this.context;
@@ -4371,7 +4372,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1522",
-                    file: "Batch3\\BridgeIssues\\1500\\N1522.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1522.cs"
                 } );
             }
             return this.context;
@@ -4395,7 +4396,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1523",
-                    file: "Batch3\\BridgeIssues\\1500\\N1523.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1523.cs"
                 } );
             }
             return this.context;
@@ -4419,7 +4420,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1524",
-                    file: "Batch3\\BridgeIssues\\1500\\N1524.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1524.cs"
                 } );
             }
             return this.context;
@@ -4450,7 +4451,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1526",
-                    file: "Batch3\\BridgeIssues\\1500\\N1526.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1526.cs"
                 } );
             }
             return this.context;
@@ -4474,7 +4475,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1527",
-                    file: "Batch3\\BridgeIssues\\1500\\N1527.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1527.cs"
                 } );
             }
             return this.context;
@@ -4498,7 +4499,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1530",
-                    file: "Batch3\\BridgeIssues\\1500\\N1530.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1530.cs"
                 } );
             }
             return this.context;
@@ -4522,7 +4523,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1533",
-                    file: "Batch3\\BridgeIssues\\1500\\N1533.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1533.cs"
                 } );
             }
             return this.context;
@@ -4546,7 +4547,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1535",
-                    file: "Batch3\\BridgeIssues\\1500\\N1535.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1535.cs"
                 } );
             }
             return this.context;
@@ -4577,7 +4578,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1536",
-                    file: "Batch3\\BridgeIssues\\1500\\N1536.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1536.cs"
                 } );
             }
             return this.context;
@@ -4601,7 +4602,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1538",
-                    file: "Batch3\\BridgeIssues\\1500\\N1538.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1538.cs"
                 } );
             }
             return this.context;
@@ -4625,7 +4626,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1599",
-                    file: "Batch3\\BridgeIssues\\1500\\N1599.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1500/N1599.cs"
                 } );
             }
             return this.context;
@@ -4649,7 +4650,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1641",
-                    file: "Batch3\\BridgeIssues\\1600\\N1641.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1600/N1641.cs"
                 } );
             }
             return this.context;
@@ -4673,7 +4674,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653",
-                    file: "Batch3\\BridgeIssues\\1600\\N1653.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1600/N1653.cs"
                 } );
             }
             return this.context;
@@ -4697,7 +4698,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1684",
-                    file: "Batch3\\BridgeIssues\\1600\\N1684.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1600/N1684.cs"
                 } );
             }
             return this.context;
@@ -4726,7 +4727,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1698",
-                    file: "Batch3\\BridgeIssues\\1600\\N1698.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1600/N1698.cs"
                 } );
             }
             return this.context;
@@ -4763,7 +4764,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1700",
-                    file: "Batch3\\BridgeIssues\\1700\\N1700.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1700.cs"
                 } );
             }
             return this.context;
@@ -4787,7 +4788,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1702",
-                    file: "Batch3\\BridgeIssues\\1700\\N1702.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1702.cs"
                 } );
             }
             return this.context;
@@ -4811,7 +4812,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1704",
-                    file: "Batch3\\BridgeIssues\\1700\\N1704.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1704.cs"
                 } );
             }
             return this.context;
@@ -4835,7 +4836,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1709",
-                    file: "Batch3\\BridgeIssues\\1700\\N1709.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1709.cs"
                 } );
             }
             return this.context;
@@ -4859,7 +4860,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1711",
-                    file: "Batch3\\BridgeIssues\\1700\\N1711.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1711.cs"
                 } );
             }
             return this.context;
@@ -4897,7 +4898,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712",
-                    file: "Batch3\\BridgeIssues\\1700\\N1712.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1712.cs"
                 } );
             }
             return this.context;
@@ -4921,7 +4922,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1713",
-                    file: "Batch3\\BridgeIssues\\1700\\N1713.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1713.cs"
                 } );
             }
             return this.context;
@@ -4952,7 +4953,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1713MSDN",
-                    file: "Batch3\\BridgeIssues\\1700\\N1713.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1713.cs"
                 } );
             }
             return this.context;
@@ -4976,7 +4977,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715",
-                    file: "Batch3\\BridgeIssues\\1700\\N1715.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1715.cs"
                 } );
             }
             return this.context;
@@ -5000,7 +5001,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1721",
-                    file: "Batch3\\BridgeIssues\\1700\\N1721.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1721.cs"
                 } );
             }
             return this.context;
@@ -5031,7 +5032,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1722",
-                    file: "Batch3\\BridgeIssues\\1700\\N1722.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1722.cs"
                 } );
             }
             return this.context;
@@ -5069,7 +5070,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1735",
-                    file: "Batch3\\BridgeIssues\\1700\\N1735.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1735.cs"
                 } );
             }
             return this.context;
@@ -5093,7 +5094,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1737",
-                    file: "Batch3\\BridgeIssues\\1700\\N1737.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1737.cs"
                 } );
             }
             return this.context;
@@ -5117,7 +5118,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1741",
-                    file: "Batch3\\BridgeIssues\\1700\\N1741.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1741.cs"
                 } );
             }
             return this.context;
@@ -5141,7 +5142,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1744",
-                    file: "Batch3\\BridgeIssues\\1700\\N1744.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1744.cs"
                 } );
             }
             return this.context;
@@ -5165,7 +5166,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1754",
-                    file: "Batch3\\BridgeIssues\\1700\\N1754.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1754.cs"
                 } );
             }
             return this.context;
@@ -5189,7 +5190,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1767",
-                    file: "Batch3\\BridgeIssues\\1700\\N1767.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1767.cs"
                 } );
             }
             return this.context;
@@ -5234,7 +5235,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1768",
-                    file: "Batch3\\BridgeIssues\\1700\\N1768.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1768.cs"
                 } );
             }
             return this.context;
@@ -5258,7 +5259,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1775",
-                    file: "Batch3\\BridgeIssues\\1700\\N1775.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1775.cs"
                 } );
             }
             return this.context;
@@ -5282,7 +5283,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1776",
-                    file: "Batch3\\BridgeIssues\\1700\\N1776.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1776.cs"
                 } );
             }
             return this.context;
@@ -5306,7 +5307,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1787",
-                    file: "Batch3\\BridgeIssues\\1700\\N1787.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1700/N1787.cs"
                 } );
             }
             return this.context;
@@ -5330,7 +5331,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1802",
-                    file: "Batch3\\BridgeIssues\\1800\\N1802.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1802.cs"
                 } );
             }
             return this.context;
@@ -5354,7 +5355,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1803",
-                    file: "Batch3\\BridgeIssues\\1800\\N1803.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1803.cs"
                 } );
             }
             return this.context;
@@ -5378,7 +5379,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1804",
-                    file: "Batch3\\BridgeIssues\\1800\\N1804.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1804.cs"
                 } );
             }
             return this.context;
@@ -5402,7 +5403,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1810",
-                    file: "Batch3\\BridgeIssues\\1800\\N1810.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1810.cs"
                 } );
             }
             return this.context;
@@ -5426,7 +5427,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1812",
-                    file: "Batch3\\BridgeIssues\\1800\\N1812.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1812.cs"
                 } );
             }
             return this.context;
@@ -5450,7 +5451,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1813",
-                    file: "Batch3\\BridgeIssues\\1800\\N1813.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1813.cs"
                 } );
             }
             return this.context;
@@ -5474,7 +5475,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1814",
-                    file: "Batch3\\BridgeIssues\\1800\\N1814.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1814.cs"
                 } );
             }
             return this.context;
@@ -5498,7 +5499,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1819",
-                    file: "Batch3\\BridgeIssues\\1800\\N1819.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1819.cs"
                 } );
             }
             return this.context;
@@ -5529,7 +5530,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1821",
-                    file: "Batch3\\BridgeIssues\\1800\\N1821.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1821.cs"
                 } );
             }
             return this.context;
@@ -5553,7 +5554,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1832",
-                    file: "Batch3\\BridgeIssues\\1800\\N1832.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1832.cs"
                 } );
             }
             return this.context;
@@ -5577,7 +5578,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1833",
-                    file: "Batch3\\BridgeIssues\\1800\\N1833.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1833.cs"
                 } );
             }
             return this.context;
@@ -5601,7 +5602,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1834",
-                    file: "Batch3\\BridgeIssues\\1800\\N1834.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1834.cs"
                 } );
             }
             return this.context;
@@ -5625,7 +5626,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1835",
-                    file: "Batch3\\BridgeIssues\\1800\\N1835.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1835.cs"
                 } );
             }
             return this.context;
@@ -5649,7 +5650,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1842",
-                    file: "Batch3\\BridgeIssues\\1800\\N1842.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1842.cs"
                 } );
             }
             return this.context;
@@ -5673,7 +5674,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1845",
-                    file: "Batch3\\BridgeIssues\\1800\\N1845.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1845.cs"
                 } );
             }
             return this.context;
@@ -5697,7 +5698,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1846",
-                    file: "Batch3\\BridgeIssues\\1800\\N1846.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1846.cs"
                 } );
             }
             return this.context;
@@ -5721,7 +5722,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1847",
-                    file: "Batch3\\BridgeIssues\\1800\\N1847.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1847.cs"
                 } );
             }
             return this.context;
@@ -5745,7 +5746,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1848",
-                    file: "Batch3\\BridgeIssues\\1800\\N1848.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1848.cs"
                 } );
             }
             return this.context;
@@ -5769,7 +5770,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1850",
-                    file: "Batch3\\BridgeIssues\\1800\\N1850.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1850.cs"
                 } );
             }
             return this.context;
@@ -5793,7 +5794,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1852",
-                    file: "Batch3\\BridgeIssues\\1800\\N1852.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1852.cs"
                 } );
             }
             return this.context;
@@ -5817,7 +5818,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1853",
-                    file: "Batch3\\BridgeIssues\\1800\\N1853.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1853.cs"
                 } );
             }
             return this.context;
@@ -5841,7 +5842,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1854",
-                    file: "Batch3\\BridgeIssues\\1800\\N1854.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1854.cs"
                 } );
             }
             return this.context;
@@ -5865,7 +5866,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1856",
-                    file: "Batch3\\BridgeIssues\\1800\\N1856.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1856.cs"
                 } );
             }
             return this.context;
@@ -5889,7 +5890,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1863",
-                    file: "Batch3\\BridgeIssues\\1800\\N1863.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1863.cs"
                 } );
             }
             return this.context;
@@ -5913,7 +5914,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1865",
-                    file: "Batch3\\BridgeIssues\\1800\\N1865.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1865.cs"
                 } );
             }
             return this.context;
@@ -5937,7 +5938,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1869",
-                    file: "Batch3\\BridgeIssues\\1800\\N1869.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1869.cs"
                 } );
             }
             return this.context;
@@ -5961,7 +5962,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1871",
-                    file: "Batch3\\BridgeIssues\\1800\\N1871.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1871.cs"
                 } );
             }
             return this.context;
@@ -5985,7 +5986,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1872",
-                    file: "Batch3\\BridgeIssues\\1800\\N1872.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1872.cs"
                 } );
             }
             return this.context;
@@ -6009,7 +6010,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1875",
-                    file: "Batch3\\BridgeIssues\\1800\\N1875.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1875.cs"
                 } );
             }
             return this.context;
@@ -6033,7 +6034,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1878",
-                    file: "Batch3\\BridgeIssues\\1800\\N1878.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1878.cs"
                 } );
             }
             return this.context;
@@ -6057,7 +6058,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1880",
-                    file: "Batch3\\BridgeIssues\\1800\\N1880.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1880.cs"
                 } );
             }
             return this.context;
@@ -6088,7 +6089,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1882",
-                    file: "Batch3\\BridgeIssues\\1800\\N1882.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1882.cs"
                 } );
             }
             return this.context;
@@ -6112,7 +6113,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1884",
-                    file: "Batch3\\BridgeIssues\\1800\\N1884.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1884.cs"
                 } );
             }
             return this.context;
@@ -6136,7 +6137,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1886",
-                    file: "Batch3\\BridgeIssues\\1800\\N1886.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1886.cs"
                 } );
             }
             return this.context;
@@ -6160,7 +6161,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892",
-                    file: "Batch3\\BridgeIssues\\1800\\N1892.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1892.cs"
                 } );
             }
             return this.context;
@@ -6184,7 +6185,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1896",
-                    file: "Batch3\\BridgeIssues\\1800\\N1896.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1896.cs"
                 } );
             }
             return this.context;
@@ -6208,7 +6209,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1897",
-                    file: "Batch3\\BridgeIssues\\1800\\N1897.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1897.cs"
                 } );
             }
             return this.context;
@@ -6232,7 +6233,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1899",
-                    file: "Batch3\\BridgeIssues\\1800\\N1899.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1800/N1899.cs"
                 } );
             }
             return this.context;
@@ -6256,7 +6257,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1900",
-                    file: "Batch3\\BridgeIssues\\1900\\N1900.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1900.cs"
                 } );
             }
             return this.context;
@@ -6280,7 +6281,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1904",
-                    file: "Batch3\\BridgeIssues\\1900\\N1904.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1904.cs"
                 } );
             }
             return this.context;
@@ -6304,7 +6305,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1906",
-                    file: "Batch3\\BridgeIssues\\1900\\N1906.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1906.cs"
                 } );
             }
             return this.context;
@@ -6328,7 +6329,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1909",
-                    file: "Batch3\\BridgeIssues\\1900\\N1909.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1909.cs"
                 } );
             }
             return this.context;
@@ -6352,7 +6353,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1910",
-                    file: "Batch3\\BridgeIssues\\1900\\N1910.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1910.cs"
                 } );
             }
             return this.context;
@@ -6383,7 +6384,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1911",
-                    file: "Batch3\\BridgeIssues\\1900\\N1911.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1911.cs"
                 } );
             }
             return this.context;
@@ -6407,7 +6408,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1912",
-                    file: "Batch3\\BridgeIssues\\1900\\N1912.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1912.cs"
                 } );
             }
             return this.context;
@@ -6431,7 +6432,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1913",
-                    file: "Batch3\\BridgeIssues\\1900\\N1913.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1913.cs"
                 } );
             }
             return this.context;
@@ -6455,7 +6456,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1914",
-                    file: "Batch3\\BridgeIssues\\1900\\N1914.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1914.cs"
                 } );
             }
             return this.context;
@@ -6479,7 +6480,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1915",
-                    file: "Batch3\\BridgeIssues\\1900\\N1915.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1915.cs"
                 } );
             }
             return this.context;
@@ -6503,7 +6504,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1920",
-                    file: "Batch3\\BridgeIssues\\1900\\N1920.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1920.cs"
                 } );
             }
             return this.context;
@@ -6527,7 +6528,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1933",
-                    file: "Batch3\\BridgeIssues\\1900\\N1933.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1933.cs"
                 } );
             }
             return this.context;
@@ -6551,7 +6552,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1934",
-                    file: "Batch3\\BridgeIssues\\1900\\N1934.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1934.cs"
                 } );
             }
             return this.context;
@@ -6575,7 +6576,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1938",
-                    file: "Batch3\\BridgeIssues\\1900\\N1938.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1938.cs"
                 } );
             }
             return this.context;
@@ -6599,7 +6600,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1948",
-                    file: "Batch3\\BridgeIssues\\1900\\N1948.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1948.cs"
                 } );
             }
             return this.context;
@@ -6623,7 +6624,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1951",
-                    file: "Batch3\\BridgeIssues\\1900\\N1951.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1951.cs"
                 } );
             }
             return this.context;
@@ -6647,7 +6648,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1955",
-                    file: "Batch3\\BridgeIssues\\1900\\N1955.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1955.cs"
                 } );
             }
             return this.context;
@@ -6671,7 +6672,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1964",
-                    file: "Batch3\\BridgeIssues\\1900\\N1964.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1964.cs"
                 } );
             }
             return this.context;
@@ -6695,7 +6696,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1965",
-                    file: "Batch3\\BridgeIssues\\1900\\N1965.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1965.cs"
                 } );
             }
             return this.context;
@@ -6719,7 +6720,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1966",
-                    file: "Batch3\\BridgeIssues\\1900\\N1966.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1966.cs"
                 } );
             }
             return this.context;
@@ -6743,7 +6744,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1968",
-                    file: "Batch3\\BridgeIssues\\1900\\N1968.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1968.cs"
                 } );
             }
             return this.context;
@@ -6767,7 +6768,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1969",
-                    file: "Batch3\\BridgeIssues\\1900\\N1969.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1969.cs"
                 } );
             }
             return this.context;
@@ -6791,7 +6792,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1970",
-                    file: "Batch3\\BridgeIssues\\1900\\N1970.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1970.cs"
                 } );
             }
             return this.context;
@@ -6815,7 +6816,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1996",
-                    file: "Batch3\\BridgeIssues\\1900\\N1996.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1900/N1996.cs"
                 } );
             }
             return this.context;
@@ -6839,7 +6840,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2003",
-                    file: "Batch3\\BridgeIssues\\2000\\N2003.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2003.cs"
                 } );
             }
             return this.context;
@@ -6863,7 +6864,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2011",
-                    file: "Batch3\\BridgeIssues\\2000\\N2011.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2011.cs"
                 } );
             }
             return this.context;
@@ -6887,7 +6888,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2013",
-                    file: "Batch3\\BridgeIssues\\2000\\N2013.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2013.cs"
                 } );
             }
             return this.context;
@@ -6911,7 +6912,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2019",
-                    file: "Batch3\\BridgeIssues\\2000\\N2019.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2019.cs"
                 } );
             }
             return this.context;
@@ -6935,7 +6936,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2024",
-                    file: "Batch3\\BridgeIssues\\2000\\N2024.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2024.cs"
                 } );
             }
             return this.context;
@@ -6959,7 +6960,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027",
-                    file: "Batch3\\BridgeIssues\\2000\\N2027.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2027.cs"
                 } );
             }
             return this.context;
@@ -6983,7 +6984,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2033",
-                    file: "Batch3\\BridgeIssues\\2000\\N2033.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2033.cs"
                 } );
             }
             return this.context;
@@ -7007,7 +7008,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2038",
-                    file: "Batch3\\BridgeIssues\\2000\\N2038.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2038.cs"
                 } );
             }
             return this.context;
@@ -7031,7 +7032,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2039",
-                    file: "Batch3\\BridgeIssues\\2000\\N2039.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2039.cs"
                 } );
             }
             return this.context;
@@ -7055,7 +7056,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2042",
-                    file: "Batch3\\BridgeIssues\\2000\\N2042.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2042.cs"
                 } );
             }
             return this.context;
@@ -7079,7 +7080,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2045",
-                    file: "Batch3\\BridgeIssues\\2000\\N2045.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2045.cs"
                 } );
             }
             return this.context;
@@ -7103,7 +7104,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2046",
-                    file: "Batch3\\BridgeIssues\\2000\\N2046.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2046.cs"
                 } );
             }
             return this.context;
@@ -7127,7 +7128,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2048",
-                    file: "Batch3\\BridgeIssues\\2000\\N2048.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2048.cs"
                 } );
             }
             return this.context;
@@ -7151,7 +7152,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2067",
-                    file: "Batch3\\BridgeIssues\\2000\\N2067.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2067.cs"
                 } );
             }
             return this.context;
@@ -7175,7 +7176,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2068",
-                    file: "Batch3\\BridgeIssues\\2000\\N2068.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2068.cs"
                 } );
             }
             return this.context;
@@ -7199,7 +7200,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2073",
-                    file: "Batch3\\BridgeIssues\\2000\\N2073.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2073.cs"
                 } );
             }
             return this.context;
@@ -7223,7 +7224,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2076",
-                    file: "Batch3\\BridgeIssues\\2000\\N2076.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2076.cs"
                 } );
             }
             return this.context;
@@ -7247,7 +7248,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2079",
-                    file: "Batch3\\BridgeIssues\\2000\\N2079.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2079.cs"
                 } );
             }
             return this.context;
@@ -7278,7 +7279,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2080",
-                    file: "Batch3\\BridgeIssues\\2000\\N2080.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2080.cs"
                 } );
             }
             return this.context;
@@ -7302,7 +7303,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2081",
-                    file: "Batch3\\BridgeIssues\\2000\\N2081.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2081.cs"
                 } );
             }
             return this.context;
@@ -7326,7 +7327,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2088",
-                    file: "Batch3\\BridgeIssues\\2000\\N2088.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2088.cs"
                 } );
             }
             return this.context;
@@ -7350,7 +7351,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2092",
-                    file: "Batch3\\BridgeIssues\\2000\\N2092.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2092.cs"
                 } );
             }
             return this.context;
@@ -7374,7 +7375,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2094",
-                    file: "Batch3\\BridgeIssues\\2000\\N2094.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2000/N2094.cs"
                 } );
             }
             return this.context;
@@ -7398,7 +7399,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2106",
-                    file: "Batch3\\BridgeIssues\\2100\\N2106.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2100/N2106.cs"
                 } );
             }
             return this.context;
@@ -7429,7 +7430,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2114",
-                    file: "Batch3\\BridgeIssues\\2100\\N2114.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2100/N2114.cs"
                 } );
             }
             return this.context;
@@ -7453,7 +7454,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2121",
-                    file: "Batch3\\BridgeIssues\\2100\\N2121.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2100/N2121.cs"
                 } );
             }
             return this.context;
@@ -7477,7 +7478,31 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2127",
-                    file: "Batch3\\BridgeIssues\\2100\\N2127.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2100/N2127.cs"
+                } );
+            }
+            return this.context;
+        }
+    });
+
+    Bridge.define("Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2137", {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137)],
+        statics: {
+            testPropertiesWithNonPrimitiveInitializers: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge2137, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
+                    method: "TestPropertiesWithNonPrimitiveInitializers()",
+                    line: "24"
+                } ));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137.testPropertiesWithNonPrimitiveInitializers();
+            }
+        },
+        context: null,
+        getContext: function () {
+            if (this.context == null) {
+                this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
+                    project: "Batch3",
+                    className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137",
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/2100/N2137.cs"
                 } );
             }
             return this.context;
@@ -7501,7 +7526,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge381",
-                    file: "Batch3\\BridgeIssues\\0300\\N381.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0300/N381.cs"
                 } );
             }
             return this.context;
@@ -7532,7 +7557,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge447",
-                    file: "Batch3\\BridgeIssues\\0400\\N447.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0400/N447.cs"
                 } );
             }
             return this.context;
@@ -7556,7 +7581,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge472",
-                    file: "Batch3\\BridgeIssues\\0400\\N472.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0400/N472.cs"
                 } );
             }
             return this.context;
@@ -7580,7 +7605,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge479",
-                    file: "Batch3\\BridgeIssues\\0400\\N479.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0400/N479.cs"
                 } );
             }
             return this.context;
@@ -7604,7 +7629,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge483",
-                    file: "Batch3\\BridgeIssues\\0400\\N483.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0400/N483.cs"
                 } );
             }
             return this.context;
@@ -7628,7 +7653,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge485",
-                    file: "Batch3\\BridgeIssues\\0400\\N485.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0400/N485.cs"
                 } );
             }
             return this.context;
@@ -7652,7 +7677,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge495",
-                    file: "Batch3\\BridgeIssues\\0400\\N495.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0400/N495.cs"
                 } );
             }
             return this.context;
@@ -7676,7 +7701,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge501",
-                    file: "Batch3\\BridgeIssues\\0500\\N501.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N501.cs"
                 } );
             }
             return this.context;
@@ -7700,7 +7725,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge502",
-                    file: "Batch3\\BridgeIssues\\0500\\N502.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N502.cs"
                 } );
             }
             return this.context;
@@ -7724,7 +7749,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge503",
-                    file: "Batch3\\BridgeIssues\\0500\\N503.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N503.cs"
                 } );
             }
             return this.context;
@@ -7748,7 +7773,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge508",
-                    file: "Batch3\\BridgeIssues\\0500\\N508.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N508.cs"
                 } );
             }
             return this.context;
@@ -7779,7 +7804,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge514",
-                    file: "Batch3\\BridgeIssues\\0500\\N514.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N514.cs"
                 } );
             }
             return this.context;
@@ -7803,7 +7828,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge520",
-                    file: "Batch3\\BridgeIssues\\0500\\N520.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N520.cs"
                 } );
             }
             return this.context;
@@ -7834,7 +7859,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge522",
-                    file: "Batch3\\BridgeIssues\\0500\\N522.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N522.cs"
                 } );
             }
             return this.context;
@@ -7858,7 +7883,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge532",
-                    file: "Batch3\\BridgeIssues\\0500\\N532.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N532.cs"
                 } );
             }
             return this.context;
@@ -7882,7 +7907,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge537",
-                    file: "Batch3\\BridgeIssues\\0500\\N537A.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N537A.cs"
                 } );
             }
             return this.context;
@@ -7906,7 +7931,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge538",
-                    file: "Batch3\\BridgeIssues\\0500\\N538.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N538.cs"
                 } );
             }
             return this.context;
@@ -7937,7 +7962,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge544",
-                    file: "Batch3\\BridgeIssues\\0500\\N544.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N544.cs"
                 } );
             }
             return this.context;
@@ -7968,7 +7993,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge546",
-                    file: "Batch3\\BridgeIssues\\0500\\N546.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N546.cs"
                 } );
             }
             return this.context;
@@ -7992,7 +8017,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge548",
-                    file: "Batch3\\BridgeIssues\\0500\\N548.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N548.cs"
                 } );
             }
             return this.context;
@@ -8016,7 +8041,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge549",
-                    file: "Batch3\\BridgeIssues\\0500\\N549.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N549.cs"
                 } );
             }
             return this.context;
@@ -8040,7 +8065,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge550",
-                    file: "Batch3\\BridgeIssues\\0500\\N550.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N550.cs"
                 } );
             }
             return this.context;
@@ -8064,7 +8089,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge554",
-                    file: "Batch3\\BridgeIssues\\0500\\N554.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N554.cs"
                 } );
             }
             return this.context;
@@ -8088,7 +8113,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge555",
-                    file: "Batch3\\BridgeIssues\\0500\\N555.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N555.cs"
                 } );
             }
             return this.context;
@@ -8112,7 +8137,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge558",
-                    file: "Batch3\\BridgeIssues\\0500\\N558.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N558.cs"
                 } );
             }
             return this.context;
@@ -8150,7 +8175,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge559",
-                    file: "Batch3\\BridgeIssues\\0500\\N559.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N559.cs"
                 } );
             }
             return this.context;
@@ -8181,7 +8206,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge563",
-                    file: "Batch3\\BridgeIssues\\0500\\N563.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N563.cs"
                 } );
             }
             return this.context;
@@ -8205,7 +8230,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge566",
-                    file: "Batch3\\BridgeIssues\\0500\\N566.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N566.cs"
                 } );
             }
             return this.context;
@@ -8229,7 +8254,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge572",
-                    file: "Batch3\\BridgeIssues\\0500\\N572.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N572.cs"
                 } );
             }
             return this.context;
@@ -8253,7 +8278,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge577",
-                    file: "Batch3\\BridgeIssues\\0500\\N577.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N577.cs"
                 } );
             }
             return this.context;
@@ -8277,7 +8302,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge578",
-                    file: "Batch3\\BridgeIssues\\0500\\N578.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N578.cs"
                 } );
             }
             return this.context;
@@ -8301,7 +8326,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge580",
-                    file: "Batch3\\BridgeIssues\\0500\\N580.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N580.cs"
                 } );
             }
             return this.context;
@@ -8353,7 +8378,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge582",
-                    file: "Batch3\\BridgeIssues\\0500\\N582.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N582.cs"
                 } );
             }
             return this.context;
@@ -8377,7 +8402,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge583",
-                    file: "Batch3\\BridgeIssues\\0500\\N583.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N583.cs"
                 } );
             }
             return this.context;
@@ -8401,7 +8426,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge586",
-                    file: "Batch3\\BridgeIssues\\0500\\N586.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N586.cs"
                 } );
             }
             return this.context;
@@ -8425,7 +8450,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge588",
-                    file: "Batch3\\BridgeIssues\\0500\\N588.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N588.cs"
                 } );
             }
             return this.context;
@@ -8449,7 +8474,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge588C",
-                    file: "Batch3\\BridgeIssues\\0500\\N588.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N588.cs"
                 } );
             }
             return this.context;
@@ -8473,7 +8498,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge592",
-                    file: "Batch3\\BridgeIssues\\0500\\N592.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N592.cs"
                 } );
             }
             return this.context;
@@ -8497,7 +8522,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge595",
-                    file: "Batch3\\BridgeIssues\\0500\\N595.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N595.cs"
                 } );
             }
             return this.context;
@@ -8521,7 +8546,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge597",
-                    file: "Batch3\\BridgeIssues\\0500\\N597.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0500/N597.cs"
                 } );
             }
             return this.context;
@@ -8552,7 +8577,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge603",
-                    file: "Batch3\\BridgeIssues\\0600\\N603.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N603.cs"
                 } );
             }
             return this.context;
@@ -8576,7 +8601,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge606",
-                    file: "Batch3\\BridgeIssues\\0600\\N606.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N606.cs"
                 } );
             }
             return this.context;
@@ -8600,7 +8625,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge607",
-                    file: "Batch3\\BridgeIssues\\0600\\N607.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N607.cs"
                 } );
             }
             return this.context;
@@ -8624,7 +8649,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge608",
-                    file: "Batch3\\BridgeIssues\\0600\\N608.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N608.cs"
                 } );
             }
             return this.context;
@@ -8648,7 +8673,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge615",
-                    file: "Batch3\\BridgeIssues\\0600\\N615.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N615.cs"
                 } );
             }
             return this.context;
@@ -8672,7 +8697,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge623",
-                    file: "Batch3\\BridgeIssues\\0600\\N623.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N623.cs"
                 } );
             }
             return this.context;
@@ -8696,7 +8721,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge625",
-                    file: "Batch3\\BridgeIssues\\0600\\N625.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N625.cs"
                 } );
             }
             return this.context;
@@ -8720,7 +8745,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge634",
-                    file: "Batch3\\BridgeIssues\\0600\\N634.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N634.cs"
                 } );
             }
             return this.context;
@@ -8744,7 +8769,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge635",
-                    file: "Batch3\\BridgeIssues\\0600\\N635.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N635.cs"
                 } );
             }
             return this.context;
@@ -8768,7 +8793,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge637",
-                    file: "Batch3\\BridgeIssues\\0600\\N637.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N637.cs"
                 } );
             }
             return this.context;
@@ -8792,7 +8817,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge647",
-                    file: "Batch3\\BridgeIssues\\0600\\N647.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N647.cs"
                 } );
             }
             return this.context;
@@ -8816,7 +8841,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge648",
-                    file: "Batch3\\BridgeIssues\\0600\\N648.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N648.cs"
                 } );
             }
             return this.context;
@@ -8840,7 +8865,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge652",
-                    file: "Batch3\\BridgeIssues\\0600\\N652.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N652.cs"
                 } );
             }
             return this.context;
@@ -8864,7 +8889,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge655",
-                    file: "Batch3\\BridgeIssues\\0600\\N655.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N655.cs"
                 } );
             }
             return this.context;
@@ -8888,7 +8913,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge658",
-                    file: "Batch3\\BridgeIssues\\0600\\N658.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N658.cs"
                 } );
             }
             return this.context;
@@ -8912,7 +8937,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge660",
-                    file: "Batch3\\BridgeIssues\\0600\\N660.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N660.cs"
                 } );
             }
             return this.context;
@@ -8936,7 +8961,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge661",
-                    file: "Batch3\\BridgeIssues\\0600\\N661.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N661.cs"
                 } );
             }
             return this.context;
@@ -8960,7 +8985,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge664",
-                    file: "Batch3\\BridgeIssues\\0600\\N664.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N664.cs"
                 } );
             }
             return this.context;
@@ -8984,7 +9009,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge666",
-                    file: "Batch3\\BridgeIssues\\0600\\N666.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N666.cs"
                 } );
             }
             return this.context;
@@ -9008,7 +9033,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge671",
-                    file: "Batch3\\BridgeIssues\\0600\\N671.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N671.cs"
                 } );
             }
             return this.context;
@@ -9039,7 +9064,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge674",
-                    file: "Batch3\\BridgeIssues\\0600\\N674.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N674.cs"
                 } );
             }
             return this.context;
@@ -9063,7 +9088,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge675",
-                    file: "Batch3\\BridgeIssues\\0600\\N675.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N675.cs"
                 } );
             }
             return this.context;
@@ -9087,7 +9112,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge687",
-                    file: "Batch3\\BridgeIssues\\0600\\N687.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N687.cs"
                 } );
             }
             return this.context;
@@ -9111,7 +9136,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge689",
-                    file: "Batch3\\BridgeIssues\\0600\\N689.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N689.cs"
                 } );
             }
             return this.context;
@@ -9142,7 +9167,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge690",
-                    file: "Batch3\\BridgeIssues\\0600\\N690.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N690.cs"
                 } );
             }
             return this.context;
@@ -9166,7 +9191,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge691",
-                    file: "Batch3\\BridgeIssues\\0600\\N691.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N691.cs"
                 } );
             }
             return this.context;
@@ -9190,7 +9215,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge692",
-                    file: "Batch3\\BridgeIssues\\0600\\N692.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N692.cs"
                 } );
             }
             return this.context;
@@ -9214,7 +9239,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge693",
-                    file: "Batch3\\BridgeIssues\\0600\\N693.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N693.cs"
                 } );
             }
             return this.context;
@@ -9238,7 +9263,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge694",
-                    file: "Batch3\\BridgeIssues\\0600\\N694.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N694.cs"
                 } );
             }
             return this.context;
@@ -9262,7 +9287,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge696",
-                    file: "Batch3\\BridgeIssues\\0600\\N696.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N696.cs"
                 } );
             }
             return this.context;
@@ -9286,7 +9311,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge699",
-                    file: "Batch3\\BridgeIssues\\0600\\N699.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0600/N699.cs"
                 } );
             }
             return this.context;
@@ -9299,7 +9324,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
             testFieldPropertyWithInitializer: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge706).beforeTest(false, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge706, 1, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
                     method: "TestFieldPropertyWithInitializer()",
-                    line: "17"
+                    line: "18"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge706.testFieldPropertyWithInitializer();
             }
@@ -9310,7 +9335,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge706",
-                    file: "Batch3\\BridgeIssues\\0700\\N706.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N706.cs"
                 } );
             }
             return this.context;
@@ -9334,7 +9359,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge708",
-                    file: "Batch3\\BridgeIssues\\0700\\N708.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N708.cs"
                 } );
             }
             return this.context;
@@ -9358,7 +9383,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge721",
-                    file: "Batch3\\BridgeIssues\\0700\\N721.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N721.cs"
                 } );
             }
             return this.context;
@@ -9382,7 +9407,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge722",
-                    file: "Batch3\\BridgeIssues\\0700\\N722.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N722.cs"
                 } );
             }
             return this.context;
@@ -9406,7 +9431,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge726",
-                    file: "Batch3\\BridgeIssues\\0700\\N726.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N726.cs"
                 } );
             }
             return this.context;
@@ -9430,7 +9455,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge732",
-                    file: "Batch3\\BridgeIssues\\0700\\N732.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N732.cs"
                 } );
             }
             return this.context;
@@ -9454,7 +9479,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge733",
-                    file: "Batch3\\BridgeIssues\\0700\\N733.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N733.cs"
                 } );
             }
             return this.context;
@@ -9478,7 +9503,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge743",
-                    file: "Batch3\\BridgeIssues\\0700\\N743.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N743.cs"
                 } );
             }
             return this.context;
@@ -9502,7 +9527,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge751",
-                    file: "Batch3\\BridgeIssues\\0700\\N751.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N751.cs"
                 } );
             }
             return this.context;
@@ -9526,7 +9551,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge758",
-                    file: "Batch3\\BridgeIssues\\0700\\N758.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N758.cs"
                 } );
             }
             return this.context;
@@ -9550,7 +9575,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge760",
-                    file: "Batch3\\BridgeIssues\\0700\\N760.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N760.cs"
                 } );
             }
             return this.context;
@@ -9574,7 +9599,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge762",
-                    file: "Batch3\\BridgeIssues\\0700\\N762.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N762.cs"
                 } );
             }
             return this.context;
@@ -9598,7 +9623,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge772",
-                    file: "Batch3\\BridgeIssues\\0700\\N772.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N772.cs"
                 } );
             }
             return this.context;
@@ -9622,7 +9647,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge777",
-                    file: "Batch3\\BridgeIssues\\0700\\N777.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N777.cs"
                 } );
             }
             return this.context;
@@ -9646,7 +9671,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge782",
-                    file: "Batch3\\BridgeIssues\\0700\\N782.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N782.cs"
                 } );
             }
             return this.context;
@@ -9670,7 +9695,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge785",
-                    file: "Batch3\\BridgeIssues\\0700\\N785.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N785.cs"
                 } );
             }
             return this.context;
@@ -9694,7 +9719,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge786",
-                    file: "Batch3\\BridgeIssues\\0700\\N786.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N786.cs"
                 } );
             }
             return this.context;
@@ -9718,7 +9743,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge788",
-                    file: "Batch3\\BridgeIssues\\0700\\N788.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N788.cs"
                 } );
             }
             return this.context;
@@ -9742,7 +9767,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge789",
-                    file: "Batch3\\BridgeIssues\\0700\\N789.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N789.cs"
                 } );
             }
             return this.context;
@@ -9766,7 +9791,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge793",
-                    file: "Batch3\\BridgeIssues\\0700\\N793.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N793.cs"
                 } );
             }
             return this.context;
@@ -9797,7 +9822,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge795",
-                    file: "Batch3\\BridgeIssues\\0700\\N795.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N795.cs"
                 } );
             }
             return this.context;
@@ -9821,7 +9846,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge796",
-                    file: "Batch3\\BridgeIssues\\0700\\N796.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0700/N796.cs"
                 } );
             }
             return this.context;
@@ -9845,7 +9870,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge815",
-                    file: "Batch3\\BridgeIssues\\0800\\N815.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N815.cs"
                 } );
             }
             return this.context;
@@ -9869,7 +9894,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge816",
-                    file: "Batch3\\BridgeIssues\\0800\\N816.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N816.cs"
                 } );
             }
             return this.context;
@@ -9893,7 +9918,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge817",
-                    file: "Batch3\\BridgeIssues\\0800\\N817.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N817.cs"
                 } );
             }
             return this.context;
@@ -9917,7 +9942,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge818",
-                    file: "Batch3\\BridgeIssues\\0800\\N818.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N818.cs"
                 } );
             }
             return this.context;
@@ -9941,7 +9966,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge821",
-                    file: "Batch3\\BridgeIssues\\0800\\N821.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N821.cs"
                 } );
             }
             return this.context;
@@ -9965,7 +9990,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge823",
-                    file: "Batch3\\BridgeIssues\\0800\\N823.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N823.cs"
                 } );
             }
             return this.context;
@@ -9989,7 +10014,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge826",
-                    file: "Batch3\\BridgeIssues\\0800\\N826.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N826.cs"
                 } );
             }
             return this.context;
@@ -10013,7 +10038,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge830",
-                    file: "Batch3\\BridgeIssues\\0800\\N830.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N830.cs"
                 } );
             }
             return this.context;
@@ -10037,7 +10062,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge835",
-                    file: "Batch3\\BridgeIssues\\0800\\N835.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N835.cs"
                 } );
             }
             return this.context;
@@ -10061,7 +10086,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge841",
-                    file: "Batch3\\BridgeIssues\\0800\\N841.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N841.cs"
                 } );
             }
             return this.context;
@@ -10085,7 +10110,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge844",
-                    file: "Batch3\\BridgeIssues\\0800\\N844.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N844.cs"
                 } );
             }
             return this.context;
@@ -10109,7 +10134,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge849",
-                    file: "Batch3\\BridgeIssues\\0800\\N849.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N849.cs"
                 } );
             }
             return this.context;
@@ -10133,7 +10158,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge857",
-                    file: "Batch3\\BridgeIssues\\0800\\N857.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N857.cs"
                 } );
             }
             return this.context;
@@ -10157,7 +10182,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge861",
-                    file: "Batch3\\BridgeIssues\\0800\\N861.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N861.cs"
                 } );
             }
             return this.context;
@@ -10181,7 +10206,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge863",
-                    file: "Batch3\\BridgeIssues\\0800\\N863.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N863.cs"
                 } );
             }
             return this.context;
@@ -10205,7 +10230,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge874",
-                    file: "Batch3\\BridgeIssues\\0800\\N874.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N874.cs"
                 } );
             }
             return this.context;
@@ -10229,7 +10254,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge881",
-                    file: "Batch3\\BridgeIssues\\0800\\N881.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N881.cs"
                 } );
             }
             return this.context;
@@ -10253,7 +10278,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge882",
-                    file: "Batch3\\BridgeIssues\\0800\\N882.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N882.cs"
                 } );
             }
             return this.context;
@@ -10277,7 +10302,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge883",
-                    file: "Batch3\\BridgeIssues\\0800\\N883.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N883.cs"
                 } );
             }
             return this.context;
@@ -10308,7 +10333,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge889",
-                    file: "Batch3\\BridgeIssues\\0800\\N889.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N889.cs"
                 } );
             }
             return this.context;
@@ -10332,7 +10357,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge892",
-                    file: "Batch3\\BridgeIssues\\0800\\N892.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N892.cs"
                 } );
             }
             return this.context;
@@ -10356,7 +10381,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge893",
-                    file: "Batch3\\BridgeIssues\\0800\\N893.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N893.cs"
                 } );
             }
             return this.context;
@@ -10387,7 +10412,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge898",
-                    file: "Batch3\\BridgeIssues\\0800\\N898.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0800/N898.cs"
                 } );
             }
             return this.context;
@@ -10411,7 +10436,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge905",
-                    file: "Batch3\\BridgeIssues\\0900\\N905.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N905.cs"
                 } );
             }
             return this.context;
@@ -10442,7 +10467,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge906",
-                    file: "Batch3\\BridgeIssues\\0900\\N906.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N906.cs"
                 } );
             }
             return this.context;
@@ -10466,7 +10491,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge907",
-                    file: "Batch3\\BridgeIssues\\0900\\N907.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N907.cs"
                 } );
             }
             return this.context;
@@ -10490,7 +10515,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge912",
-                    file: "Batch3\\BridgeIssues\\0900\\N912.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N912.cs"
                 } );
             }
             return this.context;
@@ -10514,7 +10539,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge913",
-                    file: "Batch3\\BridgeIssues\\0900\\N913.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N913.cs"
                 } );
             }
             return this.context;
@@ -10538,7 +10563,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge918",
-                    file: "Batch3\\BridgeIssues\\0900\\N918.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N918.cs"
                 } );
             }
             return this.context;
@@ -10562,7 +10587,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge922",
-                    file: "Batch3\\BridgeIssues\\0900\\N922.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N922.cs"
                 } );
             }
             return this.context;
@@ -10586,7 +10611,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge928",
-                    file: "Batch3\\BridgeIssues\\0900\\N928.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N928.cs"
                 } );
             }
             return this.context;
@@ -10610,7 +10635,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge929",
-                    file: "Batch3\\BridgeIssues\\0900\\N929.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N929.cs"
                 } );
             }
             return this.context;
@@ -10634,7 +10659,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge930",
-                    file: "Batch3\\BridgeIssues\\0900\\N930.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N930.cs"
                 } );
             }
             return this.context;
@@ -10658,7 +10683,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge933",
-                    file: "Batch3\\BridgeIssues\\0900\\N933.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N933.cs"
                 } );
             }
             return this.context;
@@ -10682,7 +10707,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge952",
-                    file: "Batch3\\BridgeIssues\\0900\\N952.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N952.cs"
                 } );
             }
             return this.context;
@@ -10713,7 +10738,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge968",
-                    file: "Batch3\\BridgeIssues\\0900\\N968.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N968.cs"
                 } );
             }
             return this.context;
@@ -10737,7 +10762,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge975",
-                    file: "Batch3\\BridgeIssues\\0900\\N975.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N975.cs"
                 } );
             }
             return this.context;
@@ -10768,7 +10793,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge989",
-                    file: "Batch3\\BridgeIssues\\0900\\N989.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N989.cs"
                 } );
             }
             return this.context;
@@ -10792,7 +10817,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge991",
-                    file: "Batch3\\BridgeIssues\\0900\\N991.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N991.cs"
                 } );
             }
             return this.context;
@@ -10823,7 +10848,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge997",
-                    file: "Batch3\\BridgeIssues\\0900\\N997.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N997.cs"
                 } );
             }
             return this.context;
@@ -10847,7 +10872,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge999",
-                    file: "Batch3\\BridgeIssues\\0900\\N999.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N999.cs"
                 } );
             }
             return this.context;
@@ -10871,7 +10896,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge999_1",
-                    file: "Batch3\\BridgeIssues\\0900\\N999.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/0900/N999.cs"
                 } );
             }
             return this.context;
@@ -10923,7 +10948,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.N1122",
-                    file: "Batch3\\BridgeIssues\\1100\\N1122.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/1100/N1122.cs"
                 } );
             }
             return this.context;
@@ -11234,7 +11259,7 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues",
-                    file: "Batch3\\BridgeIssues\\TestBridgeIssues.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch3/BridgeIssues/TestBridgeIssues.cs"
                 } );
             }
             return this.context;

--- a/Tests/Runner/Batch4/code.js
+++ b/Tests/Runner/Batch4/code.js
@@ -1716,7 +1716,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("got " + enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
             }
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n");
         },
         prematureDisposalOfIEnumeratorIteratorExecutesFinallyBlocks_SPI_1555: function () {
             // #1555
@@ -1729,7 +1729,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             }
             enm.System$IDisposable$dispose();
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nin finally\n");
         },
         exceptionInIEnumeratorIteratorBodyExecutesFinallyBlocks_SPI_1554: function () {
             var sb = new System.Text.StringBuilder();
@@ -1753,7 +1753,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("caught exception");
             }
 
-            this.assertEqual(sb.toString(), "yielding 1\r\ngot 1\r\nyielding 2\r\ngot 2\r\nthrowing\r\nin finally\r\ncaught exception\r\n");
+            this.assertEqual(sb.toString(), "yielding 1\ngot 1\nyielding 2\ngot 2\nthrowing\nin finally\ncaught exception\n");
         },
         typeReturnedByIteratorBlockReturningIEnumerableImplementsThatInterface_SPI_1554: function () {
             var enm = null;
@@ -1784,7 +1784,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("got " + i1);
             }
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n-\r\nyielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n-\nyielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n");
         },
         prematureDisposalOfIEnumerableIteratorExecutesFinallyBlocks_SPI_1555: function () {
             var $t;
@@ -1800,7 +1800,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 }
             }
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nin finally\n");
         },
         exceptionInIEnumerableIteratorBodyExecutesFinallyBlocks_SPI_1554: function () {
             var sb = new System.Text.StringBuilder();
@@ -1825,7 +1825,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("caught exception");
             }
 
-            this.assertEqual(sb.toString(), "yielding 1\r\ngot 1\r\nyielding 2\r\ngot 2\r\nthrowing\r\nin finally\r\ncaught exception\r\n");
+            this.assertEqual(sb.toString(), "yielding 1\ngot 1\nyielding 2\ngot 2\nthrowing\nin finally\ncaught exception\n");
         },
         enumeratingAnIteratorBlockReturningIEnumerableMultipleTimesUsesTheInitialValuesForParameters: function () {
             var $t, $t1;
@@ -1843,7 +1843,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine(i1.toString());
             }
 
-            this.assertEqual(sb.toString(), "3\r\n2\r\n1\r\n3\r\n2\r\n1\r\n");
+            this.assertEqual(sb.toString(), "3\n2\n1\n3\n2\n1\n");
         },
         differentGetEnumeratorCallsOnIteratorBlockReturningIEnumerableGetOwnCopiesOfLocals: function () {
             var sb = new System.Text.StringBuilder();
@@ -1858,7 +1858,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine(enm2[Bridge.geti(enm2, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]().toString());
             }
 
-            this.assertEqual(sb.toString(), "0\r\n0\r\n1\r\n1\r\n2\r\n2\r\n-1\r\n-1\r\n");
+            this.assertEqual(sb.toString(), "0\n0\n1\n1\n2\n2\n-1\n-1\n");
         }
     });
 
@@ -13098,8 +13098,6 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         statics: {
             canConvert: function (T, arg) {
                 try { /// The variable `x' is assigned but its value is never used
-
-
                     var x = Bridge.cast(arg, T);
                     return true;
                 }

--- a/Tests/Runner/Batch4/test.js
+++ b/Tests/Runner/Batch4/test.js
@@ -1969,7 +1969,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ActivatorTests",
-                    file: "Batch4\\ActivatorTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/ActivatorTests.cs"
                 } );
             }
             return this.context;
@@ -1993,7 +1993,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.AppDomainTests",
-                    file: "Batch4\\AppDomainTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/AppDomainTests.cs"
                 } );
             }
             return this.context;
@@ -2038,7 +2038,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ArgumentsTests",
-                    file: "Batch4\\ArgumentsTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/ArgumentsTests.cs"
                 } );
             }
             return this.context;
@@ -2370,7 +2370,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ArrayTests",
-                    file: "Batch4\\ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -2429,7 +2429,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.ComparerTests",
-                    file: "Batch4\\Collections\\Generic\\ComparerTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/ComparerTests.cs"
                 } );
             }
             return this.context;
@@ -2495,7 +2495,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.EqualityComparerTests",
-                    file: "Batch4\\Collections\\Generic\\EqualityComparerTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/EqualityComparerTests.cs"
                 } );
             }
             return this.context;
@@ -2666,7 +2666,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.GenericDictionaryTests",
-                    file: "Batch4\\Collections\\Generic\\GenericDictionaryTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/GenericDictionaryTests.cs"
                 } );
             }
             return this.context;
@@ -2788,7 +2788,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.ICollectionTests",
-                    file: "Batch4\\Collections\\Generic\\ICollectionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/ICollectionTests.cs"
                 } );
             }
             return this.context;
@@ -2882,7 +2882,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.IDictionaryTests",
-                    file: "Batch4\\Collections\\Generic\\IDictionaryTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/IDictionaryTests.cs"
                 } );
             }
             return this.context;
@@ -2941,7 +2941,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.IEnumerableTests",
-                    file: "Batch4\\Collections\\Generic\\IEnumerableTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/IEnumerableTests.cs"
                 } );
             }
             return this.context;
@@ -3070,7 +3070,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.IListTests",
-                    file: "Batch4\\Collections\\Generic\\IListTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/IListTests.cs"
                 } );
             }
             return this.context;
@@ -3157,7 +3157,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.IteratorBlockTests",
-                    file: "Batch4\\Collections\\Generic\\IteratorBlockTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/IteratorBlockTests.cs"
                 } );
             }
             return this.context;
@@ -3216,7 +3216,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.KeyValuePairTests",
-                    file: "Batch4\\Collections\\Generic\\KeyValuePairTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/KeyValuePairTests.cs"
                 } );
             }
             return this.context;
@@ -3597,7 +3597,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.ListTests",
-                    file: "Batch4\\Collections\\Generic\\ListTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/Generic/ListTests.cs"
                 } );
             }
             return this.context;
@@ -3733,7 +3733,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.ObjectModel.ReadOnlyCollectionTests",
-                    file: "Batch4\\Collections\\ObjectModel\\ReadOnlyCollectionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/ObjectModel/ReadOnlyCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -3771,7 +3771,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.ArrayBufferTests",
-                    file: "Batch4\\Collections\\TypedArrays\\ArrayBufferTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/ArrayBufferTests.cs"
                 } );
             }
             return this.context;
@@ -3928,7 +3928,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.DataViewTests",
-                    file: "Batch4\\Collections\\TypedArrays\\DataViewTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/DataViewTests.cs"
                 } );
             }
             return this.context;
@@ -4127,7 +4127,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Float32ArrayTests",
-                    file: "Batch4\\Collections\\TypedArrays\\Float32ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/Float32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -4326,7 +4326,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Float64ArrayTests",
-                    file: "Batch4\\Collections\\TypedArrays\\Float64ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/Float64ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -4525,7 +4525,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Int16ArrayTests",
-                    file: "Batch4\\Collections\\TypedArrays\\Int16ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/Int16ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -4724,7 +4724,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Int32ArrayTests",
-                    file: "Batch4\\Collections\\TypedArrays\\Int32ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/Int32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -4923,7 +4923,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Int8ArrayTests",
-                    file: "Batch4\\Collections\\TypedArrays\\Int8ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/Int8ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -5122,7 +5122,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint16ArrayTests",
-                    file: "Batch4\\Collections\\TypedArrays\\Uint16ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/Uint16ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -5321,7 +5321,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint32ArrayTests",
-                    file: "Batch4\\Collections\\TypedArrays\\Uint32ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/Uint32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -5520,7 +5520,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint8ArrayTests",
-                    file: "Batch4\\Collections\\TypedArrays\\Uint8ArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/Uint8ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -5733,7 +5733,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint8ClampedArrayTests",
-                    file: "Batch4\\Collections\\TypedArrays\\Uint8ClampedArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Collections/TypedArrays/Uint8ClampedArrayTests.cs"
                 } );
             }
             return this.context;
@@ -5785,7 +5785,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ConvertTests",
-                    file: "Batch4\\ConvertTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/ConvertTests.cs"
                 } );
             }
             return this.context;
@@ -5823,7 +5823,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.CultureInfoTests",
-                    file: "Batch4\\CultureInfoTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/CultureInfoTests.cs"
                 } );
             }
             return this.context;
@@ -5861,7 +5861,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.DateTimeFormatInfoTests",
-                    file: "Batch4\\DateTimeFormatInfoTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/DateTimeFormatInfoTests.cs"
                 } );
             }
             return this.context;
@@ -6018,7 +6018,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.DelegateTests",
-                    file: "Batch4\\DelegateTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/DelegateTests.cs"
                 } );
             }
             return this.context;
@@ -6119,7 +6119,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Diagnostics.Contracts.ContractTests",
-                    file: "Batch4\\Diagnostics\\Contracts\\ContractTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Diagnostics/Contracts/ContractTests.cs"
                 } );
             }
             return this.context;
@@ -6143,7 +6143,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.EnvironmentTests",
-                    file: "Batch4\\EnvironmentTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/EnvironmentTests.cs"
                 } );
             }
             return this.context;
@@ -6216,7 +6216,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.AggregateExceptionTests",
-                    file: "Batch4\\Exceptions\\AggregateExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/AggregateExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6261,7 +6261,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.AmbiguousMatchExceptionTests",
-                    file: "Batch4\\Exceptions\\AmbiguousMatchExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/AmbiguousMatchExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6320,7 +6320,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ArgumentExceptionTests",
-                    file: "Batch4\\Exceptions\\ArgumentExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/ArgumentExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6372,7 +6372,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ArgumentNullExceptionTests",
-                    file: "Batch4\\Exceptions\\ArgumentNullExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/ArgumentNullExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6438,7 +6438,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ArgumentOutOfRangeExceptionTests",
-                    file: "Batch4\\Exceptions\\ArgumentOutOfRangeExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/ArgumentOutOfRangeExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6483,7 +6483,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ArithmeticExceptionTests",
-                    file: "Batch4\\Exceptions\\ArithmeticExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/ArithmeticExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6514,7 +6514,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ContractExceptionTests",
-                    file: "Batch4\\Exceptions\\ContractExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/ContractExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6559,7 +6559,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.DivideByZeroExceptionTests",
-                    file: "Batch4\\Exceptions\\DivideByZeroExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/DivideByZeroExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6597,7 +6597,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ErrorExceptionTests",
-                    file: "Batch4\\Exceptions\\JsErrorExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/JsErrorExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6656,7 +6656,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ExceptionTests",
-                    file: "Batch4\\Exceptions\\ExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/ExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6701,7 +6701,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.FormatExceptionTests",
-                    file: "Batch4\\Exceptions\\FormatExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/FormatExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6746,7 +6746,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.InvalidCastExceptionTests",
-                    file: "Batch4\\Exceptions\\InvalidCastExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/InvalidCastExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6791,7 +6791,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.InvalidOperationExceptionTests",
-                    file: "Batch4\\Exceptions\\InvalidOperationExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/InvalidOperationExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6836,7 +6836,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.KeyNotFoundExceptionTests",
-                    file: "Batch4\\Exceptions\\KeyNotFoundExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/KeyNotFoundExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6881,7 +6881,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.NotImplementedExceptionTests",
-                    file: "Batch4\\Exceptions\\NotImplementedExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/NotImplementedExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6926,7 +6926,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.NotSupportedExceptionTests",
-                    file: "Batch4\\Exceptions\\NotSupportedExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/NotSupportedExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6978,7 +6978,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.NullReferenceExceptionTests",
-                    file: "Batch4\\Exceptions\\NullReferenceExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/NullReferenceExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -7044,7 +7044,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.OperationCanceledExceptionTests",
-                    file: "Batch4\\Exceptions\\OperationCanceledExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/OperationCanceledExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -7089,7 +7089,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.OverflowExceptionTests",
-                    file: "Batch4\\Exceptions\\OverflowExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/OverflowExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -7134,7 +7134,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.PromiseExceptionTests",
-                    file: "Batch4\\Exceptions\\PromiseExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/PromiseExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -7186,7 +7186,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.TaskCanceledExceptionTests",
-                    file: "Batch4\\Exceptions\\TaskCanceledExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Exceptions/TaskCanceledExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -7238,7 +7238,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ExceptionTests",
-                    file: "Batch4\\ExceptionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/ExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -7325,7 +7325,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.FormattableStringTests",
-                    file: "Batch4\\FormattableStringTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/FormattableStringTests.cs"
                 } );
             }
             return this.context;
@@ -7524,7 +7524,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.GuidTests",
-                    file: "Batch4\\GuidTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/GuidTests.cs"
                 } );
             }
             return this.context;
@@ -7548,7 +7548,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.IComparableTests",
-                    file: "Batch4\\IComparableTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/IComparableTests.cs"
                 } );
             }
             return this.context;
@@ -7572,7 +7572,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.IEquatableTests",
-                    file: "Batch4\\IEquatableTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/IEquatableTests.cs"
                 } );
             }
             return this.context;
@@ -7603,7 +7603,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.IFormattableTests",
-                    file: "Batch4\\IFormattableTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/IFormattableTests.cs"
                 } );
             }
             return this.context;
@@ -7935,7 +7935,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests",
-                    file: "Batch4\\Linq\\Expressions\\ExpressionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Linq/Expressions/ExpressionTests.cs"
                 } );
             }
             return this.context;
@@ -8414,7 +8414,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.MathTests",
-                    file: "Batch4\\MathTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/MathTests.cs"
                 } );
             }
             return this.context;
@@ -8536,7 +8536,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.MultidimArrayTests",
-                    file: "Batch4\\MultidimArrayTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/MultidimArrayTests.cs"
                 } );
             }
             return this.context;
@@ -8847,7 +8847,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.NullableTests",
-                    file: "Batch4\\NullableTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/NullableTests.cs"
                 } );
             }
             return this.context;
@@ -8885,7 +8885,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.NumberFormatInfoTests",
-                    file: "Batch4\\NumberFormatInfoTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/NumberFormatInfoTests.cs"
                 } );
             }
             return this.context;
@@ -8944,7 +8944,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.PropertyAccessorTests",
-                    file: "Batch4\\PropertyAccessorTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/PropertyAccessorTests.cs"
                 } );
             }
             return this.context;
@@ -9017,7 +9017,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.RandomTests",
-                    file: "Batch4\\RandomTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/RandomTests.cs"
                 } );
             }
             return this.context;
@@ -9160,7 +9160,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.AssemblyTests",
-                    file: "Batch4\\Reflection\\AssemblyTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Reflection/AssemblyTests.cs"
                 } );
             }
             return this.context;
@@ -9352,7 +9352,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.AttributeTests",
-                    file: "Batch4\\Reflection\\AttributeTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Reflection/AttributeTests.cs"
                 } );
             }
             return this.context;
@@ -9565,7 +9565,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.GetMembersTests",
-                    file: "Batch4\\Reflection\\GetMembersTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Reflection/GetMembersTests.cs"
                 } );
             }
             return this.context;
@@ -10226,7 +10226,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.ReflectionTests",
-                    file: "Batch4\\Reflection\\ReflectionTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Reflection/ReflectionTests.cs"
                 } );
             }
             return this.context;
@@ -10292,7 +10292,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests",
-                    file: "Batch4\\Reflection\\TypeSystemLanguageSupportTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Reflection/TypeSystemLanguageSupportTests.cs"
                 } );
             }
             return this.context;
@@ -10673,7 +10673,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.TypeSystemTests",
-                    file: "Batch4\\Reflection\\TypeSystemTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Reflection/TypeSystemTests.cs"
                 } );
             }
             return this.context;
@@ -10725,7 +10725,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.RefParameterTests",
-                    file: "Batch4\\RefParameterTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/RefParameterTests.cs"
                 } );
             }
             return this.context;
@@ -10756,7 +10756,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Runtime.CompilerServices.RuntimeHelpersTests",
-                    file: "Batch4\\Runtime\\CompilerServices\\RuntimeHelpersTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Runtime/CompilerServices/RuntimeHelpersTests.cs"
                 } );
             }
             return this.context;
@@ -10808,7 +10808,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ScriptTests",
-                    file: "Batch4\\ScriptTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/ScriptTests.cs"
                 } );
             }
             return this.context;
@@ -10902,7 +10902,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Serialization.JsonTests",
-                    file: "Batch4\\Serialization\\JsonTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Serialization/JsonTests.cs"
                 } );
             }
             return this.context;
@@ -10989,7 +10989,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.BooleanTests",
-                    file: "Batch4\\SimpleTypes\\BooleanTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/BooleanTests.cs"
                 } );
             }
             return this.context;
@@ -11139,7 +11139,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.ByteTests",
-                    file: "Batch4\\SimpleTypes\\ByteTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/ByteTests.cs"
                 } );
             }
             return this.context;
@@ -11317,7 +11317,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.CharTests",
-                    file: "Batch4\\SimpleTypes\\CharTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/CharTests.cs"
                 } );
             }
             return this.context;
@@ -11775,7 +11775,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.DateTests",
-                    file: "Batch4\\SimpleTypes\\JsDateTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/JsDateTests.cs"
                 } );
             }
             return this.context;
@@ -12443,7 +12443,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.DateTimeTests",
-                    file: "Batch4\\SimpleTypes\\DateTimeTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/DateTimeTests.cs"
                 } );
             }
             return this.context;
@@ -12887,7 +12887,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.DecimalTests",
-                    file: "Batch4\\SimpleTypes\\DecimalTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/DecimalTests.cs"
                 } );
             }
             return this.context;
@@ -13086,7 +13086,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.DoubleTests",
-                    file: "Batch4\\SimpleTypes\\DoubleTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/DoubleTests.cs"
                 } );
             }
             return this.context;
@@ -13187,7 +13187,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.EnumTests",
-                    file: "Batch4\\SimpleTypes\\EnumTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/EnumTests.cs"
                 } );
             }
             return this.context;
@@ -13337,7 +13337,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.Int16Tests",
-                    file: "Batch4\\SimpleTypes\\Int16Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/Int16Tests.cs"
                 } );
             }
             return this.context;
@@ -13536,7 +13536,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.Int32Tests",
-                    file: "Batch4\\SimpleTypes\\Int32Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/Int32Tests.cs"
                 } );
             }
             return this.context;
@@ -13693,7 +13693,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.Int64Tests",
-                    file: "Batch4\\SimpleTypes\\Int64Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/Int64Tests.cs"
                 } );
             }
             return this.context;
@@ -13766,7 +13766,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.ObjectTests",
-                    file: "Batch4\\SimpleTypes\\ObjectTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/ObjectTests.cs"
                 } );
             }
             return this.context;
@@ -13916,7 +13916,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.SByteTests",
-                    file: "Batch4\\SimpleTypes\\SByteTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/SByteTests.cs"
                 } );
             }
             return this.context;
@@ -14115,7 +14115,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.SingleTests",
-                    file: "Batch4\\SimpleTypes\\SingleTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/SingleTests.cs"
                 } );
             }
             return this.context;
@@ -14741,7 +14741,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.StringTests",
-                    file: "Batch4\\SimpleTypes\\StringTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/StringTests.cs"
                 } );
             }
             return this.context;
@@ -14919,7 +14919,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.TimeSpanTests",
-                    file: "Batch4\\SimpleTypes\\TimeSpanTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/TimeSpanTests.cs"
                 } );
             }
             return this.context;
@@ -14992,7 +14992,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.TupleTests",
-                    file: "Batch4\\SimpleTypes\\TupleTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/TupleTests.cs"
                 } );
             }
             return this.context;
@@ -15142,7 +15142,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.UInt16Tests",
-                    file: "Batch4\\SimpleTypes\\UInt16Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/UInt16Tests.cs"
                 } );
             }
             return this.context;
@@ -15292,7 +15292,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.UInt32Tests",
-                    file: "Batch4\\SimpleTypes\\UInt32Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/UInt32Tests.cs"
                 } );
             }
             return this.context;
@@ -15456,7 +15456,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.UInt64Tests",
-                    file: "Batch4\\SimpleTypes\\UInt64Tests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/SimpleTypes/UInt64Tests.cs"
                 } );
             }
             return this.context;
@@ -15522,7 +15522,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.StopwatchTests",
-                    file: "Batch4\\StopwatchTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/StopwatchTests.cs"
                 } );
             }
             return this.context;
@@ -15623,7 +15623,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Text.RegularExpressions.RegexTests",
-                    file: "Batch4\\Text\\RegularExpressions\\RegexTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Text/RegularExpressions/RegexTests.cs"
                 } );
             }
             return this.context;
@@ -15787,7 +15787,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Text.StringBuilderTests",
-                    file: "Batch4\\Text\\StringBuilderTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Text/StringBuilderTests.cs"
                 } );
             }
             return this.context;
@@ -15846,7 +15846,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Threading.AsyncTests",
-                    file: "Batch4\\Threading\\Tasks\\AsyncTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Threading/Tasks/AsyncTests.cs"
                 } );
             }
             return this.context;
@@ -16059,7 +16059,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Threading.CancellationTokenTests",
-                    file: "Batch4\\Threading\\CancellationTokenTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Threading/CancellationTokenTests.cs"
                 } );
             }
             return this.context;
@@ -16118,7 +16118,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Threading.PromiseTests",
-                    file: "Batch4\\Threading\\Tasks\\PromiseTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Threading/Tasks/PromiseTests.cs"
                 } );
             }
             return this.context;
@@ -16450,7 +16450,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Threading.TaskTests",
-                    file: "Batch4\\Threading\\Tasks\\TaskTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/Threading/Tasks/TaskTests.cs"
                 } );
             }
             return this.context;
@@ -16663,7 +16663,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.UserDefinedStructTests",
-                    file: "Batch4\\UserDefinedStructTests.cs"
+                    file: "file:///C:/projects/Bridge/v1/Bridge/Tests/Batch4/UserDefinedStructTests.cs"
                 } );
             }
             return this.context;


### PR DESCRIPTION
Fixes #2137