### PR TITLE
[1566] [Zaid-Ajaj] Math.Log fixes

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -5097,6 +5097,10 @@
             return Math.round(n) / m;
         },
 
+        log10: Math.log10 || function (x) {
+            return Math.log(x) / Math.LN10;
+        },
+
         logWithBase: function (x, newBase) {
             if (isNaN(x)) {
                 return x;
@@ -5114,7 +5118,7 @@
                 return NaN;
             }
 
-            return Math.log10(x) / Math.log10(newBase);
+            return Bridge.Math.log10(x) / Bridge.Math.log10(newBase);
         },
 
         log: function (x) {

--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -5097,6 +5097,46 @@
             return Math.round(n) / m;
         },
 
+        logWithBase: function (x, newBase) {
+            if (isNaN(x)) {
+                return x;
+            }
+
+            if (isNaN(newBase)) {
+                return newBase;
+            }
+
+            if (newBase === 1) {
+                return NaN
+            }
+
+            if (x !== 1 && (newBase === 0 || newBase === Number.POSITIVE_INFINITY)) {
+                return NaN;
+            }
+
+            return Math.log10(x) / Math.log10(newBase);
+        },
+
+        log: function (x) {
+            if (x === 0.0) {
+                return Number.NEGATIVE_INFINITY;
+            }
+
+            if (x < 0.0 || isNaN(x)) {
+                return NaN;
+            }
+
+            if (x === Number.POSITIVE_INFINITY) {
+                return Number.POSITIVE_INFINITY;
+            }
+
+            if (x === Number.NEGATIVE_INFINITY) {
+                return NaN;
+            }
+
+            return Math.log(x);
+        },
+
         sinh: Math.sinh || function (x) {
             return (Math.exp(x) - Math.exp(-x)) / 2;
         },

--- a/Bridge/Resources/Math.js
+++ b/Bridge/Resources/Math.js
@@ -23,9 +23,7 @@
             return Math.round(n) / m;
         },
 
-        // according to this implementation https://referencesource.microsoft.com/#mscorlib/system/math.cs,506
-        logWithBase: function (x, newBase) { 
-
+        logWithBase: function (x, newBase) {
             if (isNaN(x)) {
                 return x;
             }
@@ -45,8 +43,7 @@
             return Math.log10(x) / Math.log10(newBase);
         },
 
-        // according to https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L228
-        log: function (x) { 
+        log: function (x) {
             if (x === 0.0) {
                 return Number.NEGATIVE_INFINITY;
             }
@@ -64,7 +61,6 @@
             }
 
             return Math.log(x);
-
         },
 
         sinh: Math.sinh || function (x) {

--- a/Bridge/Resources/Math.js
+++ b/Bridge/Resources/Math.js
@@ -23,6 +23,10 @@
             return Math.round(n) / m;
         },
 
+        log10: Math.log10 || function (x) {
+            return Math.log(x) / Math.LN10;
+        },
+
         logWithBase: function (x, newBase) {
             if (isNaN(x)) {
                 return x;
@@ -40,7 +44,7 @@
                 return NaN;
             }
 
-            return Math.log10(x) / Math.log10(newBase);
+            return Bridge.Math.log10(x) / Bridge.Math.log10(newBase);
         },
 
         log: function (x) {

--- a/Bridge/Resources/Math.js
+++ b/Bridge/Resources/Math.js
@@ -23,6 +23,50 @@
             return Math.round(n) / m;
         },
 
+        // according to this implementation https://referencesource.microsoft.com/#mscorlib/system/math.cs,506
+        logWithBase: function (x, newBase) { 
+
+            if (isNaN(x)) {
+                return x;
+            }
+
+            if (isNaN(newBase)) {
+                return newBase;
+            }
+
+            if (newBase === 1) {
+                return NaN
+            }
+
+            if (x !== 1 && (newBase === 0 || newBase === Number.POSITIVE_INFINITY)) {
+                return NaN;
+            }
+
+            return Math.log10(x) / Math.log10(newBase);
+        },
+
+        // according to https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L228
+        log: function (x) { 
+            if (x === 0.0) {
+                return Number.NEGATIVE_INFINITY;
+            }
+
+            if (x < 0.0 || isNaN(x)) {
+                return NaN;
+            }
+
+            if (x === Number.POSITIVE_INFINITY) {
+                return Number.POSITIVE_INFINITY;
+            }
+
+            if (x === Number.NEGATIVE_INFINITY) {
+                return NaN;
+            }
+
+            return Math.log(x);
+
+        },
+
         sinh: Math.sinh || function (x) {
             return (Math.exp(x) - Math.exp(-x)) / 2;
         },

--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -122,19 +122,20 @@ namespace System
         [Template("{x}.exponential()")]
         public static extern decimal Exp(decimal x);
 
-        [Template("{x}.ln()")]
-        public static extern decimal Ln(decimal x);
+        [Template("Bridge.Math.log({x})")]
+        public static extern double Log(double x);
 
-        [Template("{x}.log({logBase})")]
-        public static extern decimal Log(decimal x, decimal logBase);
+        [Template("Bridge.Math.logWithBase({x}, {logBase})")]
+        public static extern double Log(double x, double logBase);
+
+        [Template("Bridge.Math.logWithBase({x}, 10.0)")]
+        public static extern double Log10(double x);
 
         [Template("{x}.pow({y})")]
         public static extern decimal Pow(decimal x, decimal y);
 
         [Template("{x}.sqrt()")]
         public static extern decimal Sqrt(decimal x);
-
-        public static extern double Log(double x);
 
         public static extern double Pow(double x, double y);
 

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -317,6 +317,7 @@
     <Compile Include="BridgeIssues\1500\N1535.cs" />
     <Compile Include="BridgeIssues\1500\N1536.cs" />
     <Compile Include="BridgeIssues\1500\N1538.cs" />
+    <Compile Include="BridgeIssues\1500\N1566.cs" />
     <Compile Include="BridgeIssues\1500\N1599.cs" />
     <Compile Include="BridgeIssues\1600\N1641.cs" />
     <Compile Include="BridgeIssues\1600\N1653.cs" />

--- a/Tests/Batch3/BridgeIssues/1500/N1566.cs
+++ b/Tests/Batch3/BridgeIssues/1500/N1566.cs
@@ -13,35 +13,46 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
         [Test]
         public void TestMathLog10()
         {
-            Assert.AreEqual(0.477121254719662, Math.Log10(3.0));
-            Assert.AreEqual(double.NegativeInfinity, Math.Log10(0.0));
-            Assert.AreEqual(double.NaN, Math.Log10(-3.0));
-            Assert.AreEqual(double.NaN, Math.Log10(double.NaN));
-            Assert.AreEqual(double.PositiveInfinity, Math.Log10(double.PositiveInfinity));
-            Assert.AreEqual(double.NaN, Math.Log10(double.NegativeInfinity));
+            AssertAlmostEqual(0.477121254719662, Math.Log10(3.0));
+            AssertAlmostEqual(double.NegativeInfinity, Math.Log10(0.0));
+            AssertAlmostEqual(double.NaN, Math.Log10(-3.0));
+            AssertAlmostEqual(double.NaN, Math.Log10(double.NaN));
+            AssertAlmostEqual(double.PositiveInfinity, Math.Log10(double.PositiveInfinity));
+            AssertAlmostEqual(double.NaN, Math.Log10(double.NegativeInfinity));
         }
 
         [Test]
         public void TestMathLogWithBase()
         {
-            Assert.AreEqual(1.0, Math.Log(3.0, 3.0));
-            Assert.AreEqual(2.40217350273, Math.Log(14, 3.0));
-            Assert.AreEqual(double.NegativeInfinity, Math.Log(0.0, 3.0));
-            Assert.AreEqual(double.NaN, Math.Log(-3.0, 3.0));
-            Assert.AreEqual(double.NaN, Math.Log(double.NaN, 3.0));
-            Assert.AreEqual(double.PositiveInfinity, Math.Log(double.PositiveInfinity, 3.0));
-            Assert.AreEqual(double.NaN, Math.Log(double.NegativeInfinity, 3.0));
+            AssertAlmostEqual(1.0, Math.Log(3.0, 3.0));
+            AssertAlmostEqual(2.40217350273, Math.Log(14, 3.0));
+            AssertAlmostEqual(double.NegativeInfinity, Math.Log(0.0, 3.0));
+            AssertAlmostEqual(double.NaN, Math.Log(-3.0, 3.0));
+            AssertAlmostEqual(double.NaN, Math.Log(double.NaN, 3.0));
+            AssertAlmostEqual(double.PositiveInfinity, Math.Log(double.PositiveInfinity, 3.0));
+            AssertAlmostEqual(double.NaN, Math.Log(double.NegativeInfinity, 3.0));
         }
 
         [Test]
         public void TestMathLog()
         {
-            Assert.AreEqual(1.09861228866811, Math.Log(3.0));
-            Assert.AreEqual(double.NegativeInfinity, Math.Log(0.0));
-            Assert.AreEqual(double.NaN, Math.Log(-3.0));
-            Assert.AreEqual(double.NaN, Math.Log(double.NaN));
-            Assert.AreEqual(double.PositiveInfinity, Math.Log(double.PositiveInfinity));
-            Assert.AreEqual(double.NaN, Math.Log(double.NegativeInfinity));
+            AssertAlmostEqual(1.09861228866811, Math.Log(3.0));
+            AssertAlmostEqual(double.NegativeInfinity, Math.Log(0.0));
+            AssertAlmostEqual(double.NaN, Math.Log(-3.0));
+            AssertAlmostEqual(double.NaN, Math.Log(double.NaN));
+            AssertAlmostEqual(double.PositiveInfinity, Math.Log(double.PositiveInfinity));
+            AssertAlmostEqual(double.NaN, Math.Log(double.NegativeInfinity));
+        }
+
+        private void AssertAlmostEqual(double expected, double actual)
+        {
+            var diff = actual - expected;
+            if (diff < 0)
+            {
+                diff = -diff;
+            }
+
+            Assert.True(diff < 1e-8, "Actual:" + actual + " vs Expected:" + expected);
         }
     }
 }

--- a/Tests/Batch3/BridgeIssues/1500/N1566.cs
+++ b/Tests/Batch3/BridgeIssues/1500/N1566.cs
@@ -46,6 +46,15 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
 
         private void AssertAlmostEqual(double expected, double actual)
         {
+            var se = expected.ToString();
+            var sa = actual.ToString();
+
+            if (sa == se)
+            {
+                Assert.True(true, "Actual:" + actual + " vs Expected:" + expected);
+                return;
+            }
+
             var diff = actual - expected;
             if (diff < 0)
             {

--- a/Tests/Batch3/BridgeIssues/1500/N1566.cs
+++ b/Tests/Batch3/BridgeIssues/1500/N1566.cs
@@ -1,0 +1,24 @@
+using Bridge.Test;
+using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#1566 - {0}")]
+    public class Bridge1566
+    {
+        [Test]
+        public void TestMathLog10()
+        {
+            Assert.AreEqual(0.477121254719662, Math.Log10(3.0));
+            Assert.AreEqual(double.NegativeInfinity, Math.Log10(0.0));
+            Assert.AreEqual(double.NaN, Math.Log10(-3.0));
+            Assert.AreEqual(double.NaN, Math.Log10(double.NaN));
+            Assert.AreEqual(double.PositiveInfinity, Math.Log10(double.PositiveInfinity));
+            Assert.AreEqual(double.NaN, Math.Log10(double.NegativeInfinity));
+        }
+    }
+}

--- a/Tests/Batch3/BridgeIssues/1500/N1566.cs
+++ b/Tests/Batch3/BridgeIssues/1500/N1566.cs
@@ -21,6 +21,7 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             Assert.AreEqual(double.NaN, Math.Log10(double.NegativeInfinity));
         }
 
+        [Test]
         public void TestMathLogWithBase()
         {
             Assert.AreEqual(1.0, Math.Log(3.0, 3.0));
@@ -30,6 +31,17 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             Assert.AreEqual(double.NaN, Math.Log(double.NaN, 3.0));
             Assert.AreEqual(double.PositiveInfinity, Math.Log(double.PositiveInfinity, 3.0));
             Assert.AreEqual(double.NaN, Math.Log(double.NegativeInfinity, 3.0));
+        }
+
+        [Test]
+        public void TestMathLog()
+        {
+            Assert.AreEqual(1.09861228866811, Math.Log(3.0));
+            Assert.AreEqual(double.NegativeInfinity, Math.Log(0.0));
+            Assert.AreEqual(double.NaN, Math.Log(-3.0));
+            Assert.AreEqual(double.NaN, Math.Log(double.NaN));
+            Assert.AreEqual(double.PositiveInfinity, Math.Log(double.PositiveInfinity));
+            Assert.AreEqual(double.NaN, Math.Log(double.NegativeInfinity));
         }
     }
 }

--- a/Tests/Batch3/BridgeIssues/1500/N1566.cs
+++ b/Tests/Batch3/BridgeIssues/1500/N1566.cs
@@ -20,5 +20,16 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             Assert.AreEqual(double.PositiveInfinity, Math.Log10(double.PositiveInfinity));
             Assert.AreEqual(double.NaN, Math.Log10(double.NegativeInfinity));
         }
+
+        public void TestMathLogWithBase()
+        {
+            Assert.AreEqual(1.0, Math.Log(3.0, 3.0));
+            Assert.AreEqual(2.40217350273, Math.Log(14, 3.0));
+            Assert.AreEqual(double.NegativeInfinity, Math.Log(0.0, 3.0));
+            Assert.AreEqual(double.NaN, Math.Log(-3.0, 3.0));
+            Assert.AreEqual(double.NaN, Math.Log(double.NaN, 3.0));
+            Assert.AreEqual(double.PositiveInfinity, Math.Log(double.PositiveInfinity, 3.0));
+            Assert.AreEqual(double.NaN, Math.Log(double.NegativeInfinity, 3.0));
+        }
     }
 }

--- a/Tests/Batch4/MathTests.cs
+++ b/Tests/Batch4/MathTests.cs
@@ -172,23 +172,23 @@ namespace Bridge.ClientTest.Batch4
         {
             // #1566
             // Test restructure to keep assertion count correct (prevent uncaught test exception)
-            decimal d1 = 0;
+            var d1 = 0d;
             TestHelper.Safe(() => d1 = Math.Log(16, 2));
             Assert.AreEqual(4.0, d1);
 
-            decimal d2 = 0;
+            var d2 = 0d;
             TestHelper.Safe(() => d2 = Math.Log(16, 4));
             Assert.AreEqual(2.0, d2);
         }
 
         // #SPI
-        //[Test]
-        //public void Log10Works_SPI_1629()
-        //{
-        //    // #1629
-        //    Assert.AreEqual(Math.Log10(10), 1.0);
-        //    Assert.AreEqual(Math.Log10(100), 2.0);
-        //}
+        [Test]
+        public void Log10Works_SPI_1629()
+        {
+            // #1629
+            Assert.AreEqual(Math.Log10(10), 1.0);
+            Assert.AreEqual(Math.Log10(100), 2.0);
+        }
 
         [Test]
         public void MaxOfByteWorks()

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -5097,6 +5097,10 @@
             return Math.round(n) / m;
         },
 
+        log10: Math.log10 || function (x) {
+            return Math.log(x) / Math.LN10;
+        },
+
         logWithBase: function (x, newBase) {
             if (isNaN(x)) {
                 return x;
@@ -5114,7 +5118,7 @@
                 return NaN;
             }
 
-            return Math.log10(x) / Math.log10(newBase);
+            return Bridge.Math.log10(x) / Bridge.Math.log10(newBase);
         },
 
         log: function (x) {

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -5097,6 +5097,46 @@
             return Math.round(n) / m;
         },
 
+        logWithBase: function (x, newBase) {
+            if (isNaN(x)) {
+                return x;
+            }
+
+            if (isNaN(newBase)) {
+                return newBase;
+            }
+
+            if (newBase === 1) {
+                return NaN
+            }
+
+            if (x !== 1 && (newBase === 0 || newBase === Number.POSITIVE_INFINITY)) {
+                return NaN;
+            }
+
+            return Math.log10(x) / Math.log10(newBase);
+        },
+
+        log: function (x) {
+            if (x === 0.0) {
+                return Number.NEGATIVE_INFINITY;
+            }
+
+            if (x < 0.0 || isNaN(x)) {
+                return NaN;
+            }
+
+            if (x === Number.POSITIVE_INFINITY) {
+                return Number.POSITIVE_INFINITY;
+            }
+
+            if (x === Number.NEGATIVE_INFINITY) {
+                return NaN;
+            }
+
+            return Math.log(x);
+        },
+
         sinh: Math.sinh || function (x) {
             return (Math.exp(x) - Math.exp(-x)) / 2;
         },

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -18892,7 +18892,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             this.assertIsDecimalAndEqualTo(System.Decimal(-3.6).floor(), -4.0);
         },
         logWorks: function () {
-            this.assertAlmostEqual(Math.log(0.5), -0.69314718055994529);
+            this.assertAlmostEqual(Bridge.Math.log(0.5), -0.69314718055994529);
         },
         maxOfByteWorks: function () {
             Bridge.Test.Assert.areEqual(3.0, Math.max(1, 3));

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -7278,6 +7278,50 @@ Bridge.$N1391Result =                 r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1566", {
+        testMathLog10: function () {
+            this.assertAlmostEqual(0.477121254719662, Bridge.Math.logWithBase(3.0, 10.0));
+            this.assertAlmostEqual(Number.NEGATIVE_INFINITY, Bridge.Math.logWithBase(0.0, 10.0));
+            this.assertAlmostEqual(Number.NaN, Bridge.Math.logWithBase(-3.0, 10.0));
+            this.assertAlmostEqual(Number.NaN, Bridge.Math.logWithBase(Number.NaN, 10.0));
+            this.assertAlmostEqual(Number.POSITIVE_INFINITY, Bridge.Math.logWithBase(Number.POSITIVE_INFINITY, 10.0));
+            this.assertAlmostEqual(Number.NaN, Bridge.Math.logWithBase(Number.NEGATIVE_INFINITY, 10.0));
+        },
+        testMathLogWithBase: function () {
+            this.assertAlmostEqual(1.0, Bridge.Math.logWithBase(3.0, 3.0));
+            this.assertAlmostEqual(2.40217350273, Bridge.Math.logWithBase(14, 3.0));
+            this.assertAlmostEqual(Number.NEGATIVE_INFINITY, Bridge.Math.logWithBase(0.0, 3.0));
+            this.assertAlmostEqual(Number.NaN, Bridge.Math.logWithBase(-3.0, 3.0));
+            this.assertAlmostEqual(Number.NaN, Bridge.Math.logWithBase(Number.NaN, 3.0));
+            this.assertAlmostEqual(Number.POSITIVE_INFINITY, Bridge.Math.logWithBase(Number.POSITIVE_INFINITY, 3.0));
+            this.assertAlmostEqual(Number.NaN, Bridge.Math.logWithBase(Number.NEGATIVE_INFINITY, 3.0));
+        },
+        testMathLog: function () {
+            this.assertAlmostEqual(1.09861228866811, Bridge.Math.log(3.0));
+            this.assertAlmostEqual(Number.NEGATIVE_INFINITY, Bridge.Math.log(0.0));
+            this.assertAlmostEqual(Number.NaN, Bridge.Math.log(-3.0));
+            this.assertAlmostEqual(Number.NaN, Bridge.Math.log(Number.NaN));
+            this.assertAlmostEqual(Number.POSITIVE_INFINITY, Bridge.Math.log(Number.POSITIVE_INFINITY));
+            this.assertAlmostEqual(Number.NaN, Bridge.Math.log(Number.NEGATIVE_INFINITY));
+        },
+        assertAlmostEqual: function (expected, actual) {
+            var se = System.Double.format(expected, 'G');
+            var sa = System.Double.format(actual, 'G');
+
+            if (Bridge.referenceEquals(sa, se)) {
+                Bridge.Test.Assert.true$1(true, "Actual:" + System.Double.format(actual, 'G') + " vs Expected:" + System.Double.format(expected, 'G'));
+                return;
+            }
+
+            var diff = actual - expected;
+            if (diff < 0) {
+                diff = -diff;
+            }
+
+            Bridge.Test.Assert.true$1(diff < 1E-08, "Actual:" + System.Double.format(actual, 'G') + " vs Expected:" + System.Double.format(expected, 'G'));
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge1599", {
         testCustomIEnumerableForStringJoin: function () {
             var intValues = new (Bridge.ClientTest.Batch3.BridgeIssues.Bridge1599.MyEnumerable$1(System.Int32))([1, 5, 6]);

--- a/Tests/Runner/Batch3/test.js
+++ b/Tests/Runner/Batch3/test.js
@@ -246,6 +246,9 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
             QUnit.test("#1536 - TestEventNameConflict", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1536.testEventNameConflict);
             QUnit.test("#1536 - TestPropertyNameConflict", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1536.testPropertyNameConflict);
             QUnit.test("#1538 - TestOutParameterInIndexer", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1538.testOutParameterInIndexer);
+            QUnit.test("#1566 - TestMathLog10", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1566.testMathLog10);
+            QUnit.test("#1566 - TestMathLogWithBase", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1566.testMathLogWithBase);
+            QUnit.test("#1566 - TestMathLog", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1566.testMathLog);
             QUnit.test("#1599 - TestCustomIEnumerableForStringJoin", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1599.testCustomIEnumerableForStringJoin);
             QUnit.test("#1641 - TestOutInAsync", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1641.testOutInAsync);
             QUnit.test("#1653 - TestLiftedFunctionsWithGenericInvocation", Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1653.testLiftedFunctionsWithGenericInvocation);
@@ -4636,6 +4639,44 @@ Bridge.assembly("Bridge_ClientTest_Batch3_Tests", function ($asm, globals) {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1538",
                     file: "Batch3\\BridgeIssues\\1500\\N1538.cs"
+                } );
+            }
+            return this.context;
+        }
+    });
+
+    Bridge.define("Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1566", {
+        inherits: [Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1566)],
+        statics: {
+            testMathLog10: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1566).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1566, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
+                    method: "TestMathLog10()",
+                    line: "13"
+                } ));
+                t.getFixture().testMathLog10();
+            },
+            testMathLogWithBase: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1566).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1566, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
+                    method: "TestMathLogWithBase()",
+                    line: "24"
+                } ));
+                t.getFixture().testMathLogWithBase();
+            },
+            testMathLog: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge1566).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch3_Tests_Runner.Bridge_ClientTest_Batch3_BridgeIssues_Bridge1566, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
+                    method: "TestMathLog()",
+                    line: "36"
+                } ));
+                t.getFixture().testMathLog();
+            }
+        },
+        context: null,
+        getContext: function () {
+            if (this.context == null) {
+                this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
+                    project: "Batch3",
+                    className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1566",
+                    file: "Batch3\\BridgeIssues\\1500\\N1566.cs"
                 } );
             }
             return this.context;

--- a/Tests/Runner/Batch4/code.js
+++ b/Tests/Runner/Batch4/code.js
@@ -9174,22 +9174,27 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             this.assertIsDecimalAndEqualTo(System.Decimal(3.0).floor(), 3);
         },
         logWorks: function () {
-            this.assertAlmostEqual(Math.log(0.5), -0.69314718055994529);
+            this.assertAlmostEqual(Bridge.Math.log(0.5), -0.69314718055994529);
         },
         logWithBaseWorks_SPI_1566: function () {
             // #1566
             // Test restructure to keep assertion count correct (prevent uncaught test exception)
-            var d1 = System.Decimal(0);
+            var d1 = 0.0;
             Bridge.ClientTest.Batch4.TestHelper.safe(function () {
-                d1 = System.Decimal(16).log(System.Decimal(2));
+                d1 = Bridge.Math.logWithBase(16, 2);
             });
             Bridge.Test.Assert.areEqual(4.0, d1);
 
-            var d2 = System.Decimal(0);
+            var d2 = 0.0;
             Bridge.ClientTest.Batch4.TestHelper.safe(function () {
-                d2 = System.Decimal(16).log(System.Decimal(4));
+                d2 = Bridge.Math.logWithBase(16, 4);
             });
             Bridge.Test.Assert.areEqual(2.0, d2);
+        },
+        log10Works_SPI_1629: function () {
+            // #1629
+            Bridge.Test.Assert.areEqual(Bridge.Math.logWithBase(10, 10.0), 1.0);
+            Bridge.Test.Assert.areEqual(Bridge.Math.logWithBase(100, 10.0), 2.0);
         },
         maxOfByteWorks: function () {
             Bridge.Test.Assert.areEqual(3.0, Math.max(1, 3));

--- a/Tests/Runner/Batch4/test.js
+++ b/Tests/Runner/Batch4/test.js
@@ -748,6 +748,7 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
             QUnit.test("MathTests - FloorOfDecimalWorks", Bridge.Test.QUnit.Bridge_ClientTest_Batch4_Tests_Runner.Bridge_ClientTest_Batch4_MathTests.floorOfDecimalWorks);
             QUnit.test("MathTests - LogWorks", Bridge.Test.QUnit.Bridge_ClientTest_Batch4_Tests_Runner.Bridge_ClientTest_Batch4_MathTests.logWorks);
             QUnit.test("MathTests - LogWithBaseWorks_SPI_1566", Bridge.Test.QUnit.Bridge_ClientTest_Batch4_Tests_Runner.Bridge_ClientTest_Batch4_MathTests.logWithBaseWorks_SPI_1566);
+            QUnit.test("MathTests - Log10Works_SPI_1629", Bridge.Test.QUnit.Bridge_ClientTest_Batch4_Tests_Runner.Bridge_ClientTest_Batch4_MathTests.log10Works_SPI_1629);
             QUnit.test("MathTests - MaxOfByteWorks", Bridge.Test.QUnit.Bridge_ClientTest_Batch4_Tests_Runner.Bridge_ClientTest_Batch4_MathTests.maxOfByteWorks);
             QUnit.test("MathTests - MaxOfDecimalWorks", Bridge.Test.QUnit.Bridge_ClientTest_Batch4_Tests_Runner.Bridge_ClientTest_Batch4_MathTests.maxOfDecimalWorks);
             QUnit.test("MathTests - MaxOfDoubleWorks", Bridge.Test.QUnit.Bridge_ClientTest_Batch4_Tests_Runner.Bridge_ClientTest_Batch4_MathTests.maxOfDoubleWorks);
@@ -8105,6 +8106,13 @@ Bridge.assembly("Bridge_ClientTest_Batch4_Tests", function ($asm, globals) {
                     line: "170"
                 } ));
                 t.getFixture().logWithBaseWorks_SPI_1566();
+            },
+            log10Works_SPI_1629: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch4.MathTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch4_Tests_Runner.Bridge_ClientTest_Batch4_MathTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
+                    method: "Log10Works_SPI_1629()",
+                    line: "185"
+                } ));
+                t.getFixture().log10Works_SPI_1629();
             },
             maxOfByteWorks: function (assert) {
                 var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.Batch4.MathTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Batch4_Tests_Runner.Bridge_ClientTest_Batch4_MathTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {


### PR DESCRIPTION
See #1566.

This PR is to merge changes introduced by @Zaid-Ajaj PR #2132, correct it a bit and add client tests.

Changes proposed in this pull request:
- Missing [MSDN Math.Log10 Method (Double)](https://msdn.microsoft.com/en-us/library/system.math.log10%28v=vs.110%29.aspx)
  - Compatible with .Net [tests](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L251)
- Missing [MSDN Math.Log Method (Double, Double)](https://msdn.microsoft.com/en-us/library/system.math.log10%28v=vs.110%29.aspx)
  - Compatible with the .Net [implementation](https://referencesource.microsoft.com/#mscorlib/system/math.cs,506)
  - Compatible with .Net [tests](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L239)
- Fix `Math.Log(Double)` to be compatile with .Net [tests](https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Extensions/tests/System/Math.cs#L228) 
- Remove non C# API `decimal Log(decimal x, decimal logBase)`
- Remove non C# API `decimal Ln(decimal x)`