### PR TITLE
[2149] Support DateTime's ToShortDateString() and ToShortTimeString()

### DIFF
--- a/Bridge/System/DateTime.cs
+++ b/Bridge/System/DateTime.cs
@@ -372,6 +372,12 @@ namespace System
         [Template("Bridge.Date.toLocal({this})")]
         public extern DateTime ToLocalTime();
 
+        [Template("Bridge.Date.format({this}, 'MM/dd/yyyy')")]
+        public extern string ToShortDateString();
+
+        [Template("Bridge.Date.format({this}, 'hh:mm tt')")]
+        public extern string ToShortTimeString();
+
         [Template("new Date(({this}).getTime() + (({value}).ticks.div(10000).toNumber()))")]
         public extern DateTime Add(TimeSpan value);
 

--- a/Bridge/System/DateTime.cs
+++ b/Bridge/System/DateTime.cs
@@ -372,10 +372,10 @@ namespace System
         [Template("Bridge.Date.toLocal({this})")]
         public extern DateTime ToLocalTime();
 
-        [Template("Bridge.Date.format({this}, 'MM/dd/yyyy')")]
+        [Template("Bridge.Date.format({this}, 'd')")]
         public extern string ToShortDateString();
 
-        [Template("Bridge.Date.format({this}, 'hh:mm tt')")]
+        [Template("Bridge.Date.format({this}, 't')")]
         public extern string ToShortTimeString();
 
         [Template("new Date(({this}).getTime() + (({value}).ticks.div(10000).toNumber()))")]

--- a/Tests/Batch1/Batch1.csproj
+++ b/Tests/Batch1/Batch1.csproj
@@ -244,7 +244,7 @@
     <Compile Include="SimpleTypes\DoubleTests.cs" />
     <Compile Include="SimpleTypes\DecimalTests.cs" />
     <Compile Include="SimpleTypes\StringTests.cs" />
-    <Compile Include="SimpleTypes\JsDateTests.cs" />
+    <Compile Include="SimpleTypes\DateTimeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Tests/Batch1/SimpleTypes/DateTimeTests.cs
+++ b/Tests/Batch1/SimpleTypes/DateTimeTests.cs
@@ -718,5 +718,54 @@ namespace Bridge.ClientTest.SimpleTypes
 
             Assert.True(result1 == result2, "[#1901] DateTime to Timestamp back to DateTime is different");
         }
+
+        [Test(Name = "#2149 - {0}")]
+        public void ToShortDateStringWorks()
+        {
+            DateTime date = new DateTime(2009, 6, 1, 8, 42, 50);
+            var r = date.ToShortDateString();
+
+            Assert.AreEqual("06/01/2009", r, "Invariant culture");
+
+            var defaultCulture = CultureInfo.CurrentCulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("ru-RU");
+
+                date = new DateTime(2009, 6, 1, 8, 42, 50);
+                r = date.ToShortDateString();
+
+                Assert.AreEqual("01.06.2009", r, "ru-RU culture");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = defaultCulture;
+            }
+        }
+
+        [Test(Name = "#2149 - {0}")]
+        public void ToShortTimeStringWorks()
+        {
+            DateTime date = new DateTime(2001, 5, 16, 3, 2, 15);
+            var r = date.ToShortTimeString();
+
+            Assert.AreEqual("03:02", r, "Invariant culture");
+
+            var defaultCulture = CultureInfo.CurrentCulture;
+
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("ru-RU");
+
+                r = date.ToShortTimeString();
+
+                Assert.AreEqual("3:02", r, "ru-RU culture");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = defaultCulture;
+            }
+        }
     }
 }

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -26892,6 +26892,45 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             var result2 = Bridge.Date.format(parsedUnixNow);
 
             Bridge.Test.Assert.true$1(Bridge.referenceEquals(result1, result2), "[#1901] DateTime to Timestamp back to DateTime is different");
+        },
+        toShortDateStringWorks: function () {
+            var date = new Date(2009, 6 - 1, 1, 8, 42, 50);
+            var r = Bridge.Date.format(date, 'd');
+
+            Bridge.Test.Assert.areEqual$1("06/01/2009", r, "Invariant culture");
+
+            var defaultCulture = System.Globalization.CultureInfo.getCurrentCulture();
+
+            try {
+                System.Globalization.CultureInfo.setCurrentCulture(System.Globalization.CultureInfo.getCultureInfo("ru-RU"));
+
+                date = new Date(2009, 6 - 1, 1, 8, 42, 50);
+                r = Bridge.Date.format(date, 'd');
+
+                Bridge.Test.Assert.areEqual$1("01.06.2009", r, "ru-RU culture");
+            }
+            finally {
+                System.Globalization.CultureInfo.setCurrentCulture(defaultCulture);
+            }
+        },
+        toShortTimeStringWorks: function () {
+            var date = new Date(2001, 5 - 1, 16, 3, 2, 15);
+            var r = Bridge.Date.format(date, 't');
+
+            Bridge.Test.Assert.areEqual$1("03:02", r, "Invariant culture");
+
+            var defaultCulture = System.Globalization.CultureInfo.getCurrentCulture();
+
+            try {
+                System.Globalization.CultureInfo.setCurrentCulture(System.Globalization.CultureInfo.getCultureInfo("ru-RU"));
+
+                r = Bridge.Date.format(date, 't');
+
+                Bridge.Test.Assert.areEqual$1("3:02", r, "ru-RU culture");
+            }
+            finally {
+                System.Globalization.CultureInfo.setCurrentCulture(defaultCulture);
+            }
         }
     });
 

--- a/Tests/Runner/Batch1/test.js
+++ b/Tests/Runner/Batch1/test.js
@@ -713,6 +713,8 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
             QUnit.test("DateTime - CompareToWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_JsDateTimeTests.compareToWorks);
             QUnit.test("DateTime - DateTimes", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_JsDateTimeTests.dateTimes);
             QUnit.test("DateTime - CreateUnixTimestampAndConvertBackToDateTime", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_JsDateTimeTests.createUnixTimestampAndConvertBackToDateTime);
+            QUnit.test("#2149 - ToShortDateStringWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_JsDateTimeTests.toShortDateStringWorks);
+            QUnit.test("#2149 - ToShortTimeStringWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_JsDateTimeTests.toShortTimeStringWorks);
             QUnit.test("TimeSpan - TypePropertiesAreCorrect", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_TimeSpanTests.typePropertiesAreCorrect);
             QUnit.test("TimeSpan - DefaultConstructorWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_TimeSpanTests.defaultConstructorWorks);
             QUnit.test("TimeSpan - DefaultValueWorks", Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_TimeSpanTests.defaultValueWorks);
@@ -18110,6 +18112,20 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                     line: "696"
                 } ));
                 t.getFixture().createUnixTimestampAndConvertBackToDateTime();
+            },
+            toShortDateStringWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.SimpleTypes.JsDateTimeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_JsDateTimeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
+                    method: "ToShortDateStringWorks()",
+                    line: "722"
+                } ));
+                t.getFixture().toShortDateStringWorks();
+            },
+            toShortTimeStringWorks: function (assert) {
+                var t = Bridge.Test.QUnit.TestFixture$1(Bridge.ClientTest.SimpleTypes.JsDateTimeTests).beforeTest(true, assert, Bridge.Test.QUnit.Bridge_ClientTest_Tests_Runner.Bridge_ClientTest_SimpleTypes_JsDateTimeTests, void 0, Bridge.merge(new Bridge.Test.QUnit.TestContext(), {
+                    method: "ToShortTimeStringWorks()",
+                    line: "747"
+                } ));
+                t.getFixture().toShortTimeStringWorks();
             }
         },
         context: null,
@@ -18118,7 +18134,7 @@ Bridge.assembly("Bridge_ClientTest_Tests", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.QUnit.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.JsDateTimeTests",
-                    file: "Batch1\\SimpleTypes\\JsDateTests.cs"
+                    file: "Batch1\\SimpleTypes\\DateTimeTests.cs"
                 } );
             }
             return this.context;


### PR DESCRIPTION
Fixes #2149.

This PR is to merge changes introduced by @Zaid-Ajaj PR #2150, correct it a bit to support culture locales and add client tests.