### PR TITLE
Added warning (using [Obsolete] attribute) about IE11 lack of support…

### DIFF
--- a/Html5/Elements/HTMLSelectElement.cs
+++ b/Html5/Elements/HTMLSelectElement.cs
@@ -68,6 +68,7 @@ namespace Bridge.Html5
         /// <summary>
         /// The set of options that are selected.
         /// </summary>
+        [Obsolete("This property is not supported by IE11 or earlier, you might want to use the Options property and check the Selected property on each item")]
         public OptionsCollection SelectedOptions;
 
         /// <summary>


### PR DESCRIPTION
… for HTMLSelectElement's SelectOptions property

I think the ideas in http://forums.bridge.net/forum/community/help/3459-warning-about-supported-browsers-for-selectedoptions make a lot of sense as a better solution but I thought that this might help in the meantime?