### PR TITLE
[2362] [2363] Mark HTML[Tag]Element classes as sealed and remove virtual keyword

### DIFF
--- a/Html5/Elements/HTMLAnchorElement.cs
+++ b/Html5/Elements/HTMLAnchorElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLAnchorElement")]
-    public class HTMLAnchorElement : HTMLElement<HTMLAnchorElement>
+    public sealed class HTMLAnchorElement : HTMLElement<HTMLAnchorElement>
     {
         [Template("document.createElement('a')")]
         public HTMLAnchorElement()

--- a/Html5/Elements/HTMLAnchorElement.cs
+++ b/Html5/Elements/HTMLAnchorElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLAnchorElement : HTMLElement<HTMLAnchorElement>
     {
         [Template("document.createElement('a')")]
-        public HTMLAnchorElement()
-        {
-        }
+        public extern HTMLAnchorElement();
 
         /// <summary>
         /// Is a DOMString representing the character encoding of the linked resource.

--- a/Html5/Elements/HTMLAreaElement.cs
+++ b/Html5/Elements/HTMLAreaElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLAreaElement : HTMLElement<HTMLAreaElement>
     {
         [Template("document.createElement('area')")]
-        public HTMLAreaElement()
-        {
-        }
+        public extern HTMLAreaElement();
 
         /// <summary>
         /// Is a DOMString that reflects the alt HTML attribute, containing alternative text for the element.

--- a/Html5/Elements/HTMLAreaElement.cs
+++ b/Html5/Elements/HTMLAreaElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLAreaElement")]
-    public class HTMLAreaElement : HTMLElement<HTMLAreaElement>
+    public sealed class HTMLAreaElement : HTMLElement<HTMLAreaElement>
     {
         [Template("document.createElement('area')")]
         public HTMLAreaElement()

--- a/Html5/Elements/HTMLAudioElement.cs
+++ b/Html5/Elements/HTMLAudioElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     [External]
     [Name("HTMLAudioElement")]
     [Constructor("Audio")]
-    public class HTMLAudioElement : HTMLMediaElement<HTMLAudioElement>
+    public sealed class HTMLAudioElement : HTMLMediaElement<HTMLAudioElement>
     {
         /// <summary>
         /// Constructor for audio elements. The preload property of the returned object is set to auto and the src property is set to the argument value. The browser begins asynchronously selecting the resource before returning the object.

--- a/Html5/Elements/HTMLAudioElement.cs
+++ b/Html5/Elements/HTMLAudioElement.cs
@@ -13,9 +13,7 @@ namespace Bridge.Html5
         /// Constructor for audio elements. The preload property of the returned object is set to auto and the src property is set to the argument value. The browser begins asynchronously selecting the resource before returning the object.
         /// </summary>
         [Template("new Audio()")]
-        public HTMLAudioElement()
-        {
-        }
+        public extern HTMLAudioElement();
 
         /// <summary>
         /// Constructor for audio elements. The preload property of the returned object is set to auto and the src property is set to the argument value. The browser begins asynchronously selecting the resource before returning the object.

--- a/Html5/Elements/HTMLBRElement.cs
+++ b/Html5/Elements/HTMLBRElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLBRElement : HTMLElement<HTMLBRElement>
     {
         [Template("document.createElement('br')")]
-        public HTMLBRElement()
-        {
-        }
+        public extern HTMLBRElement();
 
         /// <summary>
         /// Indicates flow of text around floating objects.

--- a/Html5/Elements/HTMLBRElement.cs
+++ b/Html5/Elements/HTMLBRElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLBRElement")]
-    public class HTMLBRElement : HTMLElement<HTMLBRElement>
+    public sealed class HTMLBRElement : HTMLElement<HTMLBRElement>
     {
         [Template("document.createElement('br')")]
         public HTMLBRElement()

--- a/Html5/Elements/HTMLBaseElement.cs
+++ b/Html5/Elements/HTMLBaseElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLBaseElement")]
-    public class HTMLBaseElement : HTMLElement<HTMLBaseElement>
+    public sealed class HTMLBaseElement : HTMLElement<HTMLBaseElement>
     {
         [Template("document.createElement('base')")]
         public HTMLBaseElement()

--- a/Html5/Elements/HTMLBaseElement.cs
+++ b/Html5/Elements/HTMLBaseElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLBaseElement : HTMLElement<HTMLBaseElement>
     {
         [Template("document.createElement('base')")]
-        public HTMLBaseElement()
-        {
-        }
+        public extern HTMLBaseElement();
 
         /// <summary>
         /// Is a DOMString that reflects the href HTML attribute, containing a base URL for relative URLs in the document.

--- a/Html5/Elements/HTMLBodyElement.cs
+++ b/Html5/Elements/HTMLBodyElement.cs
@@ -10,9 +10,7 @@ namespace Bridge.Html5
     public sealed class HTMLBodyElement : HTMLElement<HTMLBodyElement>
     {
         [Template("document.createElement('body')")]
-        public HTMLBodyElement()
-        {
-        }
+        public extern HTMLBodyElement();
 
         /// <summary>
         /// Color of active hyperlinks.

--- a/Html5/Elements/HTMLBodyElement.cs
+++ b/Html5/Elements/HTMLBodyElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLBodyElement")]
-    public class HTMLBodyElement : HTMLElement<HTMLBodyElement>
+    public sealed class HTMLBodyElement : HTMLElement<HTMLBodyElement>
     {
         [Template("document.createElement('body')")]
         public HTMLBodyElement()

--- a/Html5/Elements/HTMLButtonElement.cs
+++ b/Html5/Elements/HTMLButtonElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLButtonElement")]
-    public class HTMLButtonElement : HTMLElement<HTMLButtonElement>
+    public sealed class HTMLButtonElement : HTMLElement<HTMLButtonElement>
     {
         [Template("document.createElement('button')")]
         public HTMLButtonElement()

--- a/Html5/Elements/HTMLButtonElement.cs
+++ b/Html5/Elements/HTMLButtonElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLButtonElement : HTMLElement<HTMLButtonElement>
     {
         [Template("document.createElement('button')")]
-        public HTMLButtonElement()
-        {
-        }
+        public extern HTMLButtonElement();
 
         /// <summary>
         /// The control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form-associated element in a document can have this attribute specified.

--- a/Html5/Elements/HTMLCanvasElement.cs
+++ b/Html5/Elements/HTMLCanvasElement.cs
@@ -6,7 +6,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLCanvasElement")]
-    public class HTMLCanvasElement : HTMLElement<HTMLCanvasElement>
+    public sealed class HTMLCanvasElement : HTMLElement<HTMLCanvasElement>
     {
         [Template("document.createElement('canvas')")]
         public HTMLCanvasElement()
@@ -28,7 +28,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="contextId">The context's id</param>
         /// <returns>A drawing context. A CanvasRenderingContext2D, IWebGLRenderingContext or IWebGL2RenderingContext object.</returns>
-        public virtual extern Union<CanvasRenderingContext2D, IWebGLRenderingContext> GetContext(string contextId);
+        public extern Union<CanvasRenderingContext2D, IWebGLRenderingContext> GetContext(string contextId);
 
         /// <summary>
         /// Returns CanvasRenderingContext2D drawing context on the canvas, or null if the context ID is not supported.
@@ -36,7 +36,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="contextId">The context's id</param>
         /// <returns>A CanvasRenderingContext2D drawing context object.</returns>
-        public virtual extern CanvasRenderingContext2D GetContext(CanvasTypes.CanvasContext2DType contextId);
+        public extern CanvasRenderingContext2D GetContext(CanvasTypes.CanvasContext2DType contextId);
 
         /// <summary>
         /// Returns WebGLRenderingContext drawing context on the canvas, or null if the context ID is not supported.
@@ -45,7 +45,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="contextId">The context's id</param>
         /// <returns>A WebGLRenderingContext drawing context object.</returns>
-        public virtual extern IWebGLRenderingContext GetContext(CanvasTypes.CanvasContextWebGLType contextId);
+        public extern IWebGLRenderingContext GetContext(CanvasTypes.CanvasContextWebGLType contextId);
 
         /// <summary>
         /// Returns a data: URL containing a representation of the image in the format specified by type (defaults to PNG). The returned image is 96dpi.
@@ -55,7 +55,7 @@ namespace Bridge.Html5
         /// If the requested type is image/jpeg or image/webp, then the second argument, if it is between 0.0 and 1.0, is treated as indicating image quality; if the second argument is anything else, the default value for image quality is used. Other arguments are ignored.
         /// </summary>
         /// <returns>URL containing a representation of the image</returns>
-        public virtual extern string ToDataURL();
+        public extern string ToDataURL();
 
         /// <summary>
         /// Returns a data: URL containing a representation of the image in the format specified by type (defaults to PNG). The returned image is 96dpi.
@@ -66,7 +66,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="type">The format. Defaults to PNG.</param>
         /// <returns>URL containing a representation of the image</returns>
-        public virtual extern string ToDataURL(string type);
+        public extern string ToDataURL(string type);
 
         /// <summary>
         /// Returns a data: URL containing a representation of the image in the format specified by type (defaults to PNG). The returned image is 96dpi.
@@ -78,7 +78,7 @@ namespace Bridge.Html5
         /// <param name="type">The format. Defaults to PNG.</param>
         /// /// <param name="args">Any additional parameters</param>
         /// <returns>URL containing a representation of the image</returns>
-        public virtual extern string ToDataURL(string type, params object[] args);
+        public extern string ToDataURL(string type, params object[] args);
     }
 
     /// <summary>

--- a/Html5/Elements/HTMLCanvasElement.cs
+++ b/Html5/Elements/HTMLCanvasElement.cs
@@ -9,9 +9,7 @@ namespace Bridge.Html5
     public sealed class HTMLCanvasElement : HTMLElement<HTMLCanvasElement>
     {
         [Template("document.createElement('canvas')")]
-        public HTMLCanvasElement()
-        {
-        }
+        public extern HTMLCanvasElement();
 
         /// <summary>
         /// Reflects the height HTML attribute, specifying the height of the coordinate space in CSS pixels.

--- a/Html5/Elements/HTMLDListElement.cs
+++ b/Html5/Elements/HTMLDListElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLDListElement : HTMLElement<HTMLDListElement>
     {
         [Template("document.createElement('dl')")]
-        public HTMLDListElement()
-        {
-        }
+        public extern HTMLDListElement();
 
         /// <summary>
         /// Indicates that spacing between list items should be reduced.

--- a/Html5/Elements/HTMLDListElement.cs
+++ b/Html5/Elements/HTMLDListElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLDListElement")]
-    public class HTMLDListElement : HTMLElement<HTMLDListElement>
+    public sealed class HTMLDListElement : HTMLElement<HTMLDListElement>
     {
         [Template("document.createElement('dl')")]
         public HTMLDListElement()

--- a/Html5/Elements/HTMLDataListElement.cs
+++ b/Html5/Elements/HTMLDataListElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLDataListElement")]
-    public class HTMLDataListElement : HTMLElement<HTMLDataListElement>
+    public sealed class HTMLDataListElement : HTMLElement<HTMLDataListElement>
     {
         [Template("document.createElement('datalist')")]
         public HTMLDataListElement()

--- a/Html5/Elements/HTMLDataListElement.cs
+++ b/Html5/Elements/HTMLDataListElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLDataListElement : HTMLElement<HTMLDataListElement>
     {
         [Template("document.createElement('datalist')")]
-        public HTMLDataListElement()
-        {
-        }
+        public extern HTMLDataListElement();
 
         /// <summary>
         /// A collection of the contained option elements.

--- a/Html5/Elements/HTMLDivElement.cs
+++ b/Html5/Elements/HTMLDivElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLDivElement")]
-    public class HTMLDivElement : HTMLElement<HTMLDivElement>
+    public sealed class HTMLDivElement : HTMLElement<HTMLDivElement>
     {
         [Template("document.createElement('div')")]
         public HTMLDivElement()

--- a/Html5/Elements/HTMLDivElement.cs
+++ b/Html5/Elements/HTMLDivElement.cs
@@ -8,8 +8,6 @@ namespace Bridge.Html5
     public sealed class HTMLDivElement : HTMLElement<HTMLDivElement>
     {
         [Template("document.createElement('div')")]
-        public HTMLDivElement()
-        {
-        }
+        public extern HTMLDivElement();
     }
 }

--- a/Html5/Elements/HTMLElement.cs
+++ b/Html5/Elements/HTMLElement.cs
@@ -10,19 +10,13 @@ namespace Bridge.Html5
     public class HTMLElement : Element
     {
         [Template("document.createElement('div')")]
-        public HTMLElement()
-        {
-        }
+        public extern HTMLElement();
 
         [Template("document.createElement({0})")]
-        public HTMLElement(ElementType type)
-        {
-        }
+        public extern HTMLElement(ElementType type);
 
         [Template("document.createElement({0})")]
-        public HTMLElement(string tagName)
-        {
-        }
+        public extern HTMLElement(string tagName);
 
         #region Properties
 

--- a/Html5/Elements/HTMLEmbedElement.cs
+++ b/Html5/Elements/HTMLEmbedElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLEmbedElement")]
-    public class HTMLEmbedElement : HTMLElement<HTMLEmbedElement>
+    public sealed class HTMLEmbedElement : HTMLElement<HTMLEmbedElement>
     {
         [Template("document.createElement('embed')")]
         public HTMLEmbedElement()

--- a/Html5/Elements/HTMLEmbedElement.cs
+++ b/Html5/Elements/HTMLEmbedElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLEmbedElement : HTMLElement<HTMLEmbedElement>
     {
         [Template("document.createElement('embed')")]
-        public HTMLEmbedElement()
-        {
-        }
+        public extern HTMLEmbedElement();
 
         /// <summary>
         /// Reflects the height HTML attribute, containing the displayed height of the resource.

--- a/Html5/Elements/HTMLFieldSetElement.cs
+++ b/Html5/Elements/HTMLFieldSetElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLFieldSetElement : HTMLElement<HTMLFieldSetElement>
     {
         [Template("document.createElement('fieldset')")]
-        public HTMLFieldSetElement()
-        {
-        }
+        public extern HTMLFieldSetElement();
 
         /// <summary>
         /// Reflects the disabled HTML attribute, indicating whether the user can interact with the control.

--- a/Html5/Elements/HTMLFieldSetElement.cs
+++ b/Html5/Elements/HTMLFieldSetElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLFieldSetElement")]
-    public class HTMLFieldSetElement : HTMLElement<HTMLFieldSetElement>
+    public sealed class HTMLFieldSetElement : HTMLElement<HTMLFieldSetElement>
     {
         [Template("document.createElement('fieldset')")]
         public HTMLFieldSetElement()
@@ -56,12 +56,12 @@ namespace Bridge.Html5
         /// <summary>
         /// Always returns true because &lt;fieldset&gt; objects are never candidates for constraint validation.
         /// </summary>
-        public virtual extern bool CheckValidity();
+        public extern bool CheckValidity();
 
         /// <summary>
         /// Sets a custom validity message for the field set. If this message is not the empty string, then the field set is suffering from a custom validity error, and does not validate.
         /// </summary>
         /// <param name="error"></param>
-        public virtual extern void SetCustomValidity(string error);
+        public extern void SetCustomValidity(string error);
     }
 }

--- a/Html5/Elements/HTMLFormElement.cs
+++ b/Html5/Elements/HTMLFormElement.cs
@@ -8,7 +8,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLFormElement")]
-    public class HTMLFormElement : HTMLElement<HTMLFormElement>, IEnumerable<HTMLElement>
+    public sealed class HTMLFormElement : HTMLElement<HTMLFormElement>, IEnumerable<HTMLElement>
     {
         [Template("document.createElement('form')")]
         public HTMLFormElement()
@@ -74,24 +74,24 @@ namespace Bridge.Html5
         /// <summary>
         /// Returns true if all controls that are subject to constraint validation satisfy their constraints, or false if some controls do not satisfy their constraints. Fires an event named invalid at any control that does not satisfy its constraints; such controls are considered invalid if the event is not canceled.
         /// </summary>
-        public virtual extern bool CheckValidity();
+        public extern bool CheckValidity();
 
         /// <summary>
         /// Submits the form to the server.
         /// </summary>
-        public virtual extern void Submit();
+        public extern void Submit();
 
         /// <summary>
         /// Resets the forms to its initial state.
         /// </summary>
-        public virtual extern void Reset();
+        public extern void Reset();
 
         /// <summary>
         /// Gets the item in the elements collection at the specified index, or null if there is no item at that index. You can also specify the index in array-style brackets or parentheses after the form object name, without calling this method explicitly.
         /// </summary>
         /// <param name="index"></param>
         /// <returns></returns>
-        public virtual HTMLElement this[int index]
+        public HTMLElement this[int index]
         {
             get
             {
@@ -104,7 +104,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="name">The name to match the Elements' name and id</param>
         /// <returns>An Element or an HTMLCollection</returns>
-        public new virtual Union<HTMLElement, HTMLCollection> this[string name]
+        public new Union<HTMLElement, HTMLCollection> this[string name]
         {
             get
             {
@@ -118,16 +118,16 @@ namespace Bridge.Html5
         /// <param name="index"></param>
         /// <returns></returns>
         [Name("item")]
-        public virtual extern HTMLElement GetItem(int index);
+        public extern HTMLElement GetItem(int index);
 
         /// <summary>
         /// Gets the item or list of items in elements collection whose name or id match the specified name, or null if no items match. You can also specify the name in array-style brackets or parentheses after the form object name, without calling this method explicitly.
         /// </summary>
         /// <param name="name">The name to match the Elements' name and id</param>
         /// <returns>An Element or an HTMLCollection</returns>
-        public virtual extern Union<HTMLElement, HTMLCollection> NamedItem(string name);
+        public extern Union<HTMLElement, HTMLCollection> NamedItem(string name);
 
-        public virtual extern IEnumerator<HTMLElement> GetEnumerator();
+        public extern IEnumerator<HTMLElement> GetEnumerator();
 
         extern IEnumerator IEnumerable.GetEnumerator();
     }

--- a/Html5/Elements/HTMLFormElement.cs
+++ b/Html5/Elements/HTMLFormElement.cs
@@ -11,9 +11,7 @@ namespace Bridge.Html5
     public sealed class HTMLFormElement : HTMLElement<HTMLFormElement>, IEnumerable<HTMLElement>
     {
         [Template("document.createElement('form')")]
-        public HTMLFormElement()
-        {
-        }
+        public extern HTMLFormElement();
 
         /// <summary>
         /// Reflects the accept-charset HTML attribute, containing a list of character encodings that the server accepts.

--- a/Html5/Elements/HTMLHRElement.cs
+++ b/Html5/Elements/HTMLHRElement.cs
@@ -10,9 +10,7 @@ namespace Bridge.Html5
     public sealed class HTMLHRElement : HTMLElement<HTMLHRElement>
     {
         [Template("document.createElement('hr')")]
-        public HTMLHRElement()
-        {
-        }
+        public extern HTMLHRElement();
 
         /// <summary>
         /// The name of the color of the rule.
@@ -23,7 +21,7 @@ namespace Bridge.Html5
         /// Sets the rule to have no shading.
         /// </summary>
         [Name("noshade")]
-        public Boolean NoShade;
+        public bool NoShade;
 
         /// <summary>
         /// The height of the rule.

--- a/Html5/Elements/HTMLHRElement.cs
+++ b/Html5/Elements/HTMLHRElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLHRElement")]
-    public class HTMLHRElement : HTMLElement<HTMLHRElement>
+    public sealed class HTMLHRElement : HTMLElement<HTMLHRElement>
     {
         [Template("document.createElement('hr')")]
         public HTMLHRElement()

--- a/Html5/Elements/HTMLHeadElement.cs
+++ b/Html5/Elements/HTMLHeadElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLHeadElement")]
-    public class HTMLHeadElement : HTMLElement<HTMLHeadElement>
+    public sealed class HTMLHeadElement : HTMLElement<HTMLHeadElement>
     {
         [Template("document.createElement('head')")]
         public HTMLHeadElement()

--- a/Html5/Elements/HTMLHeadElement.cs
+++ b/Html5/Elements/HTMLHeadElement.cs
@@ -8,8 +8,6 @@ namespace Bridge.Html5
     public sealed class HTMLHeadElement : HTMLElement<HTMLHeadElement>
     {
         [Template("document.createElement('head')")]
-        public HTMLHeadElement()
-        {
-        }
+        public extern HTMLHeadElement();
     }
 }

--- a/Html5/Elements/HTMLHeadingElement.cs
+++ b/Html5/Elements/HTMLHeadingElement.cs
@@ -10,17 +10,13 @@ namespace Bridge.Html5
     public sealed class HTMLHeadingElement : HTMLElement<HTMLHeadingElement>
     {
         [Template("document.createElement('h1')")]
-        public HTMLHeadingElement()
-        {
-        }
+        public extern HTMLHeadingElement();
 
         /// <summary>
         /// Creates a heading element of the specified type
         /// </summary>
         [Template("document.createElement({0})")]
-        public HTMLHeadingElement(HeadingType h)
-        {
-        }
+        public extern HTMLHeadingElement(HeadingType h);
     }
 
     /// <summary>

--- a/Html5/Elements/HTMLHeadingElement.cs
+++ b/Html5/Elements/HTMLHeadingElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLHeadingElement")]
-    public class HTMLHeadingElement : HTMLElement<HTMLHeadingElement>
+    public sealed class HTMLHeadingElement : HTMLElement<HTMLHeadingElement>
     {
         [Template("document.createElement('h1')")]
         public HTMLHeadingElement()

--- a/Html5/Elements/HTMLHtmlElement.cs
+++ b/Html5/Elements/HTMLHtmlElement.cs
@@ -9,8 +9,6 @@ namespace Bridge.Html5
     public sealed class HTMLHtmlElement : HTMLElement<HTMLHtmlElement>
     {
         [Template("document.createElement('html')")]
-        public HTMLHtmlElement()
-        {
-        }
+        public extern HTMLHtmlElement();
     }
 }

--- a/Html5/Elements/HTMLHtmlElement.cs
+++ b/Html5/Elements/HTMLHtmlElement.cs
@@ -6,7 +6,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLHtmlElement")]
-    public class HTMLHtmlElement : HTMLElement<HTMLHtmlElement>
+    public sealed class HTMLHtmlElement : HTMLElement<HTMLHtmlElement>
     {
         [Template("document.createElement('html')")]
         public HTMLHtmlElement()

--- a/Html5/Elements/HTMLIFrameElement.cs
+++ b/Html5/Elements/HTMLIFrameElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLIFrameElement : HTMLElement<HTMLIFrameElement>
     {
         [Template("document.createElement('iframe')")]
-        public HTMLIFrameElement()
-        {
-        }
+        public extern HTMLIFrameElement();
 
         /// <summary>
         /// Indicates whether or not the inline frame is willing to be placed into full screen mode. See Using full-screen mode for details.

--- a/Html5/Elements/HTMLIFrameElement.cs
+++ b/Html5/Elements/HTMLIFrameElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLIFrameElement")]
-    public class HTMLIFrameElement : HTMLElement<HTMLIFrameElement>
+    public sealed class HTMLIFrameElement : HTMLElement<HTMLIFrameElement>
     {
         [Template("document.createElement('iframe')")]
         public HTMLIFrameElement()

--- a/Html5/Elements/HTMLImageElement.cs
+++ b/Html5/Elements/HTMLImageElement.cs
@@ -8,19 +8,13 @@ namespace Bridge.Html5
     public sealed class HTMLImageElement : HTMLElement<HTMLImageElement>
     {
         [Template("new Image()")]
-        public HTMLImageElement()
-        {
-        }
+        public extern HTMLImageElement();
 
         [Template("new Image({0})")]
-        public HTMLImageElement(int width)
-        {
-        }
+        public extern HTMLImageElement(int width);
 
         [Template("new Image({0},{1})")]
-        public HTMLImageElement(int width, int height)
-        {
-        }
+        public extern HTMLImageElement(int width, int height);
 
         /// <summary>
         /// True if the browser has fetched the image, and it is in a supported image type that was decoded without errors.

--- a/Html5/Elements/HTMLImageElement.cs
+++ b/Html5/Elements/HTMLImageElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLImageElement")]
-    public class HTMLImageElement : HTMLElement<HTMLImageElement>
+    public sealed class HTMLImageElement : HTMLElement<HTMLImageElement>
     {
         [Template("new Image()")]
         public HTMLImageElement()

--- a/Html5/Elements/HTMLInputElement.cs
+++ b/Html5/Elements/HTMLInputElement.cs
@@ -10,9 +10,7 @@ namespace Bridge.Html5
     public sealed class HTMLInputElement : HTMLElement<HTMLInputElement>
     {
         [Template("document.createElement('input')")]
-        public HTMLInputElement()
-        {
-        }
+        public extern HTMLInputElement();
 
         /// <summary>
         /// If the value of the type attribute is file, this attribute indicates the types of files that the server accepts; otherwise it is ignored. The value must be a comma-separated list of unique content type specifiers:

--- a/Html5/Elements/HTMLInputElement.cs
+++ b/Html5/Elements/HTMLInputElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLInputElement")]
-    public class HTMLInputElement : HTMLElement<HTMLInputElement>
+    public sealed class HTMLInputElement : HTMLElement<HTMLInputElement>
     {
         [Template("document.createElement('input')")]
         public HTMLInputElement()
@@ -256,41 +256,41 @@ namespace Bridge.Html5
         /// <summary>
         /// Removes focus from input; keystrokes will subsequently go nowhere.
         /// </summary>
-        public new virtual extern void Blur();
+        public new extern void Blur();
 
         /// <summary>
         /// Returns false if the element is a candidate for constraint validation, and it does not satisfy its constraints. In this case, it also fires an invalid event at the element. It returns true if the element is not a candidate for constraint validation, or if it satisfies its constraints.
         /// </summary>
         /// <returns></returns>
-        public virtual extern bool CheckValidity();
+        public extern bool CheckValidity();
 
         /// <summary>
         /// Simulates a click on the element.
         /// </summary>
-        public new virtual extern void Click();
+        public new extern void Click();
 
         /// <summary>
         /// Focus on input; keystrokes will subsequently go to this element.
         /// </summary>
-        public new virtual extern void Focus();
+        public new extern void Focus();
 
         /// <summary>
         /// Selects the input text in the element, and focuses it so the user can subsequently replace the whole entry.
         /// </summary>
-        public virtual extern void Select();
+        public extern void Select();
 
         /// <summary>
         /// Sets a custom validity message for the element. If this message is not the empty string, then the element is suffering from a custom validity error, and does not validate.
         /// </summary>
         /// <param name="error">The custom validity message</param>
-        public virtual extern void SetCustomValidity(string error);
+        public extern void SetCustomValidity(string error);
 
         /// <summary>
         /// Selects a range of text in the element (but does not focus it). The optional selectionDirection parameter may be "forward" or "backward" to establish the direction in which selection was set, or "none" if the direction is unknown or not relevant. The default is "none". Specifying a selectionDirection parameter sets the value of the selectionDirection property.
         /// </summary>
         /// <param name="start"></param>
         /// <param name="end"></param>
-        public virtual extern void SetSelectionRange(int start, int end);
+        public extern void SetSelectionRange(int start, int end);
 
         /// <summary>
         /// Selects a range of text in the element (but does not focus it). The optional selectionDirection parameter may be "forward" or "backward" to establish the direction in which selection was set, or "none" if the direction is unknown or not relevant. The default is "none". Specifying a selectionDirection parameter sets the value of the selectionDirection property.
@@ -298,13 +298,13 @@ namespace Bridge.Html5
         /// <param name="start"></param>
         /// <param name="end"></param>
         /// <param name="direction"></param>
-        public virtual extern void SetSelectionRange(int start, int end, string direction);
+        public extern void SetSelectionRange(int start, int end, string direction);
 
         /// <summary>
         /// Replaces a range of text with the new text. Supported input types: text, search, url, tel, password.
         /// </summary>
         /// <param name="replacement"></param>
-        public virtual extern void SetRangeText(string replacement);
+        public extern void SetRangeText(string replacement);
 
         /// <summary>
         /// Replaces a range of text with the new text. Supported input types: text, search, url, tel, password.
@@ -312,7 +312,7 @@ namespace Bridge.Html5
         /// <param name="replacement"></param>
         /// <param name="start"></param>
         /// <param name="end"></param>
-        public virtual extern void SetRangeText(string replacement, int start, int end);
+        public extern void SetRangeText(string replacement, int start, int end);
 
         /// <summary>
         /// Replaces a range of text with the new text. Supported input types: text, search, url, tel, password.
@@ -321,7 +321,7 @@ namespace Bridge.Html5
         /// <param name="start"></param>
         /// <param name="end"></param>
         /// <param name="selectMode"></param>
-        public virtual extern void SetRangeText(string replacement, int start, int end, string selectMode);
+        public extern void SetRangeText(string replacement, int start, int end, string selectMode);
 
         /// <summary>
         /// Decrements the value by (step * n), where n defaults to 1 if not specified. Throws an INVALID_STATE_ERR exception:
@@ -330,7 +330,7 @@ namespace Bridge.Html5
         /// if the value cannot be converted to a number.
         /// if the resulting value is above the max or below the min.
         /// </summary>
-        public virtual extern void StepDown();
+        public extern void StepDown();
 
         /// <summary>
         /// Decrements the value by (step * n), where n defaults to 1 if not specified. Throws an INVALID_STATE_ERR exception:
@@ -339,7 +339,7 @@ namespace Bridge.Html5
         /// if the value cannot be converted to a number.
         /// if the resulting value is above the max or below the min.
         /// </summary>
-        public virtual extern void StepDown(int n);
+        public extern void StepDown(int n);
 
         /// <summary>
         /// Increments the value by (step * n), where n defaults to 1 if not specified. Throws an INVALID_STATE_ERR exception:
@@ -348,7 +348,7 @@ namespace Bridge.Html5
         /// if the value cannot be converted to a number.
         /// if the resulting value is above the max or below the min.
         /// </summary>
-        public virtual extern void StepUp();
+        public extern void StepUp();
 
         /// <summary>
         /// Increments the value by (step * n), where n defaults to 1 if not specified. Throws an INVALID_STATE_ERR exception:
@@ -357,7 +357,7 @@ namespace Bridge.Html5
         /// if the value cannot be converted to a number.
         /// if the resulting value is above the max or below the min.
         /// </summary>
-        public virtual extern void StepUp(int n);
+        public extern void StepUp(int n);
     }
 
     /// <summary>

--- a/Html5/Elements/HTMLKeygenElement.cs
+++ b/Html5/Elements/HTMLKeygenElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLKeygenElement")]
-    public class HTMLKeygenElement : HTMLElement<HTMLKeygenElement>
+    public sealed class HTMLKeygenElement : HTMLElement<HTMLKeygenElement>
     {
         [Template("document.createElement('keygen')")]
         public HTMLKeygenElement()
@@ -72,18 +72,18 @@ namespace Bridge.Html5
         /// <summary>
         /// Removes focus from input; keystrokes will subsequently go nowhere.
         /// </summary>
-        public new virtual extern void Blur();
+        public new extern void Blur();
 
         /// <summary>
         /// Always returns true because keygen objects are never candidates for constraint validation.
         /// </summary>
         /// <returns></returns>
-        public virtual extern bool CheckValidity();
+        public extern bool CheckValidity();
 
         /// <summary>
         /// Sets a custom validity message for the element. If this message is not the empty string, then the element is suffering from a custom validity error, and does not validate.
         /// </summary>
         /// <param name="error"></param>
-        public virtual extern void SetCustomValidity(string error);
+        public extern void SetCustomValidity(string error);
     }
 }

--- a/Html5/Elements/HTMLKeygenElement.cs
+++ b/Html5/Elements/HTMLKeygenElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLKeygenElement : HTMLElement<HTMLKeygenElement>
     {
         [Template("document.createElement('keygen')")]
-        public HTMLKeygenElement()
-        {
-        }
+        public extern HTMLKeygenElement();
 
         /// <summary>
         /// Reflects the autofocus HTML attribute, which specifies that a form control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form element in a document can have the autofocus attribute. It cannot be applied if the type attribute is set to hidden (that is, you cannot automatically set focus to a hidden control).

--- a/Html5/Elements/HTMLLIElement.cs
+++ b/Html5/Elements/HTMLLIElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLLIElement : HTMLElement<HTMLLIElement>
     {
         [Template("document.createElement('li')")]
-        public HTMLLIElement()
-        {
-        }
+        public extern HTMLLIElement();
 
         /// <summary>
         /// The type of the bullets, "disc", "square" or "circle". As the standard way of defining the list type is via the CSS list-style-type property, use the CSSOM methods to set it via a script.

--- a/Html5/Elements/HTMLLIElement.cs
+++ b/Html5/Elements/HTMLLIElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLLIElement")]
-    public class HTMLLIElement : HTMLElement<HTMLLIElement>
+    public sealed class HTMLLIElement : HTMLElement<HTMLLIElement>
     {
         [Template("document.createElement('li')")]
         public HTMLLIElement()

--- a/Html5/Elements/HTMLLabelElement.cs
+++ b/Html5/Elements/HTMLLabelElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLLabelElement")]
-    public class HTMLLabelElement : HTMLElement<HTMLLabelElement>
+    public sealed class HTMLLabelElement : HTMLElement<HTMLLabelElement>
     {
         [Template("document.createElement('label')")]
         public HTMLLabelElement()

--- a/Html5/Elements/HTMLLabelElement.cs
+++ b/Html5/Elements/HTMLLabelElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLLabelElement : HTMLElement<HTMLLabelElement>
     {
         [Template("document.createElement('label')")]
-        public HTMLLabelElement()
-        {
-        }
+        public extern HTMLLabelElement();
 
         /// <summary>
         /// The labeled control.

--- a/Html5/Elements/HTMLLegendElement.cs
+++ b/Html5/Elements/HTMLLegendElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLLegendElement : HTMLElement<HTMLLegendElement>
     {
         [Template("document.createElement('legend')")]
-        public HTMLLegendElement()
-        {
-        }
+        public extern HTMLLegendElement();
 
         /// <summary>
         /// The form that this legend belongs to. If the legend has a fieldset element as its parent, then this attribute returns the same value as the form attribute on the parent fieldset element. Otherwise, it returns null.

--- a/Html5/Elements/HTMLLegendElement.cs
+++ b/Html5/Elements/HTMLLegendElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLLegendElement")]
-    public class HTMLLegendElement : HTMLElement<HTMLLegendElement>
+    public sealed class HTMLLegendElement : HTMLElement<HTMLLegendElement>
     {
         [Template("document.createElement('legend')")]
         public HTMLLegendElement()

--- a/Html5/Elements/HTMLLinkElement.cs
+++ b/Html5/Elements/HTMLLinkElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLLinkElement")]
-    public class HTMLLinkElement : HTMLElement<HTMLLinkElement>
+    public sealed class HTMLLinkElement : HTMLElement<HTMLLinkElement>
     {
         [Template("document.createElement('link')")]
         public HTMLLinkElement()

--- a/Html5/Elements/HTMLLinkElement.cs
+++ b/Html5/Elements/HTMLLinkElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLLinkElement : HTMLElement<HTMLLinkElement>
     {
         [Template("document.createElement('link')")]
-        public HTMLLinkElement()
-        {
-        }
+        public extern HTMLLinkElement();
 
         /// <summary>
         /// Gets or sets whether the link is disabled; currently only used with style sheet links.

--- a/Html5/Elements/HTMLMapElement.cs
+++ b/Html5/Elements/HTMLMapElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLMapElement")]
-    public class HTMLMapElement : HTMLElement<HTMLMapElement>
+    public sealed class HTMLMapElement : HTMLElement<HTMLMapElement>
     {
         [Template("document.createElement('map')")]
         public HTMLMapElement()

--- a/Html5/Elements/HTMLMapElement.cs
+++ b/Html5/Elements/HTMLMapElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLMapElement : HTMLElement<HTMLMapElement>
     {
         [Template("document.createElement('map')")]
-        public HTMLMapElement()
-        {
-        }
+        public extern HTMLMapElement();
 
         /// <summary>
         /// Is a DOMString representing the &lt;map&gt; element for referencing it other context. If the id attribute is set, this must have the same value; and it cannot be null or empty.

--- a/Html5/Elements/HTMLMetaElement.cs
+++ b/Html5/Elements/HTMLMetaElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLMetaElement : HTMLElement<HTMLMetaElement>
     {
         [Template("document.createElement('meta')")]
-        public HTMLMetaElement()
-        {
-        }
+        public extern HTMLMetaElement();
 
         /// <summary>
         /// Gets or sets the value of meta-data property.

--- a/Html5/Elements/HTMLMetaElement.cs
+++ b/Html5/Elements/HTMLMetaElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLMetaElement")]
-    public class HTMLMetaElement : HTMLElement<HTMLMetaElement>
+    public sealed class HTMLMetaElement : HTMLElement<HTMLMetaElement>
     {
         [Template("document.createElement('meta')")]
         public HTMLMetaElement()

--- a/Html5/Elements/HTMLMeterElement.cs
+++ b/Html5/Elements/HTMLMeterElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLMeterElement")]
-    public class HTMLMeterElement : HTMLElement<HTMLMeterElement>
+    public sealed class HTMLMeterElement : HTMLElement<HTMLMeterElement>
     {
         [Template("document.createElement('meter')")]
         public HTMLMeterElement()

--- a/Html5/Elements/HTMLMeterElement.cs
+++ b/Html5/Elements/HTMLMeterElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLMeterElement : HTMLElement<HTMLMeterElement>
     {
         [Template("document.createElement('meter')")]
-        public HTMLMeterElement()
-        {
-        }
+        public extern HTMLMeterElement();
 
         /// <summary>
         /// It returns the value of the high boundary, reflecting the high &lt;meter&gt; attribute.

--- a/Html5/Elements/HTMLModElement.cs
+++ b/Html5/Elements/HTMLModElement.cs
@@ -10,9 +10,7 @@ namespace Bridge.Html5
     public sealed class HTMLModElement : HTMLElement<HTMLModElement>
     {
         [Template("document.createElement({0})")]
-        public HTMLModElement(ModElementType type)
-        {
-        }
+        public extern HTMLModElement(ModElementType type);
 
         /// <summary>
         /// Reflects the cite HTML attribute, containing a URI of a resource explaining the change.

--- a/Html5/Elements/HTMLModElement.cs
+++ b/Html5/Elements/HTMLModElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLModElement")]
-    public class HTMLModElement : HTMLElement<HTMLModElement>
+    public sealed class HTMLModElement : HTMLElement<HTMLModElement>
     {
         [Template("document.createElement({0})")]
         public HTMLModElement(ModElementType type)

--- a/Html5/Elements/HTMLOListElement.cs
+++ b/Html5/Elements/HTMLOListElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLOListElement")]
-    public class HTMLOListElement : HTMLElement<HTMLOListElement>
+    public sealed class HTMLOListElement : HTMLElement<HTMLOListElement>
     {
         [Template("document.createElement('ol')")]
         public HTMLOListElement()

--- a/Html5/Elements/HTMLOListElement.cs
+++ b/Html5/Elements/HTMLOListElement.cs
@@ -10,9 +10,7 @@ namespace Bridge.Html5
     public sealed class HTMLOListElement : HTMLElement<HTMLOListElement>
     {
         [Template("document.createElement('ol')")]
-        public HTMLOListElement()
-        {
-        }
+        public extern HTMLOListElement();
 
         /// <summary>
         /// Is a Boolean value reflecting the reversed and defining if the numbering is descending, that is its value is true, or ascending (false).

--- a/Html5/Elements/HTMLObjectElement.cs
+++ b/Html5/Elements/HTMLObjectElement.cs
@@ -6,7 +6,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLObjectElement")]
-    public class HTMLObjectElement : HTMLElement<HTMLObjectElement>
+    public sealed class HTMLObjectElement : HTMLElement<HTMLObjectElement>
     {
         [Template("document.createElement('object')")]
         public HTMLObjectElement()
@@ -87,7 +87,7 @@ namespace Bridge.Html5
         /// Always returns true, because object objects are never candidates for constraint validation.
         /// </summary>
         /// <returns>Always returns true</returns>
-        public virtual bool CheckValidity()
+        public bool CheckValidity()
         {
             return true;
         }
@@ -96,6 +96,6 @@ namespace Bridge.Html5
         /// Sets a custom validity message for the element. If this message is not the empty string, then the element is suffering from a custom validity error, and does not validate.
         /// </summary>
         /// <param name="error">The custom validity message</param>
-        public virtual extern void SetCustomValidity(string error);
+        public extern void SetCustomValidity(string error);
     }
 }

--- a/Html5/Elements/HTMLObjectElement.cs
+++ b/Html5/Elements/HTMLObjectElement.cs
@@ -9,9 +9,7 @@ namespace Bridge.Html5
     public sealed class HTMLObjectElement : HTMLElement<HTMLObjectElement>
     {
         [Template("document.createElement('object')")]
-        public HTMLObjectElement()
-        {
-        }
+        public extern HTMLObjectElement();
 
         /// <summary>
         /// The active document of the object element's nested browsing context, if any; otherwise null.

--- a/Html5/Elements/HTMLOptGroupElement.cs
+++ b/Html5/Elements/HTMLOptGroupElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLOptGroupElement")]
-    public class HTMLOptGroupElement : HTMLElement<HTMLOptGroupElement>
+    public sealed class HTMLOptGroupElement : HTMLElement<HTMLOptGroupElement>
     {
         [Template("document.createElement('optgroup')")]
         public HTMLOptGroupElement()

--- a/Html5/Elements/HTMLOptGroupElement.cs
+++ b/Html5/Elements/HTMLOptGroupElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLOptGroupElement : HTMLElement<HTMLOptGroupElement>
     {
         [Template("document.createElement('optgroup')")]
-        public HTMLOptGroupElement()
-        {
-        }
+        public extern HTMLOptGroupElement();
 
         /// <summary>
         /// If true, the whole list of children &lt;option&gt; is disabled.

--- a/Html5/Elements/HTMLOptionElement.cs
+++ b/Html5/Elements/HTMLOptionElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLOptionElement")]
-    public class HTMLOptionElement : HTMLElement<HTMLOptionElement>
+    public sealed class HTMLOptionElement : HTMLElement<HTMLOptionElement>
     {
         [Template("document.createElement('option')")]
         public HTMLOptionElement()

--- a/Html5/Elements/HTMLOptionElement.cs
+++ b/Html5/Elements/HTMLOptionElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLOptionElement : HTMLElement<HTMLOptionElement>
     {
         [Template("document.createElement('option')")]
-        public HTMLOptionElement()
-        {
-        }
+        public extern HTMLOptionElement();
 
         /// <summary>
         /// Contains the initial value of the selected HTML attribute, indicating whether the option is selected by default or not.

--- a/Html5/Elements/HTMLOutputElement.cs
+++ b/Html5/Elements/HTMLOutputElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLOutputElement : HTMLElement<HTMLOutputElement>
     {
         [Template("document.createElement('output')")]
-        public HTMLOutputElement()
-        {
-        }
+        public extern HTMLOutputElement();
 
         /// <summary>
         /// The default value of the element, initially the empty string.

--- a/Html5/Elements/HTMLOutputElement.cs
+++ b/Html5/Elements/HTMLOutputElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLOutputElement")]
-    public class HTMLOutputElement : HTMLElement<HTMLOutputElement>
+    public sealed class HTMLOutputElement : HTMLElement<HTMLOutputElement>
     {
         [Template("document.createElement('output')")]
         public HTMLOutputElement()
@@ -60,12 +60,12 @@ namespace Bridge.Html5
         /// The proposed new behavior, implemented in Firefox since Gecko 2.0 is to return false if the element is a candidate for constraint validation, and it does not satisfy its constraints. In this case, it also fires an "invalid" event at the element. It returns true if the element is not a candidate for constraint validation, or if it satisfies its constraints (See bug 604673 (https://bugzilla.mozilla.org/show_bug.cgi?id=604673)).
         /// </summary>
         /// <returns></returns>
-        public virtual extern bool CheckValidity();
+        public extern bool CheckValidity();
 
         /// <summary>
         /// Sets a custom validity message for the element. If this message is not the empty string, then the element is suffering from a custom validity error, and does not validate.
         /// </summary>
         /// <param name="error">The custom validity message</param>
-        public virtual extern void SetCustomValidity(string error);
+        public extern void SetCustomValidity(string error);
     }
 }

--- a/Html5/Elements/HTMLParagraphElement.cs
+++ b/Html5/Elements/HTMLParagraphElement.cs
@@ -8,8 +8,6 @@ namespace Bridge.Html5
     public sealed class HTMLParagraphElement : HTMLElement<HTMLParagraphElement>
     {
         [Template("document.createElement('p')")]
-        public HTMLParagraphElement()
-        {
-        }
+        public extern HTMLParagraphElement();
     }
 }

--- a/Html5/Elements/HTMLParagraphElement.cs
+++ b/Html5/Elements/HTMLParagraphElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLParagraphElement")]
-    public class HTMLParagraphElement : HTMLElement<HTMLParagraphElement>
+    public sealed class HTMLParagraphElement : HTMLElement<HTMLParagraphElement>
     {
         [Template("document.createElement('p')")]
         public HTMLParagraphElement()

--- a/Html5/Elements/HTMLParamElement.cs
+++ b/Html5/Elements/HTMLParamElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLParamElement : HTMLElement<HTMLParamElement>
     {
         [Template("document.createElement('param')")]
-        public HTMLParamElement()
-        {
-        }
+        public extern HTMLParamElement();
 
         /// <summary>
         /// Is a DOMString representing the name of the parameter. It reflects the name attribute.

--- a/Html5/Elements/HTMLParamElement.cs
+++ b/Html5/Elements/HTMLParamElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLParamElement")]
-    public class HTMLParamElement : HTMLElement<HTMLParamElement>
+    public sealed class HTMLParamElement : HTMLElement<HTMLParamElement>
     {
         [Template("document.createElement('param')")]
         public HTMLParamElement()

--- a/Html5/Elements/HTMLPreElement.cs
+++ b/Html5/Elements/HTMLPreElement.cs
@@ -8,8 +8,6 @@ namespace Bridge.Html5
     public sealed class HTMLPreElement : HTMLElement<HTMLPreElement>
     {
         [Template("document.createElement('pre')")]
-        public HTMLPreElement()
-        {
-        }
+        public extern HTMLPreElement();
     }
 }

--- a/Html5/Elements/HTMLPreElement.cs
+++ b/Html5/Elements/HTMLPreElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLPreElement")]
-    public class HTMLPreElement : HTMLElement<HTMLPreElement>
+    public sealed class HTMLPreElement : HTMLElement<HTMLPreElement>
     {
         [Template("document.createElement('pre')")]
         public HTMLPreElement()

--- a/Html5/Elements/HTMLProgressElement.cs
+++ b/Html5/Elements/HTMLProgressElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLProgressElement : HTMLElement<HTMLProgressElement>
     {
         [Template("document.createElement('progress')")]
-        public HTMLProgressElement()
-        {
-        }
+        public extern HTMLProgressElement();
 
         /// <summary>
         /// Is a double value reflecting the content attribute of the same name, limited to numbers greater than zero. Its default value is 1.0.

--- a/Html5/Elements/HTMLProgressElement.cs
+++ b/Html5/Elements/HTMLProgressElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLProgressElement")]
-    public class HTMLProgressElement : HTMLElement<HTMLProgressElement>
+    public sealed class HTMLProgressElement : HTMLElement<HTMLProgressElement>
     {
         [Template("document.createElement('progress')")]
         public HTMLProgressElement()

--- a/Html5/Elements/HTMLQuoteElement.cs
+++ b/Html5/Elements/HTMLQuoteElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLQuoteElement")]
-    public class HTMLQuoteElement : HTMLElement<HTMLQuoteElement>
+    public sealed class HTMLQuoteElement : HTMLElement<HTMLQuoteElement>
     {
         [Template("document.createElement('blockquote')")]
         public HTMLQuoteElement()

--- a/Html5/Elements/HTMLQuoteElement.cs
+++ b/Html5/Elements/HTMLQuoteElement.cs
@@ -10,9 +10,7 @@ namespace Bridge.Html5
     public sealed class HTMLQuoteElement : HTMLElement<HTMLQuoteElement>
     {
         [Template("document.createElement('blockquote')")]
-        public HTMLQuoteElement()
-        {
-        }
+        public extern HTMLQuoteElement();
 
         [Template("document.createElement({0})")]
         public HTMLQuoteElement(QuoteType type)

--- a/Html5/Elements/HTMLScriptElement.cs
+++ b/Html5/Elements/HTMLScriptElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLScriptElement")]
-    public class HTMLScriptElement : HTMLElement<HTMLScriptElement>
+    public sealed class HTMLScriptElement : HTMLElement<HTMLScriptElement>
     {
         [Template("document.createElement('script')")]
         public HTMLScriptElement()

--- a/Html5/Elements/HTMLScriptElement.cs
+++ b/Html5/Elements/HTMLScriptElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLScriptElement : HTMLElement<HTMLScriptElement>
     {
         [Template("document.createElement('script')")]
-        public HTMLScriptElement()
-        {
-        }
+        public extern HTMLScriptElement();
 
         /// <summary>
         /// The async and defer attributes are boolean attributes that indicate how the script should be executed. The defer and async attributes must not be specified if the src attribute is not present.

--- a/Html5/Elements/HTMLSelectElement.cs
+++ b/Html5/Elements/HTMLSelectElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLSelectElement")]
-    public class HTMLSelectElement : HTMLElement<HTMLSelectElement>
+    public sealed class HTMLSelectElement : HTMLElement<HTMLSelectElement>
     {
         [Template("document.createElement('select')")]
         public HTMLSelectElement()
@@ -109,27 +109,27 @@ namespace Bridge.Html5
         /// Adds an element to the collection of option elements for this select element.
         /// <param name="element">An item to add to the collection of options.</param>
         /// </summary>
-        public virtual extern void Add(HTMLElement element);
+        public extern void Add(HTMLElement element);
 
         /// <summary>
         /// Adds an element to the collection of option elements for this select element.
         /// <param name="element">An item to add to the collection of options.</param>
         /// <param name="beforeElement">An item that the new item should be inserted before. If this parameter is null, the new element is appended to the end of the collection.</param>
         /// </summary>
-        public virtual extern void Add(HTMLElement element, HTMLElement beforeElement);
+        public extern void Add(HTMLElement element, HTMLElement beforeElement);
 
         /// <summary>
         /// Adds an element to the collection of option elements for this select element.
         /// <param name="element">An item to add to the collection of options.</param>
         /// <param name="beforeIndex">An index of an item that the new item should be inserted before. If the index does not exist, the new element is appended to the end of the collection.</param>
         /// </summary>
-        public virtual extern void Add(HTMLElement element, int beforeIndex);
+        public extern void Add(HTMLElement element, int beforeIndex);
 
         /// <summary>
         /// Checks whether the element has any constraints and whether it satisfies them. If the element fails its constraints, the browser fires a cancelable invalid event at the element (and returns false).
         /// </summary>
         /// <returns>A false value if the select element is a candidate for constraint evaluation and it does not satisfy its constraints. Returns true if the element is not constrained, or if it satisfies its constraints.</returns>
-        public virtual extern bool CheckValidity();
+        public extern bool CheckValidity();
 
         /// <summary>
         /// Gets an item from the options collection for this select element. You can also access an item by specifying the index in array-style brackets or parentheses, without calling this method explicitly.
@@ -137,7 +137,7 @@ namespace Bridge.Html5
         /// <returns>The node at the specified index, or null if such a node does not exist in the collection.</returns>
         /// </summary>
         [Name("item")]
-        public virtual extern HTMLOptionElement GetItem(int index);
+        public extern HTMLOptionElement GetItem(int index);
 
         /// <summary>
         /// Gets the item in the options collection with the specified name. The name string can match either the id or the name attribute of an option node. You can also access an item by specifying the name in array-style brackets or parentheses, without calling this method explicitly.
@@ -147,18 +147,18 @@ namespace Bridge.Html5
         ///     - An OptionElement, if there is exactly one match.
         ///     - null if there are no matches.
         ///     - An OptionsCollection in tree order of nodes whose name or id attributes match the specified name.</returns>
-        public virtual extern Union<HTMLOptionElement, OptionsCollection> NamedItem(string name);
+        public extern Union<HTMLOptionElement, OptionsCollection> NamedItem(string name);
 
         /// <summary>
         /// Removes the element at the specified index from the options collection for this select element.
         /// <param name="index">The zero-based index of the option element to remove from the collection.</param>
         /// </summary>
-        public virtual extern void Remove(int index);
+        public extern void Remove(int index);
 
         /// <summary>
         /// Sets the custom validity message for the selection element to the specified message. Use the empty string to indicate that the element does not have a custom validity error.
         /// </summary>
         /// <param name="error">The string to use for the custom validity message.</param>
-        public virtual extern void SetCustomValidity(string error);
+        public extern void SetCustomValidity(string error);
     }
 }

--- a/Html5/Elements/HTMLSelectElement.cs
+++ b/Html5/Elements/HTMLSelectElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLSelectElement : HTMLElement<HTMLSelectElement>
     {
         [Template("document.createElement('select')")]
-        public HTMLSelectElement()
-        {
-        }
+        public extern HTMLSelectElement();
 
         /// <summary>
         /// Reflects the autofocus HTML attribute, which indicates whether the control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form-associated element in a document can have this attribute specified.

--- a/Html5/Elements/HTMLSourceElement.cs
+++ b/Html5/Elements/HTMLSourceElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLSourceElement : HTMLElement<HTMLSourceElement>
     {
         [Template("document.createElement('source')")]
-        public HTMLSourceElement()
-        {
-        }
+        public extern HTMLSourceElement();
 
         /// <summary>
         /// Reflects the media HTML attribute, containing the intended type of the media resource.

--- a/Html5/Elements/HTMLSourceElement.cs
+++ b/Html5/Elements/HTMLSourceElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLSourceElement")]
-    public class HTMLSourceElement : HTMLElement<HTMLSourceElement>
+    public sealed class HTMLSourceElement : HTMLElement<HTMLSourceElement>
     {
         [Template("document.createElement('source')")]
         public HTMLSourceElement()

--- a/Html5/Elements/HTMLSpanElement.cs
+++ b/Html5/Elements/HTMLSpanElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLSpanElement")]
-    public class HTMLSpanElement : HTMLElement<HTMLSpanElement>
+    public sealed class HTMLSpanElement : HTMLElement<HTMLSpanElement>
     {
         [Template("document.createElement('span')")]
         public HTMLSpanElement()

--- a/Html5/Elements/HTMLSpanElement.cs
+++ b/Html5/Elements/HTMLSpanElement.cs
@@ -8,8 +8,6 @@ namespace Bridge.Html5
     public sealed class HTMLSpanElement : HTMLElement<HTMLSpanElement>
     {
         [Template("document.createElement('span')")]
-        public HTMLSpanElement()
-        {
-        }
+        public extern HTMLSpanElement();
     }
 }

--- a/Html5/Elements/HTMLStyleElement.cs
+++ b/Html5/Elements/HTMLStyleElement.cs
@@ -6,7 +6,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLStyleElement")]
-    public class HTMLStyleElement : HTMLElement<HTMLStyleElement>
+    public sealed class HTMLStyleElement : HTMLElement<HTMLStyleElement>
     {
         [Template("document.createElement('style')")]
         public HTMLStyleElement()

--- a/Html5/Elements/HTMLStyleElement.cs
+++ b/Html5/Elements/HTMLStyleElement.cs
@@ -9,9 +9,7 @@ namespace Bridge.Html5
     public sealed class HTMLStyleElement : HTMLElement<HTMLStyleElement>
     {
         [Template("document.createElement('style')")]
-        public HTMLStyleElement()
-        {
-        }
+        public extern HTMLStyleElement();
 
         /// <summary>
         /// Is a DOMString representing the intended destination medium for style information.

--- a/Html5/Elements/HTMLTableCaptionElement.cs
+++ b/Html5/Elements/HTMLTableCaptionElement.cs
@@ -8,8 +8,6 @@ namespace Bridge.Html5
     public sealed class HTMLTableCaptionElement : HTMLElement<HTMLTableCaptionElement>
     {
         [Template("document.createElement('caption')")]
-        public HTMLTableCaptionElement()
-        {
-        }
+        public extern HTMLTableCaptionElement();
     }
 }

--- a/Html5/Elements/HTMLTableCaptionElement.cs
+++ b/Html5/Elements/HTMLTableCaptionElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTableCaptionElement")]
-    public class HTMLTableCaptionElement : HTMLElement<HTMLTableCaptionElement>
+    public sealed class HTMLTableCaptionElement : HTMLElement<HTMLTableCaptionElement>
     {
         [Template("document.createElement('caption')")]
         public HTMLTableCaptionElement()

--- a/Html5/Elements/HTMLTableColElement.cs
+++ b/Html5/Elements/HTMLTableColElement.cs
@@ -8,7 +8,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTableColElement")]
-    public class HTMLTableColElement : HTMLElement<HTMLTableColElement>
+    public sealed class HTMLTableColElement : HTMLElement<HTMLTableColElement>
     {
         [Template("document.createElement('col')")]
         public HTMLTableColElement()

--- a/Html5/Elements/HTMLTableColElement.cs
+++ b/Html5/Elements/HTMLTableColElement.cs
@@ -11,14 +11,10 @@ namespace Bridge.Html5
     public sealed class HTMLTableColElement : HTMLElement<HTMLTableColElement>
     {
         [Template("document.createElement('col')")]
-        public HTMLTableColElement()
-        {
-        }
+        public extern HTMLTableColElement();
 
         [Template("document.createElement({0})")]
-        public HTMLTableColElement(TableColumnType type)
-        {
-        }
+        public extern HTMLTableColElement(TableColumnType type);
 
         /// <summary>
         /// Reflects the span HTML attribute, indicating the number of columns to apply this object's attributes to. Must be a positive integer.

--- a/Html5/Elements/HTMLTableDataCellElement.cs
+++ b/Html5/Elements/HTMLTableDataCellElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTableDataCellElement")]
-    public class HTMLTableDataCellElement : HTMLTableCellElement<HTMLTableDataCellElement>
+    public sealed class HTMLTableDataCellElement : HTMLTableCellElement<HTMLTableDataCellElement>
     {
         [Template("document.createElement('td')")]
         public HTMLTableDataCellElement()

--- a/Html5/Elements/HTMLTableDataCellElement.cs
+++ b/Html5/Elements/HTMLTableDataCellElement.cs
@@ -8,8 +8,6 @@ namespace Bridge.Html5
     public sealed class HTMLTableDataCellElement : HTMLTableCellElement<HTMLTableDataCellElement>
     {
         [Template("document.createElement('td')")]
-        public HTMLTableDataCellElement()
-        {
-        }
+        public extern HTMLTableDataCellElement();
     }
 }

--- a/Html5/Elements/HTMLTableElement.cs
+++ b/Html5/Elements/HTMLTableElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTableElement")]
-    public class HTMLTableElement : HTMLElement<HTMLTableElement>
+    public sealed class HTMLTableElement : HTMLElement<HTMLTableElement>
     {
         [Template("document.createElement('table')")]
         public HTMLTableElement()
@@ -40,32 +40,32 @@ namespace Bridge.Html5
         /// <summary>
         /// Returns an HTMLElement representing the first &lt;thead&gt; that is a child of the element. If none is found, a new one is created and inserted in the tree immediately before the first element that is neither a &lt;caption&gt;, nor a &lt;colgroup&gt;, or as the last child if there is no such element.
         /// </summary>
-        public virtual extern HTMLTableSectionElement CreateTHead();
+        public extern HTMLTableSectionElement CreateTHead();
 
         /// <summary>
         /// Removes the first &lt;thead&gt; that is a child of the element.
         /// </summary>
-        public virtual extern void DeleteTHead();
+        public extern void DeleteTHead();
 
         /// <summary>
         /// Returns an HTMLElement representing the first &lt;tfoot&gt; that is a child of the element. If none is found, a new one is created and inserted in the tree immediately before the first element that is neither a &lt;caption&gt;, a &lt;colgroup&gt;, nor a &lt;thead&gt;, or as the last child if there is no such element.
         /// </summary>
-        public virtual extern HTMLTableSectionElement CreateTFoot();
+        public extern HTMLTableSectionElement CreateTFoot();
 
         /// <summary>
         /// Removes the first &lt;tfoot&gt; that is a child of the element.
         /// </summary>
-        public virtual extern void DeleteTFoot();
+        public extern void DeleteTFoot();
 
         /// <summary>
         /// Returns an HTMLElement representing the first &lt;caption&gt; that is a child of the element. If none is found, a new one is created and inserted in the tree as the first child of the &lt;table&gt; element.
         /// </summary>
-        public virtual extern HTMLTableCaptionElement CreateCaption();
+        public extern HTMLTableCaptionElement CreateCaption();
 
         /// <summary>
         /// Removes the first &lt;caption&gt; that is a child of the element.
         /// </summary>
-        public virtual extern void DeleteCaption();
+        public extern void DeleteCaption();
 
         /// <summary>
         /// Inserts a new row in the table and returns a reference to the row.
@@ -75,11 +75,11 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="index">The row index of the new row. Defaults to -1.</param>
         /// <returns>Returns the TableRowElement representing the new row of the table.</returns>
-        public virtual extern HTMLTableRowElement InsertRow(int index = -1);
+        public extern HTMLTableRowElement InsertRow(int index = -1);
 
         /// <summary>
         /// Removes the row corresponding to the index given in parameter. If the index value is -1 the last row is removed; if it smaller than -1 or greater than the amount of rows in the collection, a DOMException with the value IndexSizeError is raised.
         /// </summary>
-        public virtual extern void DeleteRow(int index);
+        public extern void DeleteRow(int index);
     }
 }

--- a/Html5/Elements/HTMLTableElement.cs
+++ b/Html5/Elements/HTMLTableElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLTableElement : HTMLElement<HTMLTableElement>
     {
         [Template("document.createElement('table')")]
-        public HTMLTableElement()
-        {
-        }
+        public extern HTMLTableElement();
 
         /// <summary>
         /// Is an HTMLTableCaptionElement representing the first &lt;caption&gt; that is a child of the element, or null if none is found. When set, if the object doesn't represent a &lt;caption&gt;, a DOMException with the HierarchyRequestError name is thrown. If a correct object is given, it is inserted in the tree as the first child of this element and the first &lt;caption&gt; that is a child of this element is removed from the tree, if any.

--- a/Html5/Elements/HTMLTableHeaderCellElement.cs
+++ b/Html5/Elements/HTMLTableHeaderCellElement.cs
@@ -10,9 +10,7 @@ namespace Bridge.Html5
     public sealed class HTMLTableHeaderCellElement : HTMLTableCellElement<HTMLTableHeaderCellElement>
     {
         [Template("document.createElement('th')")]
-        public HTMLTableHeaderCellElement()
-        {
-        }
+        public extern HTMLTableHeaderCellElement();
 
         /// <summary>
         /// Is a DOMString containing a name used to refer to this cell in other context. It reflects the abbr attribute.

--- a/Html5/Elements/HTMLTableHeaderCellElement.cs
+++ b/Html5/Elements/HTMLTableHeaderCellElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTableHeaderCellElement")]
-    public class HTMLTableHeaderCellElement : HTMLTableCellElement<HTMLTableHeaderCellElement>
+    public sealed class HTMLTableHeaderCellElement : HTMLTableCellElement<HTMLTableHeaderCellElement>
     {
         [Template("document.createElement('th')")]
         public HTMLTableHeaderCellElement()

--- a/Html5/Elements/HTMLTableRowElement.cs
+++ b/Html5/Elements/HTMLTableRowElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTableRowElement")]
-    public class HTMLTableRowElement : HTMLElement<HTMLTableRowElement>
+    public sealed class HTMLTableRowElement : HTMLElement<HTMLTableRowElement>
     {
         [Template("document.createElement('tr')")]
         public HTMLTableRowElement()
@@ -31,7 +31,7 @@ namespace Bridge.Html5
         /// Removes the cell at the given position in the row. If the given position is greater (or equal as it starts at zero) than the amount of cells in the row, or is smaller than 0, it raises a DOMException with the IndexSizeError value.
         /// <param name="index">The position of the cell in the row</param>
         /// </summary>
-        public virtual extern void DeleteCell(int index);
+        public extern void DeleteCell(int index);
 
         /// <summary>
         /// Inserts a new cell into a table row and returns a reference to the cell.
@@ -41,6 +41,6 @@ namespace Bridge.Html5
         /// <param name="index">The cell index of the new cell. Defaults to -1.</param>
         /// <returns>Returns the TableDataCellElement representing the new cell of the row.</returns>
         /// </summary>
-        public virtual extern HTMLTableDataCellElement InsertCell(int index = -1);
+        public extern HTMLTableDataCellElement InsertCell(int index = -1);
     }
 }

--- a/Html5/Elements/HTMLTableRowElement.cs
+++ b/Html5/Elements/HTMLTableRowElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLTableRowElement : HTMLElement<HTMLTableRowElement>
     {
         [Template("document.createElement('tr')")]
-        public HTMLTableRowElement()
-        {
-        }
+        public extern HTMLTableRowElement();
 
         /// <summary>
         /// Returns a live HTMLCollection containing the cells in the row. The HTMLCollection is live and is automatically updated when cells are added or removed.

--- a/Html5/Elements/HTMLTableSectionElement.cs
+++ b/Html5/Elements/HTMLTableSectionElement.cs
@@ -8,7 +8,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTableSectionElement")]
-    public class HTMLTableSectionElement : HTMLElement<HTMLTableSectionElement>
+    public sealed class HTMLTableSectionElement : HTMLElement<HTMLTableSectionElement>
     {
         [Template("document.createElement('tbody')")]
         public HTMLTableSectionElement()
@@ -29,7 +29,7 @@ namespace Bridge.Html5
         /// Removes the cell at the given position in the section. If the given position is greater (or equal as it starts at zero) than the amount of rows in the section, or is smaller than 0, it raises a DOMException with the IndexSizeError value.
         /// </summary>
         /// <param name="index">The position of the row to delete</param>
-        public virtual extern void DeleteRow(int index);
+        public extern void DeleteRow(int index);
 
         /// <summary>
         /// Inserts a new row just before the given position in the section.
@@ -38,7 +38,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="index">The possition of a new row to insert</param>
         /// <returns>Returns a TableRowElement object that represents a new row added to a table element.</returns>
-        public virtual extern HTMLTableRowElement InsertRow(int index = -1); // update docs
+        public extern HTMLTableRowElement InsertRow(int index = -1); // update docs
     }
 
     /// <summary>

--- a/Html5/Elements/HTMLTableSectionElement.cs
+++ b/Html5/Elements/HTMLTableSectionElement.cs
@@ -11,14 +11,10 @@ namespace Bridge.Html5
     public sealed class HTMLTableSectionElement : HTMLElement<HTMLTableSectionElement>
     {
         [Template("document.createElement('tbody')")]
-        public HTMLTableSectionElement()
-        {
-        }
+        public extern HTMLTableSectionElement();
 
         [Template("document.createElement({0})")]
-        public HTMLTableSectionElement(TableSectionType type)
-        {
-        }
+        public extern HTMLTableSectionElement(TableSectionType type);
 
         /// <summary>
         /// Returns a live HTMLCollection containing the rows in the section. The HTMLCollection is live and is automatically updated when rows are added or removed.

--- a/Html5/Elements/HTMLTemplateElement.cs
+++ b/Html5/Elements/HTMLTemplateElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTemplateElement")]
-    public class HTMLTemplateElement : HTMLElement<HTMLTemplateElement>
+    public sealed class HTMLTemplateElement : HTMLElement<HTMLTemplateElement>
     {
         [Template("document.createElement('template')")]
         public HTMLTemplateElement()

--- a/Html5/Elements/HTMLTemplateElement.cs
+++ b/Html5/Elements/HTMLTemplateElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLTemplateElement : HTMLElement<HTMLTemplateElement>
     {
         [Template("document.createElement('template')")]
-        public HTMLTemplateElement()
-        {
-        }
+        public extern HTMLTemplateElement();
 
         /// <summary>
         /// The content IDL attribute must return the template element's template contents.

--- a/Html5/Elements/HTMLTextAreaElement.cs
+++ b/Html5/Elements/HTMLTextAreaElement.cs
@@ -10,9 +10,7 @@ namespace Bridge.Html5
     public sealed class HTMLTextAreaElement : HTMLElement<HTMLTextAreaElement>
     {
         [Template("document.createElement('textarea')")]
-        public HTMLTextAreaElement()
-        {
-        }
+        public extern HTMLTextAreaElement();
 
         /// <summary>
         /// Reflects the autofocus HTML attribute, which specifies that a form control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form element in a document can have the autofocus attribute. It cannot be applied if the type attribute is set to hidden (that is, you cannot automatically set focus to a hidden control).

--- a/Html5/Elements/HTMLTextAreaElement.cs
+++ b/Html5/Elements/HTMLTextAreaElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTextAreaElement")]
-    public class HTMLTextAreaElement : HTMLElement<HTMLTextAreaElement>
+    public sealed class HTMLTextAreaElement : HTMLElement<HTMLTextAreaElement>
     {
         [Template("document.createElement('textarea')")]
         public HTMLTextAreaElement()
@@ -124,25 +124,25 @@ namespace Bridge.Html5
         /// Returns false if the button is a candidate for constraint validation, and it does not satisfy its constraints. In this case, it also fires an invalid event at the control. It returns true if the control is not a candidate for constraint validation, or if it satisfies its constraints.
         /// </summary>
         /// <returns></returns>
-        public virtual extern bool CheckValidity();
+        public extern bool CheckValidity();
 
         /// <summary>
         /// Selects the contents of the control.
         /// </summary>
-        public virtual extern void Select();
+        public extern void Select();
 
         /// <summary>
         /// Sets a custom validity message for the element. If this message is not the empty string, then the element is suffering from a custom validity error, and does not validate.
         /// </summary>
         /// <param name="error"></param>
-        public virtual extern void SetCustomValidity(string error);
+        public extern void SetCustomValidity(string error);
 
         /// <summary>
         /// Selects a range of text in the element (but does not focus it). The optional selectionDirection parameter may be "forward" or "backward" to establish the direction in which selection was set, or "none" if the direction is unknown or not relevant. The default is "none". Specifying a selectionDirection parameter sets the value of the selectionDirection property.
         /// </summary>
         /// <param name="start"></param>
         /// <param name="end"></param>
-        public virtual extern void SetSelectionRange(int start, int end);
+        public extern void SetSelectionRange(int start, int end);
 
         /// <summary>
         /// Selects a range of text in the element (but does not focus it). The optional selectionDirection parameter may be "forward" or "backward" to establish the direction in which selection was set, or "none" if the direction is unknown or not relevant. The default is "none". Specifying a selectionDirection parameter sets the value of the selectionDirection property.
@@ -150,13 +150,13 @@ namespace Bridge.Html5
         /// <param name="start"></param>
         /// <param name="end"></param>
         /// <param name="direction"></param>
-        public virtual extern void SetSelectionRange(int start, int end, string direction);
+        public extern void SetSelectionRange(int start, int end, string direction);
 
         /// <summary>
         /// Replaces a range of text with the new text. Supported input types: text, search, url, tel, password.
         /// </summary>
         /// <param name="replacement"></param>
-        public virtual extern void SetRangeText(string replacement);
+        public extern void SetRangeText(string replacement);
 
         /// <summary>
         /// Replaces a range of text with the new text. Supported input types: text, search, url, tel, password.
@@ -164,7 +164,7 @@ namespace Bridge.Html5
         /// <param name="replacement"></param>
         /// <param name="start"></param>
         /// <param name="end"></param>
-        public virtual extern void SetRangeText(string replacement, int start, int end);
+        public extern void SetRangeText(string replacement, int start, int end);
 
         /// <summary>
         /// Replaces a range of text with the new text. Supported input types: text, search, url, tel, password.
@@ -173,7 +173,7 @@ namespace Bridge.Html5
         /// <param name="start"></param>
         /// <param name="end"></param>
         /// <param name="selectMode"></param>
-        public virtual extern void SetRangeText(string replacement, int start, int end, string selectMode);
+        public extern void SetRangeText(string replacement, int start, int end, string selectMode);
 
         #endregion Methods
     }

--- a/Html5/Elements/HTMLTitleElement.cs
+++ b/Html5/Elements/HTMLTitleElement.cs
@@ -8,9 +8,7 @@ namespace Bridge.Html5
     public sealed class HTMLTitleElement : HTMLElement<HTMLTitleElement>
     {
         [Template("document.createElement('title')")]
-        public HTMLTitleElement()
-        {
-        }
+        public extern HTMLTitleElement();
 
         /// <summary>
         /// The string representing the text of the document's title.

--- a/Html5/Elements/HTMLTitleElement.cs
+++ b/Html5/Elements/HTMLTitleElement.cs
@@ -5,7 +5,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTitleElement")]
-    public class HTMLTitleElement : HTMLElement<HTMLTitleElement>
+    public sealed class HTMLTitleElement : HTMLElement<HTMLTitleElement>
     {
         [Template("document.createElement('title')")]
         public HTMLTitleElement()

--- a/Html5/Elements/HTMLTrackElement.cs
+++ b/Html5/Elements/HTMLTrackElement.cs
@@ -9,9 +9,7 @@ namespace Bridge.Html5
     public sealed class HTMLTrackElement : HTMLElement<HTMLTrackElement>
     {
         [Template("document.createElement('track')")]
-        public HTMLTrackElement()
-        {
-        }
+        public extern HTMLTrackElement();
 
         /// <summary>
         /// Reflects the kind HTML attribute, indicating how the text track is meant to be used. Possible values are: subtitles, captions, descriptions, chapters, metadata. See kind attribute documentation for details.

--- a/Html5/Elements/HTMLTrackElement.cs
+++ b/Html5/Elements/HTMLTrackElement.cs
@@ -6,7 +6,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLTrackElement")]
-    public class HTMLTrackElement : HTMLElement<HTMLTrackElement>
+    public sealed class HTMLTrackElement : HTMLElement<HTMLTrackElement>
     {
         [Template("document.createElement('track')")]
         public HTMLTrackElement()

--- a/Html5/Elements/HTMLUListElement.cs
+++ b/Html5/Elements/HTMLUListElement.cs
@@ -9,8 +9,6 @@ namespace Bridge.Html5
     public sealed class HTMLUListElement : HTMLElement<HTMLUListElement>
     {
         [Template("document.createElement('ul')")]
-        public HTMLUListElement()
-        {
-        }
+        public extern HTMLUListElement();
     }
 }

--- a/Html5/Elements/HTMLUListElement.cs
+++ b/Html5/Elements/HTMLUListElement.cs
@@ -6,7 +6,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLUListElement")]
-    public class HTMLUListElement : HTMLElement<HTMLUListElement>
+    public sealed class HTMLUListElement : HTMLElement<HTMLUListElement>
     {
         [Template("document.createElement('ul')")]
         public HTMLUListElement()

--- a/Html5/Elements/HTMLUnknownElement.cs
+++ b/Html5/Elements/HTMLUnknownElement.cs
@@ -6,7 +6,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLUnknownElement")]
-    public class HTMLUnknownElement : HTMLElement<HTMLUnknownElement>
+    public sealed class HTMLUnknownElement : HTMLElement<HTMLUnknownElement>
     {
         [Template("document.createElement({0})")]
         public HTMLUnknownElement(string tagName)

--- a/Html5/Elements/HTMLUnknownElement.cs
+++ b/Html5/Elements/HTMLUnknownElement.cs
@@ -9,8 +9,6 @@ namespace Bridge.Html5
     public sealed class HTMLUnknownElement : HTMLElement<HTMLUnknownElement>
     {
         [Template("document.createElement({0})")]
-        public HTMLUnknownElement(string tagName)
-        {
-        }
+        public extern HTMLUnknownElement(string tagName);
     }
 }

--- a/Html5/Elements/HTMLVideoElement.cs
+++ b/Html5/Elements/HTMLVideoElement.cs
@@ -10,9 +10,7 @@ namespace Bridge.Html5
     public sealed class HTMLVideoElement : HTMLMediaElement<HTMLVideoElement>
     {
         [Template("document.createElement('video')")]
-        public HTMLVideoElement()
-        {
-        }
+        public extern HTMLVideoElement();
 
         /// <summary>
         /// Reflects the height HTML attribute, which specifies the height of the display area, in CSS pixels.

--- a/Html5/Elements/HTMLVideoElement.cs
+++ b/Html5/Elements/HTMLVideoElement.cs
@@ -7,7 +7,7 @@ namespace Bridge.Html5
     /// </summary>
     [External]
     [Name("HTMLVideoElement")]
-    public class HTMLVideoElement : HTMLMediaElement<HTMLVideoElement>
+    public sealed class HTMLVideoElement : HTMLMediaElement<HTMLVideoElement>
     {
         [Template("document.createElement('video')")]
         public HTMLVideoElement()

--- a/Html5/Elements/MarkElement.cs
+++ b/Html5/Elements/MarkElement.cs
@@ -4,7 +4,7 @@ namespace Bridge.Html5
     /// The HTML Mark Element represents a &lt;mark&gt; element and derives from the HTMLElement interface, but without implementing any additional properties or methods.
     /// </summary>
     [External] // Note no [Name] attribute as a mark element is identified simply as a HTMLElement and not as a more specialised variation (such as HTMLSpanElement or HTMLDivElement)
-    public class MarkElement : HTMLElement<MarkElement>
+    public sealed class MarkElement : HTMLElement<MarkElement>
     {
         [Template("document.createElement('mark')")]
         public MarkElement()

--- a/Html5/Elements/MarkElement.cs
+++ b/Html5/Elements/MarkElement.cs
@@ -7,8 +7,6 @@ namespace Bridge.Html5
     public sealed class MarkElement : HTMLElement<MarkElement>
     {
         [Template("document.createElement('mark')")]
-        public MarkElement()
-        {
-        }
+        public extern MarkElement();
     }
 }


### PR DESCRIPTION
Fixes Issues #2362 and #2363.

#828 Standardize on extern modifier instead of empty Constructor bodies