### PR TITLE
[2399] Math.Sqrt and unsigned integers don't work.

### DIFF
--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -72,8 +72,6 @@ namespace System
 
         public static extern double Random();
 
-        public static extern double Sqrt(int x);
-
         public static extern double Sqrt(double x);
 
         [Template("{d}.ceil()")]
@@ -133,9 +131,6 @@ namespace System
 
         [Template("{x}.pow({y})")]
         public static extern decimal Pow(decimal x, decimal y);
-
-        [Template("{x}.sqrt()")]
-        public static extern decimal Sqrt(decimal x);
 
         public static extern double Pow(double x, double y);
 

--- a/Tests/Batch1/MathTests.cs
+++ b/Tests/Batch1/MathTests.cs
@@ -672,7 +672,7 @@ namespace Bridge.ClientTest
         [Test]
         public void SqrtWorks()
         {
-            AssertIsDecimalAndEqualTo(Math.Sqrt(3m), "1.7320508075688772935274463415");
+            AssertAlmostEqual(Math.Sqrt((double)3m), 1.73205080756888);
         }
 
         [Test]

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -507,6 +507,7 @@
     <Compile Include="BridgeIssues\2300\N2369.cs" />
     <Compile Include="BridgeIssues\2300\N2374.cs" />
     <Compile Include="BridgeIssues\2300\N2375.cs" />
+    <Compile Include="BridgeIssues\2300\N2399.cs" />
     <Compile Include="BridgeIssues\2300\N2386.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />

--- a/Tests/Batch3/BridgeIssues/2300/N2399.cs
+++ b/Tests/Batch3/BridgeIssues/2300/N2399.cs
@@ -1,0 +1,31 @@
+using System;
+using Bridge.Test.NUnit;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#2399 - {0}")]
+    public class Bridge2399
+    {
+        [Test]
+        public static void TestSqrt()
+        {
+            AssertAlmostEqual(1.73205080756888, Math.Sqrt(3.0));
+            Assert.AreEqual(0.0, Math.Sqrt(0.0));
+            Assert.AreEqual(double.NaN, Math.Sqrt(-3.0));
+            Assert.AreEqual(double.NaN, Math.Sqrt(double.NaN));
+            Assert.AreEqual(double.PositiveInfinity, Math.Sqrt(double.PositiveInfinity));
+            Assert.AreEqual(double.NaN, Math.Sqrt(double.NegativeInfinity));
+            Assert.AreEqual(3, Math.Sqrt(9u));
+            Assert.AreEqual(3, Math.Sqrt(9L));
+        }
+
+        private static void AssertAlmostEqual(double d1, double d2)
+        {
+            var diff = d2 - d1;
+            if (diff < 0)
+                diff = -diff;
+            Assert.True(diff < 1e-8);
+        }
+    }
+}

--- a/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
+++ b/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
@@ -20889,7 +20889,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
             testBasic: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.CSharp6.TestAutoProps).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.TestAutoProps, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestBasic()",
-                    line: "29"
+                    line: "33"
                 } ));
                 Bridge.ClientTest.CSharp6.TestAutoProps.testBasic();
             }
@@ -21231,7 +21231,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
             testBasic: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.CSharp6.TestInterpolatedStrings).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.TestInterpolatedStrings, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestBasic()",
-                    line: "35"
+                    line: "37"
                 } ));
                 Bridge.ClientTest.CSharp6.TestInterpolatedStrings.testBasic();
             }

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -20142,7 +20142,7 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             this.assertAlmostEqual(Math.sin(0.5), 0.479425538604203);
         },
         sqrtWorks: function () {
-            this.assertIsDecimalAndEqualTo(System.Decimal(3.0).sqrt(), "1.7320508075688772935274463415");
+            this.assertAlmostEqual(Math.sqrt(3.0), 1.73205080756888);
         },
         tanWorks: function () {
             this.assertAlmostEqual(Math.tan(0.5), 0.54630248984379048);

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -475,6 +475,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#2374 - TestPropertyInitializer", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2374.testPropertyInitializer);
             QUnit.test("#2375 - TestNameofWithReflection", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2375.testNameofWithReflection);
             QUnit.test("#2386 - TestStructBoxingOperations", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2386.testStructBoxingOperations);
+            QUnit.test("#2399 - TestSqrt", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2399.testSqrt);
             QUnit.test("#381 - TestUseCase", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge381.testUseCase);
             QUnit.test("#447 - CheckInlineExpression", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge447.checkInlineExpression);
             QUnit.test("#447 - CheckInlineCalls", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge447.checkInlineCalls);
@@ -8105,7 +8106,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertiesWithNonPrimitiveInitializers: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2137, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertiesWithNonPrimitiveInitializers()",
-                    line: "21"
+                    line: "24"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137.testPropertiesWithNonPrimitiveInitializers();
             }
@@ -9004,7 +9005,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertyInitializerWithDirective: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2249).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2249, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertyInitializerWithDirective()",
-                    line: "22"
+                    line: "23"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2249.testPropertyInitializerWithDirective();
             }
@@ -9076,7 +9077,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertyWithInitializerAndNestedClass: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2279).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2279, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertyWithInitializerAndNestedClass()",
-                    line: "23"
+                    line: "25"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2279.testPropertyWithInitializerAndNestedClass();
             }
@@ -9220,7 +9221,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testBridgeFields: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2310).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2310, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestBridgeFields()",
-                    line: "95"
+                    line: "97"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2310.testBridgeFields();
             }
@@ -9680,7 +9681,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertyInitializer: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2374).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2374, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertyInitializer()",
-                    line: "18"
+                    line: "20"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2374.testPropertyInitializer();
             }
@@ -9704,7 +9705,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testNameofWithReflection: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2375).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2375, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestNameofWithReflection()",
-                    line: "17"
+                    line: "18"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2375.testNameofWithReflection();
             }
@@ -9740,6 +9741,30 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2386",
                     file: "Batch3\\BridgeIssues\\2300\\N2386.cs"
+                } );
+            }
+            return this.context;
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2399", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2399)],
+        statics: {
+            testSqrt: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2399).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2399, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    method: "TestSqrt()",
+                    line: "10"
+                } ));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge2399.testSqrt();
+            }
+        },
+        context: null,
+        getContext: function () {
+            if (this.context == null) {
+                this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
+                    project: "Batch3",
+                    className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2399",
+                    file: "Batch3\\BridgeIssues\\2300\\N2399.cs"
                 } );
             }
             return this.context;
@@ -11561,7 +11586,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testFieldPropertyWithInitializer: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge706).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge706, 1, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestFieldPropertyWithInitializer()",
-                    line: "17"
+                    line: "18"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge706.testFieldPropertyWithInitializer();
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -15183,6 +15183,28 @@ Bridge.$N1391Result =                 r;
         $kind: "interface"
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2399", {
+        statics: {
+            testSqrt: function () {
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge2399.assertAlmostEqual(1.73205080756888, Math.sqrt(3.0));
+                Bridge.Test.NUnit.Assert.areEqual(0.0, Math.sqrt(0.0));
+                Bridge.Test.NUnit.Assert.areEqual(Number.NaN, Math.sqrt(-3.0));
+                Bridge.Test.NUnit.Assert.areEqual(Number.NaN, Math.sqrt(Number.NaN));
+                Bridge.Test.NUnit.Assert.areEqual(Number.POSITIVE_INFINITY, Math.sqrt(Number.POSITIVE_INFINITY));
+                Bridge.Test.NUnit.Assert.areEqual(Number.NaN, Math.sqrt(Number.NEGATIVE_INFINITY));
+                Bridge.Test.NUnit.Assert.areEqual(3, Math.sqrt(9));
+                Bridge.Test.NUnit.Assert.areEqual(3, Math.sqrt(System.Int64(9)));
+            },
+            assertAlmostEqual: function (d1, d2) {
+                var diff = d2 - d1;
+                if (diff < 0) {
+                    diff = -diff;
+                }
+                Bridge.Test.NUnit.Assert.true(diff < 1E-08);
+            }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge240A", {
         config: {
             properties: {


### PR DESCRIPTION
Fixes #2399

Changes proposed in this pull request:

-  Math.Sqrt(decimal d) is removed because it is not presented in .NET API