### PR TITLE
[2418] Add assembly name to `$type` field

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -3004,7 +3004,7 @@
 
     Bridge.define("Bridge.Utils.SystemAssemblyVersion");
 
-    // @source JSON.js
+    // @source Json.js
 
     Bridge.Json = {
         serialize: function (obj, settings, returnRaw, possibleType) {

--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -2976,7 +2976,7 @@
 
     Bridge.define("Bridge.Utils.SystemAssemblyVersion");
 
-    // @source Json.js
+    // @source JSON.js
 
     Bridge.Json = {
         serialize: function (obj, settings, returnRaw, possibleType) {
@@ -3104,7 +3104,7 @@
                     }
 
                     if (settings && settings.typeNameHandling) {
-                        raw["$type"] = Bridge.getTypeName(type);
+                        raw["$type"] = Bridge.Reflection.getTypeQName(type);
                     }
 
                     if (nometa) {

--- a/Bridge/Resources/Json.js
+++ b/Bridge/Resources/Json.js
@@ -124,7 +124,7 @@
                     }
 
                     if (settings && settings.typeNameHandling) {
-                        raw["$type"] = Bridge.getTypeName(type);
+                        raw["$type"] = Bridge.Reflection.getTypeQName(type);
                     }
 
                     if (nometa) {

--- a/Tests/Batch1/Serialization/SerializationTests.cs
+++ b/Tests/Batch1/Serialization/SerializationTests.cs
@@ -276,10 +276,10 @@ namespace Bridge.ClientTest
         {
             var c = new Class2();
             var json = Bridge.Json.Serialize(c, new JsonSettings { CamelCasePropertyNames = true });
-            Assert.AreEqual(json, "{\"intProp\":0}");
+            Assert.AreEqual("{\"intProp\":0}", json);
 
             json = Bridge.Json.Serialize(c);
-            Assert.AreEqual(json, "{\"IntProp\":0}");
+            Assert.AreEqual("{\"IntProp\":0}", json);
         }
 
         [Test]
@@ -287,10 +287,20 @@ namespace Bridge.ClientTest
         {
             var c = new Class3();
             var json = Bridge.Json.Serialize(c, new JsonSettings { IgnoreNullValue = true });
-            Assert.AreEqual(json, "{}");
+            Assert.AreEqual("{}", json);
 
             json = Bridge.Json.Serialize(c);
-            Assert.AreEqual(json, "{\"StringProp\":null}");
+            Assert.AreEqual("{\"StringProp\":null}", json);
+        }
+
+        [Test]
+        public static void TypeNameHandlingWorks()
+        {
+            var c = new Class3();
+
+            var json = Bridge.Json.Serialize(c, new JsonSettings { TypeNameHandling = true });
+
+            Assert.AreEqual("{\"$type\":\"Bridge.ClientTest.SerializationTests+Class3, Bridge.ClientTest\",\"StringProp\":null}", json);
         }
 
         [Test]
@@ -299,7 +309,7 @@ namespace Bridge.ClientTest
             var v = new { Amount = 108, Message = "Hello" };
             var json = Bridge.Json.Serialize(v);
 
-            Assert.AreEqual(json, "{\"Amount\":108,\"Message\":\"Hello\"}");
+            Assert.AreEqual("{\"Amount\":108,\"Message\":\"Hello\"}", json);
         }
     }
 }

--- a/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
+++ b/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
@@ -21222,7 +21222,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
             testBasic: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.CSharp6.TestAutoProps).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.TestAutoProps, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestBasic()",
-                    line: "33"
+                    line: "29"
                 } ));
                 Bridge.ClientTest.CSharp6.TestAutoProps.testBasic();
             }
@@ -21595,7 +21595,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
             testBasic: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.CSharp6.TestInterpolatedStrings).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.TestInterpolatedStrings, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestBasic()",
-                    line: "37"
+                    line: "35"
                 } ));
                 Bridge.ClientTest.CSharp6.TestInterpolatedStrings.testBasic();
             }

--- a/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
+++ b/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
@@ -1879,6 +1879,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
             QUnit.test("ComplexPropertiesWorks", Bridge.Test.Runtime.BridgeClientTestRunner.SerializationTests.complexPropertiesWorks);
             QUnit.test("CamelCaseSettingWorks", Bridge.Test.Runtime.BridgeClientTestRunner.SerializationTests.camelCaseSettingWorks);
             QUnit.test("IgnoreNullValueWorks", Bridge.Test.Runtime.BridgeClientTestRunner.SerializationTests.ignoreNullValueWorks);
+            QUnit.test("TypeNameHandlingWorks", Bridge.Test.Runtime.BridgeClientTestRunner.SerializationTests.typeNameHandlingWorks);
             QUnit.test("AnonymousTypesWorks", Bridge.Test.Runtime.BridgeClientTestRunner.SerializationTests.anonymousTypesWorks);
             QUnit.module("Simple types");
             QUnit.test("Boolean - TypePropertiesAreCorrect", Bridge.Test.Runtime.BridgeClientTestRunner.BooleanTests.typePropertiesAreCorrect);
@@ -19684,10 +19685,17 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 } ));
                 Bridge.ClientTest.SerializationTests.ignoreNullValueWorks();
             },
+            typeNameHandlingWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.SerializationTests).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.SerializationTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    method: "TypeNameHandlingWorks()",
+                    line: "274"
+                } ));
+                Bridge.ClientTest.SerializationTests.typeNameHandlingWorks();
+            },
             anonymousTypesWorks: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.SerializationTests).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.SerializationTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "AnonymousTypesWorks()",
-                    line: "274"
+                    line: "284"
                 } ));
                 Bridge.ClientTest.SerializationTests.anonymousTypesWorks();
             }

--- a/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
+++ b/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
@@ -21220,7 +21220,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
             testBasic: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.CSharp6.TestAutoProps).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.TestAutoProps, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestBasic()",
-                    line: "29"
+                    line: "33"
                 } ));
                 Bridge.ClientTest.CSharp6.TestAutoProps.testBasic();
             }
@@ -21562,7 +21562,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
             testBasic: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.CSharp6.TestInterpolatedStrings).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.TestInterpolatedStrings, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestBasic()",
-                    line: "35"
+                    line: "37"
                 } ));
                 Bridge.ClientTest.CSharp6.TestInterpolatedStrings.testBasic();
             }

--- a/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
+++ b/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
@@ -2764,7 +2764,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.AggregateExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/AggregateExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\AggregateExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2809,7 +2809,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.AmbiguousMatchExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/AmbiguousMatchExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\AmbiguousMatchExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2868,7 +2868,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ArgumentExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/ArgumentExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\ArgumentExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2920,7 +2920,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ArgumentNullExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/ArgumentNullExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\ArgumentNullExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2979,7 +2979,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ArgumentOutOfRangeExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/ArgumentOutOfRangeExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\ArgumentOutOfRangeExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -3024,7 +3024,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ArgumentsTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/ArgumentsTests.cs"
+                    file: "Batch1\\ArgumentsTests.cs"
                 } );
             }
             return this.context;
@@ -3069,7 +3069,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ArithmeticExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/ArithmeticExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\ArithmeticExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -3107,7 +3107,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.ArrayBufferTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/ArrayBufferTests.cs"
+                    file: "Batch1\\Collections\\Native\\ArrayBufferTests.cs"
                 } );
             }
             return this.context;
@@ -3523,7 +3523,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ArrayTests.ArrayTestsSet1",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/ArrayTests.cs"
+                    file: "Batch1\\ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -3687,7 +3687,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ArrayTests.ArrayTestsSet2",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/ArrayTests.cs"
+                    file: "Batch1\\ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -3830,7 +3830,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Batch1.Reflection.AssemblyTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Reflection/AssemblyTests.cs"
+                    file: "Batch1\\Reflection\\AssemblyTests.cs"
                 } );
             }
             return this.context;
@@ -3889,7 +3889,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.AsyncTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Threading/Tasks/AsyncTests.cs"
+                    file: "Batch1\\Threading\\Tasks\\AsyncTests.cs"
                 } );
             }
             return this.context;
@@ -3997,7 +3997,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Batch1.Reflection.AttributeTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Reflection/AttributeTests.cs"
+                    file: "Batch1\\Reflection\\AttributeTests.cs"
                 } );
             }
             return this.context;
@@ -4154,7 +4154,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.BooleanTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/BooleanTests.cs"
+                    file: "Batch1\\SimpleTypes\\BooleanTests.cs"
                 } );
             }
             return this.context;
@@ -4185,7 +4185,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.TypeSystemTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/TypeSystemTests.cs"
+                    file: "Batch1\\TypeSystemTests.cs"
                 } );
             }
             return this.context;
@@ -4209,7 +4209,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ObjectLiteralTests.Bridge1529",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/ObjectLiteralTests.cs"
+                    file: "Batch1\\ObjectLiteralTests.cs"
                 } );
             }
             return this.context;
@@ -4286,7 +4286,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BridgeConsoleTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BridgeConsoleTests.cs"
+                    file: "Batch1\\BridgeConsoleTests.cs"
                 } );
             }
             return this.context;
@@ -4383,7 +4383,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.JavaScript.BridgeRegexTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/JavaScript/BridgeRegexTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\JavaScript\\BridgeRegexTests.cs"
                 } );
             }
             return this.context;
@@ -4519,7 +4519,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.ByteTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/ByteTests.cs"
+                    file: "Batch1\\SimpleTypes\\ByteTests.cs"
                 } );
             }
             return this.context;
@@ -4732,7 +4732,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.CancellationTokenTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Threading/CancellationTokenTests.cs"
+                    file: "Batch1\\Threading\\CancellationTokenTests.cs"
                 } );
             }
             return this.context;
@@ -4910,7 +4910,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.CharTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/CharTests.cs"
+                    file: "Batch1\\SimpleTypes\\CharTests.cs"
                 } );
             }
             return this.context;
@@ -4955,7 +4955,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.CheckedInsideUncheckedTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
+                    file: "Batch1\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -5000,7 +5000,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.CheckedTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
+                    file: "Batch1\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -5052,7 +5052,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.CommonExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/CommonExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\CommonExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -5104,7 +5104,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.ComparerTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Generic/ComparerTests.cs"
+                    file: "Batch1\\Collections\\Generic\\ComparerTests.cs"
                 } );
             }
             return this.context;
@@ -5205,7 +5205,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Diagnostics.Contracts.ContractTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Diagnostics/Contracts/ContractTests.cs"
+                    file: "Batch1\\Diagnostics\\Contracts\\ContractTests.cs"
                 } );
             }
             return this.context;
@@ -5369,7 +5369,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertFromBase64Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertFromBase64Tests.cs"
+                    file: "Batch1\\Convert\\ConvertFromBase64Tests.cs"
                 } );
             }
             return this.context;
@@ -5442,7 +5442,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToBase64CharArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToBase64CharArrayTests.cs"
+                    file: "Batch1\\Convert\\ConvertToBase64CharArrayTests.cs"
                 } );
             }
             return this.context;
@@ -5494,7 +5494,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToBase64StringTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToBase64StringTests.cs"
+                    file: "Batch1\\Convert\\ConvertToBase64StringTests.cs"
                 } );
             }
             return this.context;
@@ -5609,7 +5609,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToBooleanTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToBooleanTests.cs"
+                    file: "Batch1\\Convert\\ConvertToBooleanTests.cs"
                 } );
             }
             return this.context;
@@ -5731,7 +5731,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToByteTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToByteTests.cs"
+                    file: "Batch1\\Convert\\ConvertToByteTests.cs"
                 } );
             }
             return this.context;
@@ -5867,7 +5867,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToCharTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToCharTests.cs"
+                    file: "Batch1\\Convert\\ConvertToCharTests.cs"
                 } );
             }
             return this.context;
@@ -5989,7 +5989,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToDateTimeTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToDateTimeTests.cs"
+                    file: "Batch1\\Convert\\ConvertToDateTimeTests.cs"
                 } );
             }
             return this.context;
@@ -6104,7 +6104,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToDecimalTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToDecimalTests.cs"
+                    file: "Batch1\\Convert\\ConvertToDecimalTests.cs"
                 } );
             }
             return this.context;
@@ -6219,7 +6219,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToDoubleTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToDoubleTests.cs"
+                    file: "Batch1\\Convert\\ConvertToDoubleTests.cs"
                 } );
             }
             return this.context;
@@ -6348,7 +6348,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToInt16Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToInt16Tests.cs"
+                    file: "Batch1\\Convert\\ConvertToInt16Tests.cs"
                 } );
             }
             return this.context;
@@ -6477,7 +6477,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToInt32Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToInt32Tests.cs"
+                    file: "Batch1\\Convert\\ConvertToInt32Tests.cs"
                 } );
             }
             return this.context;
@@ -6606,7 +6606,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToInt64Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToInt64Tests.cs"
+                    file: "Batch1\\Convert\\ConvertToInt64Tests.cs"
                 } );
             }
             return this.context;
@@ -6735,7 +6735,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToSByteTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToSByteTests.cs"
+                    file: "Batch1\\Convert\\ConvertToSByteTests.cs"
                 } );
             }
             return this.context;
@@ -6850,7 +6850,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToSingleTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToSingleTests.cs"
+                    file: "Batch1\\Convert\\ConvertToSingleTests.cs"
                 } );
             }
             return this.context;
@@ -7147,7 +7147,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToStringTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToStringTests.cs"
+                    file: "Batch1\\Convert\\ConvertToStringTests.cs"
                 } );
             }
             return this.context;
@@ -7276,7 +7276,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToUInt16Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToUInt16Tests.cs"
+                    file: "Batch1\\Convert\\ConvertToUInt16Tests.cs"
                 } );
             }
             return this.context;
@@ -7405,7 +7405,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToUInt32Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToUInt32Tests.cs"
+                    file: "Batch1\\Convert\\ConvertToUInt32Tests.cs"
                 } );
             }
             return this.context;
@@ -7534,7 +7534,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ConvertTests.ConvertToUInt64Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Convert/ConvertToUInt64Tests.cs"
+                    file: "Batch1\\Convert\\ConvertToUInt64Tests.cs"
                 } );
             }
             return this.context;
@@ -7558,7 +7558,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ObjectLiteralTests.CreateAndInitializationModesTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/ObjectLiteralTests.cs"
+                    file: "Batch1\\ObjectLiteralTests.cs"
                 } );
             }
             return this.context;
@@ -7582,7 +7582,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ObjectLiteralTests.CreateModeTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/ObjectLiteralTests.cs"
+                    file: "Batch1\\ObjectLiteralTests.cs"
                 } );
             }
             return this.context;
@@ -7620,7 +7620,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CultureInfoTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CultureInfoTests.cs"
+                    file: "Batch1\\CultureInfoTests.cs"
                 } );
             }
             return this.context;
@@ -7700,7 +7700,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.CultureNotFoundExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/CultureNotFoundExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\CultureNotFoundExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -7857,7 +7857,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.DataViewTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/DataViewTests.cs"
+                    file: "Batch1\\Collections\\Native\\DataViewTests.cs"
                 } );
             }
             return this.context;
@@ -7895,7 +7895,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Format.DateTimeFormatInfoTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Format/DateTimeFormatInfoTests.cs"
+                    file: "Batch1\\Format\\DateTimeFormatInfoTests.cs"
                 } );
             }
             return this.context;
@@ -7996,7 +7996,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.DecimalMathTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/DecimalMathTests.cs"
+                    file: "Batch1\\DecimalMathTests.cs"
                 } );
             }
             return this.context;
@@ -8223,7 +8223,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.DecimalTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/DecimalTests.cs"
+                    file: "Batch1\\SimpleTypes\\DecimalTests.cs"
                 } );
             }
             return this.context;
@@ -8373,7 +8373,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.DeserializationTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Serialization/DeserializationTests.cs"
+                    file: "Batch1\\Serialization\\DeserializationTests.cs"
                 } );
             }
             return this.context;
@@ -8418,7 +8418,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.DivideByZeroExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/DivideByZeroExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\DivideByZeroExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -8456,7 +8456,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.DOMParserTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/DOMParserTests.cs"
+                    file: "Batch1\\DOMParserTests.cs"
                 } );
             }
             return this.context;
@@ -8833,7 +8833,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.DoubleTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/DoubleTests.cs"
+                    file: "Batch1\\SimpleTypes\\DoubleTests.cs"
                 } );
             }
             return this.context;
@@ -8947,7 +8947,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.EnumTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/EnumTests.cs"
+                    file: "Batch1\\SimpleTypes\\EnumTests.cs"
                 } );
             }
             return this.context;
@@ -8971,7 +8971,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.EnvironmentTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/EnvironmentTests.cs"
+                    file: "Batch1\\EnvironmentTests.cs"
                 } );
             }
             return this.context;
@@ -9030,7 +9030,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.EqualityComparerTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Generic/EqualityComparerTests.cs"
+                    file: "Batch1\\Collections\\Generic\\EqualityComparerTests.cs"
                 } );
             }
             return this.context;
@@ -9089,7 +9089,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.ExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/ExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\ExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -9421,7 +9421,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.Expressions.ExpressionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/Expressions/ExpressionTests.cs"
+                    file: "Batch1\\Linq\\Expressions\\ExpressionTests.cs"
                 } );
             }
             return this.context;
@@ -9634,7 +9634,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Float32ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/Float32ArrayTests.cs"
+                    file: "Batch1\\Collections\\Native\\Float32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -9847,7 +9847,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Float64ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/Float64ArrayTests.cs"
+                    file: "Batch1\\Collections\\Native\\Float64ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -9892,7 +9892,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.FormatExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/FormatExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\FormatExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -9965,7 +9965,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.FormattableStringTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/FormattableStringTests.cs"
+                    file: "Batch1\\FormattableStringTests.cs"
                 } );
             }
             return this.context;
@@ -10003,7 +10003,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.FunctionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/FunctionTests.cs"
+                    file: "Batch1\\FunctionTests.cs"
                 } );
             }
             return this.context;
@@ -10160,7 +10160,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.GenericDictionaryTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Generic/GenericDictionaryTests.cs"
+                    file: "Batch1\\Collections\\Generic\\GenericDictionaryTests.cs"
                 } );
             }
             return this.context;
@@ -10373,7 +10373,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.GetMembersTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Reflection/GetMembersTests.cs"
+                    file: "Batch1\\Reflection\\GetMembersTests.cs"
                 } );
             }
             return this.context;
@@ -10572,7 +10572,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.GuidTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/GuidTests.cs"
+                    file: "Batch1\\GuidTests.cs"
                 } );
             }
             return this.context;
@@ -10722,7 +10722,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.ICollectionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Generic/ICollectionTests.cs"
+                    file: "Batch1\\Collections\\Generic\\ICollectionTests.cs"
                 } );
             }
             return this.context;
@@ -10746,7 +10746,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.IComparableTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/IComparableTests.cs"
+                    file: "Batch1\\IComparableTests.cs"
                 } );
             }
             return this.context;
@@ -10847,7 +10847,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.IDictionaryTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Generic/IDictionaryTests.cs"
+                    file: "Batch1\\Collections\\Generic\\IDictionaryTests.cs"
                 } );
             }
             return this.context;
@@ -10906,7 +10906,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.IEnumerableTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Generic/IEnumerableTests.cs"
+                    file: "Batch1\\Collections\\Generic\\IEnumerableTests.cs"
                 } );
             }
             return this.context;
@@ -10930,7 +10930,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.IEquatableTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/IEquatableTests.cs"
+                    file: "Batch1\\IEquatableTests.cs"
                 } );
             }
             return this.context;
@@ -11094,7 +11094,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.IListTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Generic/IListTests.cs"
+                    file: "Batch1\\Collections\\Generic\\IListTests.cs"
                 } );
             }
             return this.context;
@@ -11139,7 +11139,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.IndexOutOfRangeExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/IndexOutOfRangeExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\IndexOutOfRangeExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11163,7 +11163,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.ObjectLiteralTests.InitializationModeTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/ObjectLiteralTests.cs"
+                    file: "Batch1\\ObjectLiteralTests.cs"
                 } );
             }
             return this.context;
@@ -11376,7 +11376,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Int16ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/Int16ArrayTests.cs"
+                    file: "Batch1\\Collections\\Native\\Int16ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -11512,7 +11512,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.Int16Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/Int16Tests.cs"
+                    file: "Batch1\\SimpleTypes\\Int16Tests.cs"
                 } );
             }
             return this.context;
@@ -11725,7 +11725,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Int32ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/Int32ArrayTests.cs"
+                    file: "Batch1\\Collections\\Native\\Int32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -11910,7 +11910,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.Int32Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/Int32Tests.cs"
+                    file: "Batch1\\SimpleTypes\\Int32Tests.cs"
                 } );
             }
             return this.context;
@@ -12081,7 +12081,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.Int64Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/Int64Tests.cs"
+                    file: "Batch1\\SimpleTypes\\Int64Tests.cs"
                 } );
             }
             return this.context;
@@ -12294,7 +12294,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Int8ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/Int8ArrayTests.cs"
+                    file: "Batch1\\Collections\\Native\\Int8ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -12339,7 +12339,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.InvalidCastExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/InvalidCastExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\InvalidCastExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -12384,7 +12384,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.InvalidOperationExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/InvalidOperationExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\InvalidOperationExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -12471,7 +12471,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.IteratorBlockTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Generic/IteratorBlockTests.cs"
+                    file: "Batch1\\Collections\\Generic\\IteratorBlockTests.cs"
                 } );
             }
             return this.context;
@@ -12950,7 +12950,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.JsDateTimeTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/DateTimeTests.cs"
+                    file: "Batch1\\SimpleTypes\\DateTimeTests.cs"
                 } );
             }
             return this.context;
@@ -13184,7 +13184,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.JsonTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Serialization/JsonTests.cs"
+                    file: "Batch1\\Serialization\\JsonTests.cs"
                 } );
             }
             return this.context;
@@ -13299,7 +13299,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.JsStringTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/JsStringTests.cs"
+                    file: "Batch1\\SimpleTypes\\JsStringTests.cs"
                 } );
             }
             return this.context;
@@ -13344,7 +13344,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.KeyNotFoundExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/KeyNotFoundExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\KeyNotFoundExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -13781,7 +13781,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.ListTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Generic/ListTests.cs"
+                    file: "Batch1\\Collections\\Generic\\ListTests.cs"
                 } );
             }
             return this.context;
@@ -14162,7 +14162,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.MathTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/MathTests.cs"
+                    file: "Batch1\\MathTests.cs"
                 } );
             }
             return this.context;
@@ -14193,7 +14193,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.MixinTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/MixinTests.cs"
+                    file: "Batch1\\MixinTests.cs"
                 } );
             }
             return this.context;
@@ -14315,7 +14315,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.MultidimArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/MultidimArrayTests.cs"
+                    file: "Batch1\\MultidimArrayTests.cs"
                 } );
             }
             return this.context;
@@ -14339,7 +14339,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.MutationObserverTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/MutationObserverTests.cs"
+                    file: "Batch1\\MutationObserverTests.cs"
                 } );
             }
             return this.context;
@@ -14384,7 +14384,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.NotImplementedExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/NotImplementedExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\NotImplementedExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -14429,7 +14429,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.NotSupportedExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/NotSupportedExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\NotSupportedExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -14677,7 +14677,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.NullableTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/NullableTests.cs"
+                    file: "Batch1\\NullableTests.cs"
                 } );
             }
             return this.context;
@@ -14729,7 +14729,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.NullReferenceExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/NullReferenceExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\NullReferenceExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -14767,7 +14767,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Format.NumberFormatInfoTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Format/NumberFormatInfoTests.cs"
+                    file: "Batch1\\Format\\NumberFormatInfoTests.cs"
                 } );
             }
             return this.context;
@@ -14903,7 +14903,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Format.NumberFormatSpecifiersTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Format/NumberFormatSpecifiersTests.cs"
+                    file: "Batch1\\Format\\NumberFormatSpecifiersTests.cs"
                 } );
             }
             return this.context;
@@ -14976,7 +14976,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.ObjectTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/ObjectTests.cs"
+                    file: "Batch1\\SimpleTypes\\ObjectTests.cs"
                 } );
             }
             return this.context;
@@ -15042,7 +15042,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.OperationCanceledExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/OperationCanceledExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\OperationCanceledExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -15087,7 +15087,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.OutOfMemoryExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/OutOfMemoryExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\OutOfMemoryExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -15132,7 +15132,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.OverflowExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/OverflowExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\OverflowExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -15177,7 +15177,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.PromiseExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/PromiseExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\PromiseExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -15236,7 +15236,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.PromiseTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Threading/Tasks/PromiseTests.cs"
+                    file: "Batch1\\Threading\\Tasks\\PromiseTests.cs"
                 } );
             }
             return this.context;
@@ -15295,7 +15295,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.PropertyAccessorTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/PropertyAccessorTests.cs"
+                    file: "Batch1\\PropertyAccessorTests.cs"
                 } );
             }
             return this.context;
@@ -15333,7 +15333,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.RandomTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/RandomTests.cs"
+                    file: "Batch1\\RandomTests.cs"
                 } );
             }
             return this.context;
@@ -15371,7 +15371,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.RankExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/RankExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\RankExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -15584,7 +15584,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.ReadOnlyCollectionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/ObjectModel/ReadOnlyCollectionTests.cs"
+                    file: "Batch1\\Collections\\ObjectModel\\ReadOnlyCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -16245,7 +16245,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.ReflectionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Reflection/ReflectionTests.cs"
+                    file: "Batch1\\Reflection\\ReflectionTests.cs"
                 } );
             }
             return this.context;
@@ -16563,7 +16563,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexAlternationTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexAlternationTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexAlternationTests.cs"
                 } );
             }
             return this.context;
@@ -16727,7 +16727,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexAnchorsTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexAnchorsTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexAnchorsTests.cs"
                 } );
             }
             return this.context;
@@ -16849,7 +16849,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexBackreferenceTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexBackreferenceTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexBackreferenceTests.cs"
                 } );
             }
             return this.context;
@@ -16943,7 +16943,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexBalancingGroupsTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexBalancingGroupsTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexBalancingGroupsTests.cs"
                 } );
             }
             return this.context;
@@ -16995,7 +16995,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexCaptureCollectionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexCaptureCollectionTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexCaptureCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -17348,7 +17348,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexCharClassesTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexCharClassesTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexCharClassesTests.cs"
                 } );
             }
             return this.context;
@@ -17456,7 +17456,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexEntityTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexEntityTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexEntityTests.cs"
                 } );
             }
             return this.context;
@@ -17613,7 +17613,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexEscapesTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexEscapesTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexEscapesTests.cs"
                 } );
             }
             return this.context;
@@ -17658,7 +17658,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexEscapeTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexEscapeTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexEscapeTests.cs"
                 } );
             }
             return this.context;
@@ -17731,7 +17731,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexExamplesTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexExamplesTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexExamplesTests.cs"
                 } );
             }
             return this.context;
@@ -17783,7 +17783,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexGroupCollectionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexGroupCollectionTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexGroupCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -18066,7 +18066,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexInlineOptionsTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexInlineOptionsTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexInlineOptionsTests.cs"
                 } );
             }
             return this.context;
@@ -18118,7 +18118,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexIsMatchTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexIsMatchTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexIsMatchTests.cs"
                 } );
             }
             return this.context;
@@ -18212,7 +18212,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexLookaheadTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexLookaheadTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexLookaheadTests.cs"
                 } );
             }
             return this.context;
@@ -18313,7 +18313,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexLookbehindTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexLookbehindTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexLookbehindTests.cs"
                 } );
             }
             return this.context;
@@ -18379,7 +18379,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexMatchCollectionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexMatchCollectionTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexMatchCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -18445,7 +18445,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexMatchEntityTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexMatchEntityTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexMatchEntityTests.cs"
                 } );
             }
             return this.context;
@@ -18497,7 +18497,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexMatchesTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexMatchesTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexMatchesTests.cs"
                 } );
             }
             return this.context;
@@ -18549,7 +18549,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Entities.RegexMatchSparseTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Entities/RegexMatchSparseTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Entities\\RegexMatchSparseTests.cs"
                 } );
             }
             return this.context;
@@ -18608,7 +18608,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexMatchTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexMatchTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexMatchTests.cs"
                 } );
             }
             return this.context;
@@ -18660,7 +18660,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.RegexMatchTimeoutExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/RegexMatchTimeoutExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\RegexMatchTimeoutExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -18733,7 +18733,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexNonbacktrackingTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexNonbacktrackingTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexNonbacktrackingTests.cs"
                 } );
             }
             return this.context;
@@ -18869,7 +18869,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexOptionsTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexOptionsTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexOptionsTests.cs"
                 } );
             }
             return this.context;
@@ -19054,7 +19054,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexQuantifiersTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexQuantifiersTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexQuantifiersTests.cs"
                 } );
             }
             return this.context;
@@ -19162,7 +19162,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexReplaceTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexReplaceTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexReplaceTests.cs"
                 } );
             }
             return this.context;
@@ -19319,7 +19319,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.Methods.RegexSplitTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/Methods/RegexSplitTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\Methods\\RegexSplitTests.cs"
                 } );
             }
             return this.context;
@@ -19427,7 +19427,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.RegularExpressions.RegexTimeoutTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/RegularExpressions/RegexTimeoutTests.cs"
+                    file: "Batch1\\Text\\RegularExpressions\\RegexTimeoutTests.cs"
                 } );
             }
             return this.context;
@@ -19563,7 +19563,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.SByteTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/SByteTests.cs"
+                    file: "Batch1\\SimpleTypes\\SByteTests.cs"
                 } );
             }
             return this.context;
@@ -19706,7 +19706,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SerializationTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Serialization/SerializationTests.cs"
+                    file: "Batch1\\Serialization\\SerializationTests.cs"
                 } );
             }
             return this.context;
@@ -19891,7 +19891,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.SingleTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/SingleTests.cs"
+                    file: "Batch1\\SimpleTypes\\SingleTests.cs"
                 } );
             }
             return this.context;
@@ -19950,7 +19950,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Diagnostics.StopwatchTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Diagnostics/StopwatchTests.cs"
+                    file: "Batch1\\Diagnostics\\StopwatchTests.cs"
                 } );
             }
             return this.context;
@@ -20093,7 +20093,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Text.StringBuilderTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Text/StringBuilderTests.cs"
+                    file: "Batch1\\Text\\StringBuilderTests.cs"
                 } );
             }
             return this.context;
@@ -20166,7 +20166,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Format.StringFormatTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Format/StringFormatTests.cs"
+                    file: "Batch1\\Format\\StringFormatTests.cs"
                 } );
             }
             return this.context;
@@ -20750,7 +20750,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.StringTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/StringTests.cs"
+                    file: "Batch1\\SimpleTypes\\StringTests.cs"
                 } );
             }
             return this.context;
@@ -20795,7 +20795,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.SystemExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/SystemExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\SystemExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -20847,7 +20847,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.TaskCanceledExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/TaskCanceledExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\TaskCanceledExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -21179,7 +21179,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.TaskTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Threading/Tasks/TaskTests.cs"
+                    file: "Batch1\\Threading\\Tasks\\TaskTests.cs"
                 } );
             }
             return this.context;
@@ -21217,7 +21217,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestAbstractClass",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestAbstractClass.cs"
+                    file: "Batch1\\BasicCSharp\\TestAbstractClass.cs"
                 } );
             }
             return this.context;
@@ -21241,7 +21241,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestAutoProps",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CSharp6/TestAutoProps.cs"
+                    file: "Batch1\\CSharp6\\TestAutoProps.cs"
                 } );
             }
             return this.context;
@@ -21265,7 +21265,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestAwaitInCatchFinally",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CSharp6/TestAwaitInCatchFinally.cs"
+                    file: "Batch1\\CSharp6\\TestAwaitInCatchFinally.cs"
                 } );
             }
             return this.context;
@@ -21289,7 +21289,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestConditionAccess",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CSharp6/TestConditionalAccess.cs"
+                    file: "Batch1\\CSharp6\\TestConditionalAccess.cs"
                 } );
             }
             return this.context;
@@ -21383,7 +21383,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestEnum",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestEnum.cs"
+                    file: "Batch1\\BasicCSharp\\TestEnum.cs"
                 } );
             }
             return this.context;
@@ -21435,7 +21435,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestExceptionFilter",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CSharp6/TestExceptionFilter.cs"
+                    file: "Batch1\\CSharp6\\TestExceptionFilter.cs"
                 } );
             }
             return this.context;
@@ -21459,7 +21459,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestExpressionBodyFunction",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CSharp6/TestExpressionBodyFunction.cs"
+                    file: "Batch1\\CSharp6\\TestExpressionBodyFunction.cs"
                 } );
             }
             return this.context;
@@ -21490,7 +21490,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestGoto",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestGoto.cs"
+                    file: "Batch1\\BasicCSharp\\TestGoto.cs"
                 } );
             }
             return this.context;
@@ -21514,7 +21514,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestIndexInitializer",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CSharp6/TestIndexInitializer.cs"
+                    file: "Batch1\\CSharp6\\TestIndexInitializer.cs"
                 } );
             }
             return this.context;
@@ -21552,7 +21552,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestInheritance",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestInheritance.cs"
+                    file: "Batch1\\BasicCSharp\\TestInheritance.cs"
                 } );
             }
             return this.context;
@@ -21590,7 +21590,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestInterfaces",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestInterfaces.cs"
+                    file: "Batch1\\BasicCSharp\\TestInterfaces.cs"
                 } );
             }
             return this.context;
@@ -21614,7 +21614,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestInterpolatedStrings",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CSharp6/TestInterpolatedStrings.cs"
+                    file: "Batch1\\CSharp6\\TestInterpolatedStrings.cs"
                 } );
             }
             return this.context;
@@ -21645,7 +21645,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqAggregateOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqAggregateOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqAggregateOperators.cs"
                 } );
             }
             return this.context;
@@ -21669,7 +21669,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqConversionOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqConversionOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqConversionOperators.cs"
                 } );
             }
             return this.context;
@@ -21693,7 +21693,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqElementOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqElementOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqElementOperators.cs"
                 } );
             }
             return this.context;
@@ -21717,7 +21717,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqGenerationOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqGenerationOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqGenerationOperators.cs"
                 } );
             }
             return this.context;
@@ -21755,7 +21755,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqGroupingOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqGroupingOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqGroupingOperators.cs"
                 } );
             }
             return this.context;
@@ -21779,7 +21779,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqJoinOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqJoinOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqJoinOperators.cs"
                 } );
             }
             return this.context;
@@ -21803,7 +21803,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqMiscellaneousOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqMiscellaneousOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqMiscellaneousOperators.cs"
                 } );
             }
             return this.context;
@@ -21827,7 +21827,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqOrderingOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqOrderingOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqOrderingOperators.cs"
                 } );
             }
             return this.context;
@@ -21851,7 +21851,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqPartitioningOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqPartitioningOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqPartitioningOperators.cs"
                 } );
             }
             return this.context;
@@ -21875,7 +21875,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqProjectionOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqProjectionOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqProjectionOperators.cs"
                 } );
             }
             return this.context;
@@ -21899,7 +21899,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqQuantifiers",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqQuantifiers.cs"
+                    file: "Batch1\\Linq\\TestLinqQuantifiers.cs"
                 } );
             }
             return this.context;
@@ -21923,7 +21923,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqQueryExecution",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqQueryExecution.cs"
+                    file: "Batch1\\Linq\\TestLinqQueryExecution.cs"
                 } );
             }
             return this.context;
@@ -21947,7 +21947,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqRestrictionOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqRestrictionOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqRestrictionOperators.cs"
                 } );
             }
             return this.context;
@@ -21971,7 +21971,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Linq.TestLinqSetOperators",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Linq/TestLinqSetOperators.cs"
+                    file: "Batch1\\Linq\\TestLinqSetOperators.cs"
                 } );
             }
             return this.context;
@@ -21995,7 +21995,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestMethodParametersClass",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestMethodParametersClass.cs"
+                    file: "Batch1\\BasicCSharp\\TestMethodParametersClass.cs"
                 } );
             }
             return this.context;
@@ -22019,7 +22019,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestNameOf",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CSharp6/TestNameof.cs"
+                    file: "Batch1\\CSharp6\\TestNameof.cs"
                 } );
             }
             return this.context;
@@ -22043,7 +22043,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestOverloadInstanceMethods",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestOverloadInstanceMethods.cs"
+                    file: "Batch1\\BasicCSharp\\TestOverloadInstanceMethods.cs"
                 } );
             }
             return this.context;
@@ -22067,7 +22067,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestOverloadStaticMethods",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestOverloadStaticMethods.cs"
+                    file: "Batch1\\BasicCSharp\\TestOverloadStaticMethods.cs"
                 } );
             }
             return this.context;
@@ -22105,7 +22105,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestReferenceTypes",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestReferenceTypes.cs"
+                    file: "Batch1\\BasicCSharp\\TestReferenceTypes.cs"
                 } );
             }
             return this.context;
@@ -22157,7 +22157,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestTryCatchBlocks",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestTryCatchBlocks.cs"
+                    file: "Batch1\\BasicCSharp\\TestTryCatchBlocks.cs"
                 } );
             }
             return this.context;
@@ -22195,7 +22195,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestTryCatchFinallyBlocks",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestTryCatchFinallyBlocks.cs"
+                    file: "Batch1\\BasicCSharp\\TestTryCatchFinallyBlocks.cs"
                 } );
             }
             return this.context;
@@ -22219,7 +22219,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CSharp6.TestUsingStatic",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CSharp6/TestUsingStatic.cs"
+                    file: "Batch1\\CSharp6\\TestUsingStatic.cs"
                 } );
             }
             return this.context;
@@ -22250,7 +22250,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestValueTypes",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestValueTypes.cs"
+                    file: "Batch1\\BasicCSharp\\TestValueTypes.cs"
                 } );
             }
             return this.context;
@@ -22309,7 +22309,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.TestVersion",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/TestVersion.cs"
+                    file: "Batch1\\SimpleTypes\\TestVersion.cs"
                 } );
             }
             return this.context;
@@ -22333,7 +22333,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.BasicCSharp.TestVirtualMethods",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/BasicCSharp/TestVirtualMethods.cs"
+                    file: "Batch1\\BasicCSharp\\TestVirtualMethods.cs"
                 } );
             }
             return this.context;
@@ -22378,7 +22378,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Exceptions.TimeoutExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Exceptions/TimeoutExceptionTests.cs"
+                    file: "Batch1\\Exceptions\\TimeoutExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -22437,7 +22437,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Threading.TimerTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Threading/TimerTests.cs"
+                    file: "Batch1\\Threading\\TimerTests.cs"
                 } );
             }
             return this.context;
@@ -22615,7 +22615,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.TimeSpanTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/TimeSpanTests.cs"
+                    file: "Batch1\\SimpleTypes\\TimeSpanTests.cs"
                 } );
             }
             return this.context;
@@ -22688,7 +22688,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.TupleTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/TupleTests.cs"
+                    file: "Batch1\\SimpleTypes\\TupleTests.cs"
                 } );
             }
             return this.context;
@@ -22880,7 +22880,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.TypeAttributeTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Reflection/TypeAttributeTests.cs"
+                    file: "Batch1\\Reflection\\TypeAttributeTests.cs"
                 } );
             }
             return this.context;
@@ -22946,7 +22946,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.TypeSystemLanguageSupportTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Reflection/TypeSystemLanguageSupportTests.cs"
+                    file: "Batch1\\Reflection\\TypeSystemLanguageSupportTests.cs"
                 } );
             }
             return this.context;
@@ -23453,7 +23453,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Reflection.TypeSystemTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Reflection/TypeSystemTests.cs"
+                    file: "Batch1\\Reflection\\TypeSystemTests.cs"
                 } );
             }
             return this.context;
@@ -23666,7 +23666,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Uint16ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/Uint16ArrayTests.cs"
+                    file: "Batch1\\Collections\\Native\\Uint16ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -23802,7 +23802,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.UInt16Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/UInt16Tests.cs"
+                    file: "Batch1\\SimpleTypes\\UInt16Tests.cs"
                 } );
             }
             return this.context;
@@ -24015,7 +24015,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Uint32ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/Uint32ArrayTests.cs"
+                    file: "Batch1\\Collections\\Native\\Uint32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -24151,7 +24151,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.UInt32Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/UInt32Tests.cs"
+                    file: "Batch1\\SimpleTypes\\UInt32Tests.cs"
                 } );
             }
             return this.context;
@@ -24322,7 +24322,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.SimpleTypes.UInt64Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/SimpleTypes/UInt64Tests.cs"
+                    file: "Batch1\\SimpleTypes\\UInt64Tests.cs"
                 } );
             }
             return this.context;
@@ -24535,7 +24535,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Uint8ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/Uint8ArrayTests.cs"
+                    file: "Batch1\\Collections\\Native\\Uint8ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -24755,7 +24755,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Native.Uint8ClampedArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/Uint8ClampedArrayTests.cs"
+                    file: "Batch1\\Collections\\Native\\Uint8ClampedArrayTests.cs"
                 } );
             }
             return this.context;
@@ -24800,7 +24800,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.UncheckedInsideCheckedTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
+                    file: "Batch1\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -24845,7 +24845,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.UncheckedTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
+                    file: "Batch1\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -24869,7 +24869,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.Collections.Generic.WeakMapTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/Collections/Native/WeakMapTests.cs"
+                    file: "Batch1\\Collections\\Native\\WeakMapTests.cs"
                 } );
             }
             return this.context;
@@ -24914,7 +24914,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch1",
                     className: "Bridge.ClientTest.CheckedUncheckedTests.WithNoUncheckedKeywordTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch1/CheckedUncheckedTests.cs"
+                    file: "Batch1\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -3004,7 +3004,7 @@
 
     Bridge.define("Bridge.Utils.SystemAssemblyVersion");
 
-    // @source JSON.js
+    // @source Json.js
 
     Bridge.Json = {
         serialize: function (obj, settings, returnRaw, possibleType) {

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -2976,7 +2976,7 @@
 
     Bridge.define("Bridge.Utils.SystemAssemblyVersion");
 
-    // @source Json.js
+    // @source JSON.js
 
     Bridge.Json = {
         serialize: function (obj, settings, returnRaw, possibleType) {
@@ -3104,7 +3104,7 @@
                     }
 
                     if (settings && settings.typeNameHandling) {
-                        raw["$type"] = Bridge.getTypeName(type);
+                        raw["$type"] = Bridge.Reflection.getTypeQName(type);
                     }
 
                     if (nometa) {

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -26576,24 +26576,31 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
             camelCaseSettingWorks: function () {
                 var c = new Bridge.ClientTest.SerializationTests.Class2();
                 var json = Bridge.Json.serialize(c, { camelCasePropertyNames: true });
-                Bridge.Test.NUnit.Assert.areEqual(json, "{\"intProp\":0}");
+                Bridge.Test.NUnit.Assert.areEqual("{\"intProp\":0}", json);
 
                 json = Bridge.Json.serialize(c);
-                Bridge.Test.NUnit.Assert.areEqual(json, "{\"IntProp\":0}");
+                Bridge.Test.NUnit.Assert.areEqual("{\"IntProp\":0}", json);
             },
             ignoreNullValueWorks: function () {
                 var c = new Bridge.ClientTest.SerializationTests.Class3();
                 var json = Bridge.Json.serialize(c, { ignoreNullValue: true });
-                Bridge.Test.NUnit.Assert.areEqual(json, "{}");
+                Bridge.Test.NUnit.Assert.areEqual("{}", json);
 
                 json = Bridge.Json.serialize(c);
-                Bridge.Test.NUnit.Assert.areEqual(json, "{\"StringProp\":null}");
+                Bridge.Test.NUnit.Assert.areEqual("{\"StringProp\":null}", json);
+            },
+            typeNameHandlingWorks: function () {
+                var c = new Bridge.ClientTest.SerializationTests.Class3();
+
+                var json = Bridge.Json.serialize(c, { typeNameHandling: true });
+
+                Bridge.Test.NUnit.Assert.areEqual("{\"$type\":\"Bridge.ClientTest.SerializationTests+Class3, Bridge.ClientTest\",\"StringProp\":null}", json);
             },
             anonymousTypesWorks: function () {
                 var v = new $asm.$AnonymousType$1(108, "Hello");
                 var json = Bridge.Json.serialize(v);
 
-                Bridge.Test.NUnit.Assert.areEqual(json, "{\"Amount\":108,\"Message\":\"Hello\"}");
+                Bridge.Test.NUnit.Assert.areEqual("{\"Amount\":108,\"Message\":\"Hello\"}", json);
             }
         }
     });

--- a/Tests/Runner/Batch2/Bridge.Test/bridge.clienttest.batch2.runner.js
+++ b/Tests/Runner/Batch2/Bridge.Test/bridge.clienttest.batch2.runner.js
@@ -103,7 +103,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.Bridge1385",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/BridgeIssues/N1385.cs"
+                    file: "Batch2\\BridgeIssues\\N1385.cs"
                 } );
             }
             return this.context;
@@ -127,7 +127,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.Bridge1499",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/BridgeIssues/N1499.cs"
+                    file: "Batch2\\BridgeIssues\\N1499.cs"
                 } );
             }
             return this.context;
@@ -172,7 +172,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.CheckedInsideUncheckedTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
+                    file: "Batch2\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -217,7 +217,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.CheckedTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
+                    file: "Batch2\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -248,7 +248,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.N1122",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/BridgeIssues/N1122.cs"
+                    file: "Batch2\\BridgeIssues\\N1122.cs"
                 } );
             }
             return this.context;
@@ -272,7 +272,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.N1204",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/BridgeIssues/N1204.cs"
+                    file: "Batch2\\BridgeIssues\\N1204.cs"
                 } );
             }
             return this.context;
@@ -632,7 +632,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.BridgeIssues.N772",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/BridgeIssues/N772.cs"
+                    file: "Batch2\\BridgeIssues\\N772.cs"
                 } );
             }
             return this.context;
@@ -677,7 +677,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.UncheckedInsideCheckedTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
+                    file: "Batch2\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -722,7 +722,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.UncheckedTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
+                    file: "Batch2\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;
@@ -767,7 +767,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch2", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch2",
                     className: "Bridge.ClientTest.Batch2.CheckedUncheckedTests.WithNoUncheckedKeywordTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch2/CheckedUncheckedTests.cs"
+                    file: "Batch2\\CheckedUncheckedTests.cs"
                 } );
             }
             return this.context;

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -711,7 +711,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge069",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0100/N069.cs"
+                    file: "Batch3\\BridgeIssues\\0100\\N069.cs"
                 } );
             }
             return this.context;
@@ -735,7 +735,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1000",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1000.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1000.cs"
                 } );
             }
             return this.context;
@@ -759,7 +759,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1001",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1001.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1001.cs"
                 } );
             }
             return this.context;
@@ -783,7 +783,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1003",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1003.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1003.cs"
                 } );
             }
             return this.context;
@@ -828,7 +828,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1012",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1012.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1012.cs"
                 } );
             }
             return this.context;
@@ -859,7 +859,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1020",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1020.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1020.cs"
                 } );
             }
             return this.context;
@@ -883,7 +883,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1024",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1024.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1024.cs"
                 } );
             }
             return this.context;
@@ -998,7 +998,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1025",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1025.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1025.cs"
                 } );
             }
             return this.context;
@@ -1022,7 +1022,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1026",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1026.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1026.cs"
                 } );
             }
             return this.context;
@@ -1046,7 +1046,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1027",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1027.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1027.cs"
                 } );
             }
             return this.context;
@@ -1070,7 +1070,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1029",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1029.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1029.cs"
                 } );
             }
             return this.context;
@@ -1094,7 +1094,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1039",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1039.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1039.cs"
                 } );
             }
             return this.context;
@@ -1139,7 +1139,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Decimal",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1041.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1041.cs"
                 } );
             }
             return this.context;
@@ -1184,7 +1184,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1041.Bridge1041Integer",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1041.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1041.cs"
                 } );
             }
             return this.context;
@@ -1208,7 +1208,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1051",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1051.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1051.cs"
                 } );
             }
             return this.context;
@@ -1232,7 +1232,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1053",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1053.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1053.cs"
                 } );
             }
             return this.context;
@@ -1263,7 +1263,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1058",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1058.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1058.cs"
                 } );
             }
             return this.context;
@@ -1287,7 +1287,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1059",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1059.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1059.cs"
                 } );
             }
             return this.context;
@@ -1311,7 +1311,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1061",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1061.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1061.cs"
                 } );
             }
             return this.context;
@@ -1335,7 +1335,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1065",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1065.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1065.cs"
                 } );
             }
             return this.context;
@@ -1359,7 +1359,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1066",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1066.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1066.cs"
                 } );
             }
             return this.context;
@@ -1383,7 +1383,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1067",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1067.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1067.cs"
                 } );
             }
             return this.context;
@@ -1407,7 +1407,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1071",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1071.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1071.cs"
                 } );
             }
             return this.context;
@@ -1431,7 +1431,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1072",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1172.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1172.cs"
                 } );
             }
             return this.context;
@@ -1462,7 +1462,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1076",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1076.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1076.cs"
                 } );
             }
             return this.context;
@@ -1486,7 +1486,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1081",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1081.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1081.cs"
                 } );
             }
             return this.context;
@@ -1510,7 +1510,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1083",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1083.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1083.cs"
                 } );
             }
             return this.context;
@@ -1534,7 +1534,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1085",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1085.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1085.cs"
                 } );
             }
             return this.context;
@@ -1558,7 +1558,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1096",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1096.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1096.cs"
                 } );
             }
             return this.context;
@@ -1582,7 +1582,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1098",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1000/N1098.cs"
+                    file: "Batch3\\BridgeIssues\\1000\\N1098.cs"
                 } );
             }
             return this.context;
@@ -1606,7 +1606,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1103",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1103.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1103.cs"
                 } );
             }
             return this.context;
@@ -1630,7 +1630,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1105",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1105.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1105.cs"
                 } );
             }
             return this.context;
@@ -1654,7 +1654,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1109",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1109.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1109.cs"
                 } );
             }
             return this.context;
@@ -1692,7 +1692,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1110",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1110.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1110.cs"
                 } );
             }
             return this.context;
@@ -1723,7 +1723,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1120",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1120.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1120.cs"
                 } );
             }
             return this.context;
@@ -1747,7 +1747,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1128",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1128.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1128.cs"
                 } );
             }
             return this.context;
@@ -1771,7 +1771,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1130",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1130.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1130.cs"
                 } );
             }
             return this.context;
@@ -1795,7 +1795,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1134",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1134.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1134.cs"
                 } );
             }
             return this.context;
@@ -1819,7 +1819,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1140",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1140.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1140.cs"
                 } );
             }
             return this.context;
@@ -1843,7 +1843,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1141",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1141.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1141.cs"
                 } );
             }
             return this.context;
@@ -1867,7 +1867,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1144",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1144.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1144.cs"
                 } );
             }
             return this.context;
@@ -1891,7 +1891,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1146",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1146.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1146.cs"
                 } );
             }
             return this.context;
@@ -1915,7 +1915,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1149",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1149.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1149.cs"
                 } );
             }
             return this.context;
@@ -1939,7 +1939,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1160",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1160.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1160.cs"
                 } );
             }
             return this.context;
@@ -1970,7 +1970,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1170",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1170.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1170.cs"
                 } );
             }
             return this.context;
@@ -1994,7 +1994,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1171",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1171.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1171.cs"
                 } );
             }
             return this.context;
@@ -2018,7 +2018,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1175",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1175.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1175.cs"
                 } );
             }
             return this.context;
@@ -2042,7 +2042,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1176",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1176.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1176.cs"
                 } );
             }
             return this.context;
@@ -2066,7 +2066,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1177",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1177.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1177.cs"
                 } );
             }
             return this.context;
@@ -2090,7 +2090,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1180",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1180.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1180.cs"
                 } );
             }
             return this.context;
@@ -2114,7 +2114,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1184",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1184.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1184.cs"
                 } );
             }
             return this.context;
@@ -2138,7 +2138,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1186",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1186.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1186.cs"
                 } );
             }
             return this.context;
@@ -2162,7 +2162,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1189",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1189.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1189.cs"
                 } );
             }
             return this.context;
@@ -2186,7 +2186,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1193",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1193.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1193.cs"
                 } );
             }
             return this.context;
@@ -2210,7 +2210,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1197",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1197.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1197.cs"
                 } );
             }
             return this.context;
@@ -2234,7 +2234,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1199",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1199.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1199.cs"
                 } );
             }
             return this.context;
@@ -2321,7 +2321,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1202",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1202.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1202.cs"
                 } );
             }
             return this.context;
@@ -2345,7 +2345,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1203",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1203.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1203.cs"
                 } );
             }
             return this.context;
@@ -2369,7 +2369,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1206",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1206.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1206.cs"
                 } );
             }
             return this.context;
@@ -2393,7 +2393,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1217",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1217.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1217.cs"
                 } );
             }
             return this.context;
@@ -2417,7 +2417,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1219",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1219.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1219.cs"
                 } );
             }
             return this.context;
@@ -2441,7 +2441,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge122",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0100/N122.cs"
+                    file: "Batch3\\BridgeIssues\\0100\\N122.cs"
                 } );
             }
             return this.context;
@@ -2465,7 +2465,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1220",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1220.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1220.cs"
                 } );
             }
             return this.context;
@@ -2503,7 +2503,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1226",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1226.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1226.cs"
                 } );
             }
             return this.context;
@@ -2527,7 +2527,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1231",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1231.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1231.cs"
                 } );
             }
             return this.context;
@@ -2558,7 +2558,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1232",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1232.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1232.cs"
                 } );
             }
             return this.context;
@@ -2582,7 +2582,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1241",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1241.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1241.cs"
                 } );
             }
             return this.context;
@@ -2606,7 +2606,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1249",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1249.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1249.cs"
                 } );
             }
             return this.context;
@@ -2630,7 +2630,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1253",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1253.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1253.cs"
                 } );
             }
             return this.context;
@@ -2668,7 +2668,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1256",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1256.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1256.cs"
                 } );
             }
             return this.context;
@@ -2706,7 +2706,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1260",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1260.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1260.cs"
                 } );
             }
             return this.context;
@@ -2730,7 +2730,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1264",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1264.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1264.cs"
                 } );
             }
             return this.context;
@@ -2754,7 +2754,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1266",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1266.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1266.cs"
                 } );
             }
             return this.context;
@@ -2778,7 +2778,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge1290",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -2802,7 +2802,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge1292",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -2840,7 +2840,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1296",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1296.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1296.cs"
                 } );
             }
             return this.context;
@@ -2864,7 +2864,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1298",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1200/N1298.cs"
+                    file: "Batch3\\BridgeIssues\\1200\\N1298.cs"
                 } );
             }
             return this.context;
@@ -2888,7 +2888,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge1301",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -2929,7 +2929,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1304",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1304.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1304.cs"
                 } );
             }
             return this.context;
@@ -2973,7 +2973,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1305",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1305.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1305.cs"
                 } );
             }
             return this.context;
@@ -2997,7 +2997,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge1309",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -3021,7 +3021,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1311",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1311.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1311.cs"
                 } );
             }
             return this.context;
@@ -3045,7 +3045,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge1312",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -3076,7 +3076,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1313",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1313.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1313.cs"
                 } );
             }
             return this.context;
@@ -3121,7 +3121,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1316",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1316.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1316.cs"
                 } );
             }
             return this.context;
@@ -3145,7 +3145,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge1317",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -3176,7 +3176,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1328",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1328.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1328.cs"
                 } );
             }
             return this.context;
@@ -3200,7 +3200,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1339",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1339.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1339.cs"
                 } );
             }
             return this.context;
@@ -3322,7 +3322,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1340",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1340.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1340.cs"
                 } );
             }
             return this.context;
@@ -3402,7 +3402,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1341",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1341.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1341.cs"
                 } );
             }
             return this.context;
@@ -3433,7 +3433,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1343",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1343.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1343.cs"
                 } );
             }
             return this.context;
@@ -3457,7 +3457,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1344",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1344.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1344.cs"
                 } );
             }
             return this.context;
@@ -3481,7 +3481,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1345",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1345.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1345.cs"
                 } );
             }
             return this.context;
@@ -3505,7 +3505,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge1347",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -3529,7 +3529,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1348",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1348.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1348.cs"
                 } );
             }
             return this.context;
@@ -3553,7 +3553,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1355",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1355.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1355.cs"
                 } );
             }
             return this.context;
@@ -3577,7 +3577,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge1357",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -3629,7 +3629,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1374",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1374.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1374.cs"
                 } );
             }
             return this.context;
@@ -3688,7 +3688,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1378",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1378.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1378.cs"
                 } );
             }
             return this.context;
@@ -3712,7 +3712,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1379",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1379.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1379.cs"
                 } );
             }
             return this.context;
@@ -3743,7 +3743,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1381",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1381.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1381.cs"
                 } );
             }
             return this.context;
@@ -3767,7 +3767,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1385",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1385.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1385.cs"
                 } );
             }
             return this.context;
@@ -3791,7 +3791,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1389",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1389.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1389.cs"
                 } );
             }
             return this.context;
@@ -3815,7 +3815,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1391",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1391.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1391.cs"
                 } );
             }
             return this.context;
@@ -3839,7 +3839,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1391Ready",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1300/N1391.cs"
+                    file: "Batch3\\BridgeIssues\\1300\\N1391.cs"
                 } );
             }
             return this.context;
@@ -3863,7 +3863,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1402",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1402.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1402.cs"
                 } );
             }
             return this.context;
@@ -3901,7 +3901,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1410",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1410.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1410.cs"
                 } );
             }
             return this.context;
@@ -3939,7 +3939,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1411",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1411.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1411.cs"
                 } );
             }
             return this.context;
@@ -3963,7 +3963,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1428",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1428.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1428.cs"
                 } );
             }
             return this.context;
@@ -3987,7 +3987,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1429",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1429.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1429.cs"
                 } );
             }
             return this.context;
@@ -4011,7 +4011,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1430",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1430.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1430.cs"
                 } );
             }
             return this.context;
@@ -4042,7 +4042,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1438",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1438.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1438.cs"
                 } );
             }
             return this.context;
@@ -4080,7 +4080,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1448",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1448.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1448.cs"
                 } );
             }
             return this.context;
@@ -4109,7 +4109,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1458",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1458.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1458.cs"
                 } );
             }
             return this.context;
@@ -4139,7 +4139,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1459",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1459.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1459.cs"
                 } );
             }
             return this.context;
@@ -4163,7 +4163,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1467",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1467.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1467.cs"
                 } );
             }
             return this.context;
@@ -4194,7 +4194,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1472",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1472.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1472.cs"
                 } );
             }
             return this.context;
@@ -4218,7 +4218,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1476",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1476.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1476.cs"
                 } );
             }
             return this.context;
@@ -4242,7 +4242,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1480",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1480.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1480.cs"
                 } );
             }
             return this.context;
@@ -4266,7 +4266,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1485",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1485.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1485.cs"
                 } );
             }
             return this.context;
@@ -4311,7 +4311,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1486",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1486.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1486.cs"
                 } );
             }
             return this.context;
@@ -4342,7 +4342,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1489",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1489.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1489.cs"
                 } );
             }
             return this.context;
@@ -4366,7 +4366,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1490",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1490.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1490.cs"
                 } );
             }
             return this.context;
@@ -4390,7 +4390,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1492",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1492.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1492.cs"
                 } );
             }
             return this.context;
@@ -4414,7 +4414,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1493",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1493.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1493.cs"
                 } );
             }
             return this.context;
@@ -4438,7 +4438,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1499",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1400/N1499.cs"
+                    file: "Batch3\\BridgeIssues\\1400\\N1499.cs"
                 } );
             }
             return this.context;
@@ -4462,7 +4462,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1501",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1501.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1501.cs"
                 } );
             }
             return this.context;
@@ -4486,7 +4486,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1509",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1509.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1509.cs"
                 } );
             }
             return this.context;
@@ -4510,7 +4510,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1510",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1510.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1510.cs"
                 } );
             }
             return this.context;
@@ -4534,7 +4534,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1511",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1511.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1511.cs"
                 } );
             }
             return this.context;
@@ -4558,7 +4558,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1512",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1512.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1512.cs"
                 } );
             }
             return this.context;
@@ -4582,7 +4582,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge1514",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -4613,7 +4613,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1517",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1517.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1517.cs"
                 } );
             }
             return this.context;
@@ -4637,7 +4637,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1518",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1518.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1518.cs"
                 } );
             }
             return this.context;
@@ -4661,7 +4661,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1519",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1519.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1519.cs"
                 } );
             }
             return this.context;
@@ -4699,7 +4699,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1520",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1520.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1520.cs"
                 } );
             }
             return this.context;
@@ -4723,7 +4723,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1521",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1521.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1521.cs"
                 } );
             }
             return this.context;
@@ -4747,7 +4747,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1522",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1522.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1522.cs"
                 } );
             }
             return this.context;
@@ -4771,7 +4771,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1523",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1523.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1523.cs"
                 } );
             }
             return this.context;
@@ -4795,7 +4795,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1524",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1524.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1524.cs"
                 } );
             }
             return this.context;
@@ -4826,7 +4826,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1526",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1526.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1526.cs"
                 } );
             }
             return this.context;
@@ -4850,7 +4850,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1527",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1527.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1527.cs"
                 } );
             }
             return this.context;
@@ -4874,7 +4874,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1530",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1530.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1530.cs"
                 } );
             }
             return this.context;
@@ -4898,7 +4898,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1533",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1533.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1533.cs"
                 } );
             }
             return this.context;
@@ -4922,7 +4922,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1535",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1535.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1535.cs"
                 } );
             }
             return this.context;
@@ -4953,7 +4953,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1536",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1536.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1536.cs"
                 } );
             }
             return this.context;
@@ -4977,7 +4977,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1538",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1538.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1538.cs"
                 } );
             }
             return this.context;
@@ -5015,7 +5015,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1566",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1566.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1566.cs"
                 } );
             }
             return this.context;
@@ -5039,7 +5039,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1579",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1579.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1579.cs"
                 } );
             }
             return this.context;
@@ -5063,7 +5063,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1599",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1500/N1599.cs"
+                    file: "Batch3\\BridgeIssues\\1500\\N1599.cs"
                 } );
             }
             return this.context;
@@ -5087,7 +5087,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1600",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1600/N1600.cs"
+                    file: "Batch3\\BridgeIssues\\1600\\N1600.cs"
                 } );
             }
             return this.context;
@@ -5111,7 +5111,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1641",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1600/N1641.cs"
+                    file: "Batch3\\BridgeIssues\\1600\\N1641.cs"
                 } );
             }
             return this.context;
@@ -5135,7 +5135,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1653",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1600/N1653.cs"
+                    file: "Batch3\\BridgeIssues\\1600\\N1653.cs"
                 } );
             }
             return this.context;
@@ -5159,7 +5159,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1684",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1600/N1684.cs"
+                    file: "Batch3\\BridgeIssues\\1600\\N1684.cs"
                 } );
             }
             return this.context;
@@ -5188,7 +5188,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1698",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1600/N1698.cs"
+                    file: "Batch3\\BridgeIssues\\1600\\N1698.cs"
                 } );
             }
             return this.context;
@@ -5225,7 +5225,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1700",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1700.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1700.cs"
                 } );
             }
             return this.context;
@@ -5249,7 +5249,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1702",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1702.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1702.cs"
                 } );
             }
             return this.context;
@@ -5273,7 +5273,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1704",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1704.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1704.cs"
                 } );
             }
             return this.context;
@@ -5297,7 +5297,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1709",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1709.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1709.cs"
                 } );
             }
             return this.context;
@@ -5321,7 +5321,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1711",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1711.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1711.cs"
                 } );
             }
             return this.context;
@@ -5359,7 +5359,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1712",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1712.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1712.cs"
                 } );
             }
             return this.context;
@@ -5383,7 +5383,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1713",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1713.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1713.cs"
                 } );
             }
             return this.context;
@@ -5414,7 +5414,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1713MSDN",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1713.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1713.cs"
                 } );
             }
             return this.context;
@@ -5438,7 +5438,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1715",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1715.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1715.cs"
                 } );
             }
             return this.context;
@@ -5462,7 +5462,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1721",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1721.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1721.cs"
                 } );
             }
             return this.context;
@@ -5493,7 +5493,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1722",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1722.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1722.cs"
                 } );
             }
             return this.context;
@@ -5531,7 +5531,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1735",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1735.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1735.cs"
                 } );
             }
             return this.context;
@@ -5555,7 +5555,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1737",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1737.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1737.cs"
                 } );
             }
             return this.context;
@@ -5579,7 +5579,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1741",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1741.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1741.cs"
                 } );
             }
             return this.context;
@@ -5603,7 +5603,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1744",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1744.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1744.cs"
                 } );
             }
             return this.context;
@@ -5627,7 +5627,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1754",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1754.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1754.cs"
                 } );
             }
             return this.context;
@@ -5651,7 +5651,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1767",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1767.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1767.cs"
                 } );
             }
             return this.context;
@@ -5696,7 +5696,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1768",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1768.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1768.cs"
                 } );
             }
             return this.context;
@@ -5720,7 +5720,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1775",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1775.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1775.cs"
                 } );
             }
             return this.context;
@@ -5744,7 +5744,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1776",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1776.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1776.cs"
                 } );
             }
             return this.context;
@@ -5768,7 +5768,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1787",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1700/N1787.cs"
+                    file: "Batch3\\BridgeIssues\\1700\\N1787.cs"
                 } );
             }
             return this.context;
@@ -5792,7 +5792,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1802",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1802.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1802.cs"
                 } );
             }
             return this.context;
@@ -5816,7 +5816,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1803",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1803.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1803.cs"
                 } );
             }
             return this.context;
@@ -5840,7 +5840,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1804",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1804.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1804.cs"
                 } );
             }
             return this.context;
@@ -5864,7 +5864,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1810",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1810.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1810.cs"
                 } );
             }
             return this.context;
@@ -5888,7 +5888,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1812",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1812.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1812.cs"
                 } );
             }
             return this.context;
@@ -5912,7 +5912,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1813",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1813.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1813.cs"
                 } );
             }
             return this.context;
@@ -5936,7 +5936,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1814",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1814.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1814.cs"
                 } );
             }
             return this.context;
@@ -5960,7 +5960,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1819",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1819.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1819.cs"
                 } );
             }
             return this.context;
@@ -5991,7 +5991,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1821",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1821.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1821.cs"
                 } );
             }
             return this.context;
@@ -6015,7 +6015,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1832",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1832.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1832.cs"
                 } );
             }
             return this.context;
@@ -6039,7 +6039,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1833",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1833.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1833.cs"
                 } );
             }
             return this.context;
@@ -6063,7 +6063,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1834",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1834.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1834.cs"
                 } );
             }
             return this.context;
@@ -6087,7 +6087,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1835",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1835.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1835.cs"
                 } );
             }
             return this.context;
@@ -6111,7 +6111,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1842",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1842.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1842.cs"
                 } );
             }
             return this.context;
@@ -6135,7 +6135,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1845",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1845.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1845.cs"
                 } );
             }
             return this.context;
@@ -6159,7 +6159,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1846",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1846.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1846.cs"
                 } );
             }
             return this.context;
@@ -6183,7 +6183,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1847",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1847.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1847.cs"
                 } );
             }
             return this.context;
@@ -6207,7 +6207,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1848",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1848.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1848.cs"
                 } );
             }
             return this.context;
@@ -6231,7 +6231,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1850",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1850.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1850.cs"
                 } );
             }
             return this.context;
@@ -6255,7 +6255,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1852",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1852.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1852.cs"
                 } );
             }
             return this.context;
@@ -6279,7 +6279,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1853",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1853.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1853.cs"
                 } );
             }
             return this.context;
@@ -6303,7 +6303,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1854",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1854.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1854.cs"
                 } );
             }
             return this.context;
@@ -6327,7 +6327,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1856",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1856.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1856.cs"
                 } );
             }
             return this.context;
@@ -6351,7 +6351,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1863",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1863.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1863.cs"
                 } );
             }
             return this.context;
@@ -6375,7 +6375,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1865",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1865.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1865.cs"
                 } );
             }
             return this.context;
@@ -6399,7 +6399,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1869",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1869.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1869.cs"
                 } );
             }
             return this.context;
@@ -6423,7 +6423,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1871",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1871.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1871.cs"
                 } );
             }
             return this.context;
@@ -6447,7 +6447,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1872",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1872.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1872.cs"
                 } );
             }
             return this.context;
@@ -6471,7 +6471,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1875",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1875.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1875.cs"
                 } );
             }
             return this.context;
@@ -6495,7 +6495,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1878",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1878.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1878.cs"
                 } );
             }
             return this.context;
@@ -6519,7 +6519,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1880",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1880.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1880.cs"
                 } );
             }
             return this.context;
@@ -6550,7 +6550,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1882",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1882.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1882.cs"
                 } );
             }
             return this.context;
@@ -6574,7 +6574,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1884",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1884.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1884.cs"
                 } );
             }
             return this.context;
@@ -6598,7 +6598,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1886",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1886.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1886.cs"
                 } );
             }
             return this.context;
@@ -6622,7 +6622,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1892",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1892.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1892.cs"
                 } );
             }
             return this.context;
@@ -6646,7 +6646,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1896",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1896.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1896.cs"
                 } );
             }
             return this.context;
@@ -6670,7 +6670,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1897",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1897.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1897.cs"
                 } );
             }
             return this.context;
@@ -6694,7 +6694,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1899",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1800/N1899.cs"
+                    file: "Batch3\\BridgeIssues\\1800\\N1899.cs"
                 } );
             }
             return this.context;
@@ -6718,7 +6718,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1900",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1900.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1900.cs"
                 } );
             }
             return this.context;
@@ -6742,7 +6742,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1904",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1904.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1904.cs"
                 } );
             }
             return this.context;
@@ -6766,7 +6766,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1906",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1906.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1906.cs"
                 } );
             }
             return this.context;
@@ -6790,7 +6790,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1909",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1909.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1909.cs"
                 } );
             }
             return this.context;
@@ -6814,7 +6814,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1910",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1910.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1910.cs"
                 } );
             }
             return this.context;
@@ -6845,7 +6845,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1911",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1911.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1911.cs"
                 } );
             }
             return this.context;
@@ -6869,7 +6869,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1912",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1912.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1912.cs"
                 } );
             }
             return this.context;
@@ -6893,7 +6893,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1913",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1913.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1913.cs"
                 } );
             }
             return this.context;
@@ -6917,7 +6917,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1914",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1914.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1914.cs"
                 } );
             }
             return this.context;
@@ -6941,7 +6941,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1915",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1915.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1915.cs"
                 } );
             }
             return this.context;
@@ -6965,7 +6965,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1920",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1920.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1920.cs"
                 } );
             }
             return this.context;
@@ -6989,7 +6989,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1933",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1933.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1933.cs"
                 } );
             }
             return this.context;
@@ -7013,7 +7013,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1934",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1934.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1934.cs"
                 } );
             }
             return this.context;
@@ -7037,7 +7037,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1938",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1938.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1938.cs"
                 } );
             }
             return this.context;
@@ -7061,7 +7061,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1948",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1948.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1948.cs"
                 } );
             }
             return this.context;
@@ -7085,7 +7085,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1951",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1951.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1951.cs"
                 } );
             }
             return this.context;
@@ -7109,7 +7109,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1955",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1955.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1955.cs"
                 } );
             }
             return this.context;
@@ -7133,7 +7133,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1964",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1964.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1964.cs"
                 } );
             }
             return this.context;
@@ -7157,7 +7157,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1965",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1965.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1965.cs"
                 } );
             }
             return this.context;
@@ -7181,7 +7181,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1966",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1966.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1966.cs"
                 } );
             }
             return this.context;
@@ -7205,7 +7205,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1968",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1968.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1968.cs"
                 } );
             }
             return this.context;
@@ -7229,7 +7229,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1969",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1969.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1969.cs"
                 } );
             }
             return this.context;
@@ -7253,7 +7253,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1970",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1970.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1970.cs"
                 } );
             }
             return this.context;
@@ -7277,7 +7277,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge1996",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1900/N1996.cs"
+                    file: "Batch3\\BridgeIssues\\1900\\N1996.cs"
                 } );
             }
             return this.context;
@@ -7301,7 +7301,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2003",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2003.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2003.cs"
                 } );
             }
             return this.context;
@@ -7325,7 +7325,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2011",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2011.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2011.cs"
                 } );
             }
             return this.context;
@@ -7349,7 +7349,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2013",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2013.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2013.cs"
                 } );
             }
             return this.context;
@@ -7373,7 +7373,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2019",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2019.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2019.cs"
                 } );
             }
             return this.context;
@@ -7397,7 +7397,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2024",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2024.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2024.cs"
                 } );
             }
             return this.context;
@@ -7421,7 +7421,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2027",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2027.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2027.cs"
                 } );
             }
             return this.context;
@@ -7445,7 +7445,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2033",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2033.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2033.cs"
                 } );
             }
             return this.context;
@@ -7469,7 +7469,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2038",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2038.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2038.cs"
                 } );
             }
             return this.context;
@@ -7493,7 +7493,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2039",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2039.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2039.cs"
                 } );
             }
             return this.context;
@@ -7517,7 +7517,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2042",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2042.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2042.cs"
                 } );
             }
             return this.context;
@@ -7541,7 +7541,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2045",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2045.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2045.cs"
                 } );
             }
             return this.context;
@@ -7565,7 +7565,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2046",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2046.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2046.cs"
                 } );
             }
             return this.context;
@@ -7589,7 +7589,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2048",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2048.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2048.cs"
                 } );
             }
             return this.context;
@@ -7613,7 +7613,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2049",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2049.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2049.cs"
                 } );
             }
             return this.context;
@@ -7644,7 +7644,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2050",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2050.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2050.cs"
                 } );
             }
             return this.context;
@@ -7668,7 +7668,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2051",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2051.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2051.cs"
                 } );
             }
             return this.context;
@@ -7699,7 +7699,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2052",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2052.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2052.cs"
                 } );
             }
             return this.context;
@@ -7730,7 +7730,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2056",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2056.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2056.cs"
                 } );
             }
             return this.context;
@@ -7754,7 +7754,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2077.Bridge2065",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2077.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2077.cs"
                 } );
             }
             return this.context;
@@ -7778,7 +7778,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2067",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2067.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2067.cs"
                 } );
             }
             return this.context;
@@ -7802,7 +7802,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2068",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2068.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2068.cs"
                 } );
             }
             return this.context;
@@ -7826,7 +7826,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2073",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2073.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2073.cs"
                 } );
             }
             return this.context;
@@ -7850,7 +7850,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2076",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2076.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2076.cs"
                 } );
             }
             return this.context;
@@ -7874,7 +7874,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2079",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2079.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2079.cs"
                 } );
             }
             return this.context;
@@ -7905,7 +7905,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2080",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2080.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2080.cs"
                 } );
             }
             return this.context;
@@ -7929,7 +7929,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2081",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2081.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2081.cs"
                 } );
             }
             return this.context;
@@ -7953,7 +7953,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2088",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2088.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2088.cs"
                 } );
             }
             return this.context;
@@ -7977,7 +7977,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2092",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2092.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2092.cs"
                 } );
             }
             return this.context;
@@ -8001,7 +8001,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2094",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2000/N2094.cs"
+                    file: "Batch3\\BridgeIssues\\2000\\N2094.cs"
                 } );
             }
             return this.context;
@@ -8025,7 +8025,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2106",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2106.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2106.cs"
                 } );
             }
             return this.context;
@@ -8056,7 +8056,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2114",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2114.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2114.cs"
                 } );
             }
             return this.context;
@@ -8080,7 +8080,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2121",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2121.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2121.cs"
                 } );
             }
             return this.context;
@@ -8104,7 +8104,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2127",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2127.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2127.cs"
                 } );
             }
             return this.context;
@@ -8128,7 +8128,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2135",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2135.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2135.cs"
                 } );
             }
             return this.context;
@@ -8152,7 +8152,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2137.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2137.cs"
                 } );
             }
             return this.context;
@@ -8176,7 +8176,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2138",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2138.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2138.cs"
                 } );
             }
             return this.context;
@@ -8200,7 +8200,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2141",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2141.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2141.cs"
                 } );
             }
             return this.context;
@@ -8224,7 +8224,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2143",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2143.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2143.cs"
                 } );
             }
             return this.context;
@@ -8248,7 +8248,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2146",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2146.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2146.cs"
                 } );
             }
             return this.context;
@@ -8272,7 +8272,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2147",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2147.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2147.cs"
                 } );
             }
             return this.context;
@@ -8296,7 +8296,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2156",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2156.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2156.cs"
                 } );
             }
             return this.context;
@@ -8320,7 +8320,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2157",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2157.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2157.cs"
                 } );
             }
             return this.context;
@@ -8344,7 +8344,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2159",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2160.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2160.cs"
                 } );
             }
             return this.context;
@@ -8368,7 +8368,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2160",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2159.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2159.cs"
                 } );
             }
             return this.context;
@@ -8392,7 +8392,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2163",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2163.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2163.cs"
                 } );
             }
             return this.context;
@@ -8416,7 +8416,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2167",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2167.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2167.cs"
                 } );
             }
             return this.context;
@@ -8440,7 +8440,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2174",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2174.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2174.cs"
                 } );
             }
             return this.context;
@@ -8464,7 +8464,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2176",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2176.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2176.cs"
                 } );
             }
             return this.context;
@@ -8488,7 +8488,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2181",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2181.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2181.cs"
                 } );
             }
             return this.context;
@@ -8517,7 +8517,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2186",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2186.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2186.cs"
                 } );
             }
             return this.context;
@@ -8547,7 +8547,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2189",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2189.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2189.cs"
                 } );
             }
             return this.context;
@@ -8571,7 +8571,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2190",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2190.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2190.cs"
                 } );
             }
             return this.context;
@@ -8595,7 +8595,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2192",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2192.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2192.cs"
                 } );
             }
             return this.context;
@@ -8619,7 +8619,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2195",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2195.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2195.cs"
                 } );
             }
             return this.context;
@@ -8643,7 +8643,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2199",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2100/N2199.cs"
+                    file: "Batch3\\BridgeIssues\\2100\\N2199.cs"
                 } );
             }
             return this.context;
@@ -8667,7 +8667,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2200",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2200.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2200.cs"
                 } );
             }
             return this.context;
@@ -8691,7 +8691,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2203",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2203.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2203.cs"
                 } );
             }
             return this.context;
@@ -8715,7 +8715,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2204",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2204.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2204.cs"
                 } );
             }
             return this.context;
@@ -8739,7 +8739,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2207",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2207.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2207.cs"
                 } );
             }
             return this.context;
@@ -8763,7 +8763,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2210",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2210.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2210.cs"
                 } );
             }
             return this.context;
@@ -8787,7 +8787,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2211",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2211.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2211.cs"
                 } );
             }
             return this.context;
@@ -8811,7 +8811,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2212",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2212.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2212.cs"
                 } );
             }
             return this.context;
@@ -8835,7 +8835,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2213",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2213.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2213.cs"
                 } );
             }
             return this.context;
@@ -8859,7 +8859,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2214",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2214.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2214.cs"
                 } );
             }
             return this.context;
@@ -8883,7 +8883,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2216",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2216.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2216.cs"
                 } );
             }
             return this.context;
@@ -8907,7 +8907,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2220",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2220.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2220.cs"
                 } );
             }
             return this.context;
@@ -8931,7 +8931,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2221",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2221.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2221.cs"
                 } );
             }
             return this.context;
@@ -8955,7 +8955,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2222",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2222.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2222.cs"
                 } );
             }
             return this.context;
@@ -8979,7 +8979,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2225",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2225.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2225.cs"
                 } );
             }
             return this.context;
@@ -9003,7 +9003,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2243",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2243.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2243.cs"
                 } );
             }
             return this.context;
@@ -9027,7 +9027,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2246",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2246.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2246.cs"
                 } );
             }
             return this.context;
@@ -9051,7 +9051,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2249",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2249.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2249.cs"
                 } );
             }
             return this.context;
@@ -9075,7 +9075,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2251",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2251.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2251.cs"
                 } );
             }
             return this.context;
@@ -9099,7 +9099,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2278",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2278.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2278.cs"
                 } );
             }
             return this.context;
@@ -9123,7 +9123,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2279",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2279.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2279.cs"
                 } );
             }
             return this.context;
@@ -9147,7 +9147,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2280",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2280.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2280.cs"
                 } );
             }
             return this.context;
@@ -9171,7 +9171,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2281",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2281.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2281.cs"
                 } );
             }
             return this.context;
@@ -9195,7 +9195,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2284",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2284.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2284.cs"
                 } );
             }
             return this.context;
@@ -9219,7 +9219,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2293",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2293.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2293.cs"
                 } );
             }
             return this.context;
@@ -9243,7 +9243,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2298",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2200/N2298.cs"
+                    file: "Batch3\\BridgeIssues\\2200\\N2298.cs"
                 } );
             }
             return this.context;
@@ -9267,7 +9267,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2310",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2310.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2310.cs"
                 } );
             }
             return this.context;
@@ -9305,7 +9305,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2313",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2313.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2313.cs"
                 } );
             }
             return this.context;
@@ -9329,7 +9329,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2318",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2318.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2318.cs"
                 } );
             }
             return this.context;
@@ -9353,7 +9353,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2320",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2320.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2320.cs"
                 } );
             }
             return this.context;
@@ -9377,7 +9377,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2322",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2322.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2322.cs"
                 } );
             }
             return this.context;
@@ -9401,7 +9401,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2327",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2327.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2327.cs"
                 } );
             }
             return this.context;
@@ -9425,7 +9425,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2330",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2330.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2330.cs"
                 } );
             }
             return this.context;
@@ -9449,7 +9449,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2337",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2337.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2337.cs"
                 } );
             }
             return this.context;
@@ -9473,7 +9473,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2338",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2338.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2338.cs"
                 } );
             }
             return this.context;
@@ -9497,7 +9497,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2342",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2342.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2342.cs"
                 } );
             }
             return this.context;
@@ -9521,7 +9521,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2343",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2343.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2343.cs"
                 } );
             }
             return this.context;
@@ -9545,7 +9545,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2344",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2344.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2344.cs"
                 } );
             }
             return this.context;
@@ -9604,7 +9604,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2345",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2345.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2345.cs"
                 } );
             }
             return this.context;
@@ -9628,7 +9628,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2347",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2347.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2347.cs"
                 } );
             }
             return this.context;
@@ -9652,7 +9652,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2349",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2349.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2349.cs"
                 } );
             }
             return this.context;
@@ -9676,7 +9676,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2352",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2352.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2352.cs"
                 } );
             }
             return this.context;
@@ -9714,7 +9714,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2355",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2355.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2355.cs"
                 } );
             }
             return this.context;
@@ -9738,7 +9738,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2359",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2359.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2359.cs"
                 } );
             }
             return this.context;
@@ -9762,7 +9762,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2369",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2369.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2369.cs"
                 } );
             }
             return this.context;
@@ -9786,7 +9786,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2374",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2374.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2374.cs"
                 } );
             }
             return this.context;
@@ -9810,7 +9810,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2375",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2375.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2375.cs"
                 } );
             }
             return this.context;
@@ -9834,7 +9834,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2386",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2386.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2386.cs"
                 } );
             }
             return this.context;
@@ -9858,7 +9858,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2393",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2393.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2393.cs"
                 } );
             }
             return this.context;
@@ -9882,7 +9882,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2399",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2300/N2399.cs"
+                    file: "Batch3\\BridgeIssues\\2300\\N2399.cs"
                 } );
             }
             return this.context;
@@ -9906,7 +9906,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2401",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2400/N2401.cs"
+                    file: "Batch3\\BridgeIssues\\2400\\N2401.cs"
                 } );
             }
             return this.context;
@@ -9930,7 +9930,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2419",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2400/N2420.cs"
+                    file: "Batch3\\BridgeIssues\\2400\\N2420.cs"
                 } );
             }
             return this.context;
@@ -9954,7 +9954,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2430",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/2400/N2430.cs"
+                    file: "Batch3\\BridgeIssues\\2400\\N2430.cs"
                 } );
             }
             return this.context;
@@ -9978,7 +9978,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge381",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0300/N381.cs"
+                    file: "Batch3\\BridgeIssues\\0300\\N381.cs"
                 } );
             }
             return this.context;
@@ -10009,7 +10009,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge447",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0400/N447.cs"
+                    file: "Batch3\\BridgeIssues\\0400\\N447.cs"
                 } );
             }
             return this.context;
@@ -10033,7 +10033,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge472",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0400/N472.cs"
+                    file: "Batch3\\BridgeIssues\\0400\\N472.cs"
                 } );
             }
             return this.context;
@@ -10057,7 +10057,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge479",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0400/N479.cs"
+                    file: "Batch3\\BridgeIssues\\0400\\N479.cs"
                 } );
             }
             return this.context;
@@ -10081,7 +10081,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge483",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0400/N483.cs"
+                    file: "Batch3\\BridgeIssues\\0400\\N483.cs"
                 } );
             }
             return this.context;
@@ -10105,7 +10105,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge485",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0400/N485.cs"
+                    file: "Batch3\\BridgeIssues\\0400\\N485.cs"
                 } );
             }
             return this.context;
@@ -10129,7 +10129,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge495",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0400/N495.cs"
+                    file: "Batch3\\BridgeIssues\\0400\\N495.cs"
                 } );
             }
             return this.context;
@@ -10153,7 +10153,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge501",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N501.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N501.cs"
                 } );
             }
             return this.context;
@@ -10177,7 +10177,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge502",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N502.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N502.cs"
                 } );
             }
             return this.context;
@@ -10201,7 +10201,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge503",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N503.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N503.cs"
                 } );
             }
             return this.context;
@@ -10225,7 +10225,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge508",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N508.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N508.cs"
                 } );
             }
             return this.context;
@@ -10256,7 +10256,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge514",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N514.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N514.cs"
                 } );
             }
             return this.context;
@@ -10280,7 +10280,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge520",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N520.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N520.cs"
                 } );
             }
             return this.context;
@@ -10311,7 +10311,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge522",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N522.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N522.cs"
                 } );
             }
             return this.context;
@@ -10335,7 +10335,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge532",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N532.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N532.cs"
                 } );
             }
             return this.context;
@@ -10359,7 +10359,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge537",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N537A.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N537A.cs"
                 } );
             }
             return this.context;
@@ -10383,7 +10383,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge538",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N538.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N538.cs"
                 } );
             }
             return this.context;
@@ -10414,7 +10414,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge544",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N544.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N544.cs"
                 } );
             }
             return this.context;
@@ -10445,7 +10445,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge546",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N546.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N546.cs"
                 } );
             }
             return this.context;
@@ -10469,7 +10469,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge548",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N548.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N548.cs"
                 } );
             }
             return this.context;
@@ -10493,7 +10493,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge549",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N549.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N549.cs"
                 } );
             }
             return this.context;
@@ -10517,7 +10517,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge550",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N550.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N550.cs"
                 } );
             }
             return this.context;
@@ -10541,7 +10541,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge554",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N554.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N554.cs"
                 } );
             }
             return this.context;
@@ -10565,7 +10565,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge555",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N555.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N555.cs"
                 } );
             }
             return this.context;
@@ -10589,7 +10589,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge558",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N558.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N558.cs"
                 } );
             }
             return this.context;
@@ -10627,7 +10627,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge559",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N559.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N559.cs"
                 } );
             }
             return this.context;
@@ -10658,7 +10658,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge563",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N563.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N563.cs"
                 } );
             }
             return this.context;
@@ -10682,7 +10682,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge566",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N566.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N566.cs"
                 } );
             }
             return this.context;
@@ -10706,7 +10706,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge572",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N572.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N572.cs"
                 } );
             }
             return this.context;
@@ -10730,7 +10730,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge577",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N577.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N577.cs"
                 } );
             }
             return this.context;
@@ -10754,7 +10754,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge578",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N578.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N578.cs"
                 } );
             }
             return this.context;
@@ -10778,7 +10778,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge580",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N580.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N580.cs"
                 } );
             }
             return this.context;
@@ -10830,7 +10830,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge582",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N582.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N582.cs"
                 } );
             }
             return this.context;
@@ -10854,7 +10854,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge583",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N583.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N583.cs"
                 } );
             }
             return this.context;
@@ -10878,7 +10878,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge586",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N586.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N586.cs"
                 } );
             }
             return this.context;
@@ -10902,7 +10902,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge588",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N588.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N588.cs"
                 } );
             }
             return this.context;
@@ -10926,7 +10926,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge588C",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N588.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N588.cs"
                 } );
             }
             return this.context;
@@ -10950,7 +10950,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge592",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N592.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N592.cs"
                 } );
             }
             return this.context;
@@ -10974,7 +10974,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge595",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N595.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N595.cs"
                 } );
             }
             return this.context;
@@ -10998,7 +10998,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge597",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0500/N597.cs"
+                    file: "Batch3\\BridgeIssues\\0500\\N597.cs"
                 } );
             }
             return this.context;
@@ -11029,7 +11029,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge603",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N603.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N603.cs"
                 } );
             }
             return this.context;
@@ -11053,7 +11053,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge606",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N606.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N606.cs"
                 } );
             }
             return this.context;
@@ -11077,7 +11077,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge607",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N607.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N607.cs"
                 } );
             }
             return this.context;
@@ -11101,7 +11101,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge608",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N608.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N608.cs"
                 } );
             }
             return this.context;
@@ -11125,7 +11125,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge615",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N615.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N615.cs"
                 } );
             }
             return this.context;
@@ -11149,7 +11149,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge623",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N623.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N623.cs"
                 } );
             }
             return this.context;
@@ -11173,7 +11173,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge625",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N625.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N625.cs"
                 } );
             }
             return this.context;
@@ -11197,7 +11197,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge634",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N634.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N634.cs"
                 } );
             }
             return this.context;
@@ -11221,7 +11221,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge635",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N635.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N635.cs"
                 } );
             }
             return this.context;
@@ -11245,7 +11245,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge637",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N637.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N637.cs"
                 } );
             }
             return this.context;
@@ -11269,7 +11269,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge647",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N647.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N647.cs"
                 } );
             }
             return this.context;
@@ -11293,7 +11293,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge648",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N648.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N648.cs"
                 } );
             }
             return this.context;
@@ -11317,7 +11317,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge652",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N652.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N652.cs"
                 } );
             }
             return this.context;
@@ -11341,7 +11341,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge655",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N655.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N655.cs"
                 } );
             }
             return this.context;
@@ -11365,7 +11365,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge658",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N658.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N658.cs"
                 } );
             }
             return this.context;
@@ -11389,7 +11389,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge660",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N660.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N660.cs"
                 } );
             }
             return this.context;
@@ -11413,7 +11413,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge661",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N661.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N661.cs"
                 } );
             }
             return this.context;
@@ -11437,7 +11437,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge664",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N664.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N664.cs"
                 } );
             }
             return this.context;
@@ -11461,7 +11461,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge666",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N666.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N666.cs"
                 } );
             }
             return this.context;
@@ -11485,7 +11485,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge671",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N671.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N671.cs"
                 } );
             }
             return this.context;
@@ -11516,7 +11516,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge674",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N674.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N674.cs"
                 } );
             }
             return this.context;
@@ -11540,7 +11540,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge675",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N675.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N675.cs"
                 } );
             }
             return this.context;
@@ -11564,7 +11564,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge687",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N687.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N687.cs"
                 } );
             }
             return this.context;
@@ -11588,7 +11588,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge689",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N689.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N689.cs"
                 } );
             }
             return this.context;
@@ -11619,7 +11619,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge690",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N690.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N690.cs"
                 } );
             }
             return this.context;
@@ -11643,7 +11643,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge691",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N691.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N691.cs"
                 } );
             }
             return this.context;
@@ -11667,7 +11667,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge692",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N692.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N692.cs"
                 } );
             }
             return this.context;
@@ -11691,7 +11691,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge693",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N693.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N693.cs"
                 } );
             }
             return this.context;
@@ -11715,7 +11715,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge694",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N694.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N694.cs"
                 } );
             }
             return this.context;
@@ -11739,7 +11739,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge696",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N696.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N696.cs"
                 } );
             }
             return this.context;
@@ -11763,7 +11763,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge699",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0600/N699.cs"
+                    file: "Batch3\\BridgeIssues\\0600\\N699.cs"
                 } );
             }
             return this.context;
@@ -11787,7 +11787,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge706",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N706.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N706.cs"
                 } );
             }
             return this.context;
@@ -11811,7 +11811,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge708",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N708.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N708.cs"
                 } );
             }
             return this.context;
@@ -11835,7 +11835,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge721",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N721.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N721.cs"
                 } );
             }
             return this.context;
@@ -11859,7 +11859,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge722",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N722.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N722.cs"
                 } );
             }
             return this.context;
@@ -11883,7 +11883,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge726",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N726.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N726.cs"
                 } );
             }
             return this.context;
@@ -11907,7 +11907,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge732",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N732.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N732.cs"
                 } );
             }
             return this.context;
@@ -11931,7 +11931,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge733",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N733.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N733.cs"
                 } );
             }
             return this.context;
@@ -11955,7 +11955,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge743",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N743.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N743.cs"
                 } );
             }
             return this.context;
@@ -11979,7 +11979,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge751",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N751.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N751.cs"
                 } );
             }
             return this.context;
@@ -12003,7 +12003,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge758",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N758.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N758.cs"
                 } );
             }
             return this.context;
@@ -12027,7 +12027,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge760",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N760.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N760.cs"
                 } );
             }
             return this.context;
@@ -12051,7 +12051,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge762",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N762.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N762.cs"
                 } );
             }
             return this.context;
@@ -12075,7 +12075,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge772",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N772.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N772.cs"
                 } );
             }
             return this.context;
@@ -12099,7 +12099,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge777",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N777.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N777.cs"
                 } );
             }
             return this.context;
@@ -12123,7 +12123,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge782",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N782.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N782.cs"
                 } );
             }
             return this.context;
@@ -12147,7 +12147,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge785",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N785.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N785.cs"
                 } );
             }
             return this.context;
@@ -12171,7 +12171,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge786",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N786.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N786.cs"
                 } );
             }
             return this.context;
@@ -12195,7 +12195,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge788",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N788.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N788.cs"
                 } );
             }
             return this.context;
@@ -12219,7 +12219,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge789",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N789.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N789.cs"
                 } );
             }
             return this.context;
@@ -12243,7 +12243,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge793",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N793.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N793.cs"
                 } );
             }
             return this.context;
@@ -12274,7 +12274,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge795",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N795.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N795.cs"
                 } );
             }
             return this.context;
@@ -12298,7 +12298,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge796",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0700/N796.cs"
+                    file: "Batch3\\BridgeIssues\\0700\\N796.cs"
                 } );
             }
             return this.context;
@@ -12322,7 +12322,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge815",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N815.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N815.cs"
                 } );
             }
             return this.context;
@@ -12346,7 +12346,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge816",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N816.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N816.cs"
                 } );
             }
             return this.context;
@@ -12370,7 +12370,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge817",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N817.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N817.cs"
                 } );
             }
             return this.context;
@@ -12394,7 +12394,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge818",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N818.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N818.cs"
                 } );
             }
             return this.context;
@@ -12418,7 +12418,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge821",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N821.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N821.cs"
                 } );
             }
             return this.context;
@@ -12442,7 +12442,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge823",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N823.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N823.cs"
                 } );
             }
             return this.context;
@@ -12466,7 +12466,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge826",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N826.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N826.cs"
                 } );
             }
             return this.context;
@@ -12490,7 +12490,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge830",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N830.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N830.cs"
                 } );
             }
             return this.context;
@@ -12514,7 +12514,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge835",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N835.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N835.cs"
                 } );
             }
             return this.context;
@@ -12538,7 +12538,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge841",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N841.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N841.cs"
                 } );
             }
             return this.context;
@@ -12562,7 +12562,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge844",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N844.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N844.cs"
                 } );
             }
             return this.context;
@@ -12586,7 +12586,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge849",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N849.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N849.cs"
                 } );
             }
             return this.context;
@@ -12610,7 +12610,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge857",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N857.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N857.cs"
                 } );
             }
             return this.context;
@@ -12634,7 +12634,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge861",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N861.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N861.cs"
                 } );
             }
             return this.context;
@@ -12658,7 +12658,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge863",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N863.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N863.cs"
                 } );
             }
             return this.context;
@@ -12682,7 +12682,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge874",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N874.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N874.cs"
                 } );
             }
             return this.context;
@@ -12706,7 +12706,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge881",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N881.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N881.cs"
                 } );
             }
             return this.context;
@@ -12730,7 +12730,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge882",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N882.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N882.cs"
                 } );
             }
             return this.context;
@@ -12754,7 +12754,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge883",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N883.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N883.cs"
                 } );
             }
             return this.context;
@@ -12785,7 +12785,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge889",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N889.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N889.cs"
                 } );
             }
             return this.context;
@@ -12809,7 +12809,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge892",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N892.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N892.cs"
                 } );
             }
             return this.context;
@@ -12833,7 +12833,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge893",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N893.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N893.cs"
                 } );
             }
             return this.context;
@@ -12864,7 +12864,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge898",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0800/N898.cs"
+                    file: "Batch3\\BridgeIssues\\0800\\N898.cs"
                 } );
             }
             return this.context;
@@ -12888,7 +12888,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge905",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N905.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N905.cs"
                 } );
             }
             return this.context;
@@ -12919,7 +12919,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge906",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N906.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N906.cs"
                 } );
             }
             return this.context;
@@ -12943,7 +12943,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge907",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N907.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N907.cs"
                 } );
             }
             return this.context;
@@ -12967,7 +12967,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge912",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N912.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N912.cs"
                 } );
             }
             return this.context;
@@ -12991,7 +12991,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge913",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N913.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N913.cs"
                 } );
             }
             return this.context;
@@ -13015,7 +13015,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge918",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N918.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N918.cs"
                 } );
             }
             return this.context;
@@ -13039,7 +13039,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge922",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N922.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N922.cs"
                 } );
             }
             return this.context;
@@ -13063,7 +13063,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge928",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N928.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N928.cs"
                 } );
             }
             return this.context;
@@ -13087,7 +13087,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge929",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N929.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N929.cs"
                 } );
             }
             return this.context;
@@ -13111,7 +13111,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge930",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N930.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N930.cs"
                 } );
             }
             return this.context;
@@ -13135,7 +13135,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge933",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N933.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N933.cs"
                 } );
             }
             return this.context;
@@ -13159,7 +13159,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge952",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N952.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N952.cs"
                 } );
             }
             return this.context;
@@ -13190,7 +13190,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge968",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N968.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N968.cs"
                 } );
             }
             return this.context;
@@ -13214,7 +13214,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge975",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N975.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N975.cs"
                 } );
             }
             return this.context;
@@ -13245,7 +13245,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge989",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N989.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N989.cs"
                 } );
             }
             return this.context;
@@ -13269,7 +13269,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge991",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N991.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N991.cs"
                 } );
             }
             return this.context;
@@ -13300,7 +13300,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge997",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N997.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N997.cs"
                 } );
             }
             return this.context;
@@ -13324,7 +13324,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge999",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N999.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N999.cs"
                 } );
             }
             return this.context;
@@ -13348,7 +13348,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge999_1",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/0900/N999.cs"
+                    file: "Batch3\\BridgeIssues\\0900\\N999.cs"
                 } );
             }
             return this.context;
@@ -13400,7 +13400,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.N1122",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/1100/N1122.cs"
+                    file: "Batch3\\BridgeIssues\\1100\\N1122.cs"
                 } );
             }
             return this.context;
@@ -13711,7 +13711,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.TestBridgeIssues",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch3/BridgeIssues/TestBridgeIssues.cs"
+                    file: "Batch3\\BridgeIssues\\TestBridgeIssues.cs"
                 } );
             }
             return this.context;

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -8141,7 +8141,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertiesWithNonPrimitiveInitializers: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2137, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertiesWithNonPrimitiveInitializers()",
-                    line: "24"
+                    line: "21"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137.testPropertiesWithNonPrimitiveInitializers();
             }
@@ -9040,7 +9040,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertyInitializerWithDirective: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2249).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2249, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertyInitializerWithDirective()",
-                    line: "23"
+                    line: "22"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2249.testPropertyInitializerWithDirective();
             }
@@ -9112,7 +9112,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertyWithInitializerAndNestedClass: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2279).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2279, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertyWithInitializerAndNestedClass()",
-                    line: "25"
+                    line: "23"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2279.testPropertyWithInitializerAndNestedClass();
             }
@@ -9256,7 +9256,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testBridgeFields: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2310).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2310, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestBridgeFields()",
-                    line: "97"
+                    line: "95"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2310.testBridgeFields();
             }
@@ -9775,7 +9775,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertyInitializer: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2374).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2374, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertyInitializer()",
-                    line: "20"
+                    line: "18"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2374.testPropertyInitializer();
             }
@@ -9799,7 +9799,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testNameofWithReflection: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2375).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2375, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestNameofWithReflection()",
-                    line: "18"
+                    line: "17"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2375.testNameofWithReflection();
             }
@@ -11776,7 +11776,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testFieldPropertyWithInitializer: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge706).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge706, 1, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestFieldPropertyWithInitializer()",
-                    line: "18"
+                    line: "17"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge706.testFieldPropertyWithInitializer();
             }

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -8140,7 +8140,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertiesWithNonPrimitiveInitializers: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2137, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertiesWithNonPrimitiveInitializers()",
-                    line: "21"
+                    line: "24"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2137.testPropertiesWithNonPrimitiveInitializers();
             }
@@ -9039,7 +9039,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertyInitializerWithDirective: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2249).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2249, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertyInitializerWithDirective()",
-                    line: "22"
+                    line: "23"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2249.testPropertyInitializerWithDirective();
             }
@@ -9111,7 +9111,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertyWithInitializerAndNestedClass: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2279).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2279, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertyWithInitializerAndNestedClass()",
-                    line: "23"
+                    line: "25"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2279.testPropertyWithInitializerAndNestedClass();
             }
@@ -9255,7 +9255,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testBridgeFields: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2310).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2310, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestBridgeFields()",
-                    line: "95"
+                    line: "97"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2310.testBridgeFields();
             }
@@ -9774,7 +9774,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testPropertyInitializer: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2374).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2374, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestPropertyInitializer()",
-                    line: "18"
+                    line: "20"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2374.testPropertyInitializer();
             }
@@ -9798,7 +9798,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testNameofWithReflection: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2375).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2375, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestNameofWithReflection()",
-                    line: "17"
+                    line: "18"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2375.testNameofWithReflection();
             }
@@ -11751,7 +11751,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testFieldPropertyWithInitializer: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge706).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge706, 1, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestFieldPropertyWithInitializer()",
-                    line: "17"
+                    line: "18"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge706.testFieldPropertyWithInitializer();
             }

--- a/Tests/Runner/Batch4/Bridge.Test/bridge.clienttest.batch4.runner.js
+++ b/Tests/Runner/Batch4/Bridge.Test/bridge.clienttest.batch4.runner.js
@@ -1976,7 +1976,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ActivatorTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/ActivatorTests.cs"
+                    file: "Batch4\\ActivatorTests.cs"
                 } );
             }
             return this.context;
@@ -2049,7 +2049,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.AggregateExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/AggregateExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\AggregateExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2094,7 +2094,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.AmbiguousMatchExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/AmbiguousMatchExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\AmbiguousMatchExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2118,7 +2118,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.AppDomainTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/AppDomainTests.cs"
+                    file: "Batch4\\AppDomainTests.cs"
                 } );
             }
             return this.context;
@@ -2177,7 +2177,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ArgumentExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/ArgumentExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\ArgumentExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2229,7 +2229,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ArgumentNullExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/ArgumentNullExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\ArgumentNullExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2288,7 +2288,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ArgumentOutOfRangeExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/ArgumentOutOfRangeExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\ArgumentOutOfRangeExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2333,7 +2333,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ArgumentsTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/ArgumentsTests.cs"
+                    file: "Batch4\\ArgumentsTests.cs"
                 } );
             }
             return this.context;
@@ -2378,7 +2378,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ArithmeticExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/ArithmeticExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\ArithmeticExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -2416,7 +2416,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.ArrayBufferTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/ArrayBufferTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\ArrayBufferTests.cs"
                 } );
             }
             return this.context;
@@ -2755,7 +2755,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/ArrayTests.cs"
+                    file: "Batch4\\ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -2898,7 +2898,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.AssemblyTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Reflection/AssemblyTests.cs"
+                    file: "Batch4\\Reflection\\AssemblyTests.cs"
                 } );
             }
             return this.context;
@@ -2957,7 +2957,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Threading.AsyncTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Threading/Tasks/AsyncTests.cs"
+                    file: "Batch4\\Threading\\Tasks\\AsyncTests.cs"
                 } );
             }
             return this.context;
@@ -3149,7 +3149,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.AttributeTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Reflection/AttributeTests.cs"
+                    file: "Batch4\\Reflection\\AttributeTests.cs"
                 } );
             }
             return this.context;
@@ -3236,7 +3236,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.BooleanTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/BooleanTests.cs"
+                    file: "Batch4\\SimpleTypes\\BooleanTests.cs"
                 } );
             }
             return this.context;
@@ -3288,7 +3288,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/ExceptionTests.cs"
+                    file: "Batch4\\ExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -3438,7 +3438,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.ByteTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/ByteTests.cs"
+                    file: "Batch4\\SimpleTypes\\ByteTests.cs"
                 } );
             }
             return this.context;
@@ -3651,7 +3651,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Threading.CancellationTokenTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Threading/CancellationTokenTests.cs"
+                    file: "Batch4\\Threading\\CancellationTokenTests.cs"
                 } );
             }
             return this.context;
@@ -3829,7 +3829,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.CharTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/CharTests.cs"
+                    file: "Batch4\\SimpleTypes\\CharTests.cs"
                 } );
             }
             return this.context;
@@ -3888,7 +3888,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.ComparerTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/ComparerTests.cs"
+                    file: "Batch4\\Collections\\Generic\\ComparerTests.cs"
                 } );
             }
             return this.context;
@@ -3919,7 +3919,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ContractExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/ContractExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\ContractExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -4020,7 +4020,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Diagnostics.Contracts.ContractTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Diagnostics/Contracts/ContractTests.cs"
+                    file: "Batch4\\Diagnostics\\Contracts\\ContractTests.cs"
                 } );
             }
             return this.context;
@@ -4072,7 +4072,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ConvertTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/ConvertTests.cs"
+                    file: "Batch4\\ConvertTests.cs"
                 } );
             }
             return this.context;
@@ -4110,7 +4110,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.CultureInfoTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/CultureInfoTests.cs"
+                    file: "Batch4\\CultureInfoTests.cs"
                 } );
             }
             return this.context;
@@ -4267,7 +4267,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.DataViewTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/DataViewTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\DataViewTests.cs"
                 } );
             }
             return this.context;
@@ -4753,7 +4753,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.DateTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/JsDateTests.cs"
+                    file: "Batch4\\SimpleTypes\\JsDateTests.cs"
                 } );
             }
             return this.context;
@@ -4791,7 +4791,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.DateTimeFormatInfoTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/DateTimeFormatInfoTests.cs"
+                    file: "Batch4\\DateTimeFormatInfoTests.cs"
                 } );
             }
             return this.context;
@@ -5459,7 +5459,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.DateTimeTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/DateTimeTests.cs"
+                    file: "Batch4\\SimpleTypes\\DateTimeTests.cs"
                 } );
             }
             return this.context;
@@ -5903,7 +5903,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.DecimalTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/DecimalTests.cs"
+                    file: "Batch4\\SimpleTypes\\DecimalTests.cs"
                 } );
             }
             return this.context;
@@ -6060,7 +6060,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.DelegateTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/DelegateTests.cs"
+                    file: "Batch4\\DelegateTests.cs"
                 } );
             }
             return this.context;
@@ -6105,7 +6105,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.DivideByZeroExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/DivideByZeroExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\DivideByZeroExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6304,7 +6304,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.DoubleTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/DoubleTests.cs"
+                    file: "Batch4\\SimpleTypes\\DoubleTests.cs"
                 } );
             }
             return this.context;
@@ -6405,7 +6405,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.EnumTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/EnumTests.cs"
+                    file: "Batch4\\SimpleTypes\\EnumTests.cs"
                 } );
             }
             return this.context;
@@ -6429,7 +6429,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.EnvironmentTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/EnvironmentTests.cs"
+                    file: "Batch4\\EnvironmentTests.cs"
                 } );
             }
             return this.context;
@@ -6495,7 +6495,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.EqualityComparerTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/EqualityComparerTests.cs"
+                    file: "Batch4\\Collections\\Generic\\EqualityComparerTests.cs"
                 } );
             }
             return this.context;
@@ -6533,7 +6533,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ErrorExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/JsErrorExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\JsErrorExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6592,7 +6592,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.ExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/ExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\ExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -6924,7 +6924,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Linq.Expressions.ExpressionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Linq/Expressions/ExpressionTests.cs"
+                    file: "Batch4\\Linq\\Expressions\\ExpressionTests.cs"
                 } );
             }
             return this.context;
@@ -7123,7 +7123,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Float32ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/Float32ArrayTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\Float32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -7322,7 +7322,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Float64ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/Float64ArrayTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\Float64ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -7367,7 +7367,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.FormatExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/FormatExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\FormatExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -7454,7 +7454,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.FormattableStringTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/FormattableStringTests.cs"
+                    file: "Batch4\\FormattableStringTests.cs"
                 } );
             }
             return this.context;
@@ -7625,7 +7625,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.GenericDictionaryTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/GenericDictionaryTests.cs"
+                    file: "Batch4\\Collections\\Generic\\GenericDictionaryTests.cs"
                 } );
             }
             return this.context;
@@ -7838,7 +7838,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.GetMembersTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Reflection/GetMembersTests.cs"
+                    file: "Batch4\\Reflection\\GetMembersTests.cs"
                 } );
             }
             return this.context;
@@ -8037,7 +8037,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.GuidTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/GuidTests.cs"
+                    file: "Batch4\\GuidTests.cs"
                 } );
             }
             return this.context;
@@ -8159,7 +8159,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.ICollectionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/ICollectionTests.cs"
+                    file: "Batch4\\Collections\\Generic\\ICollectionTests.cs"
                 } );
             }
             return this.context;
@@ -8183,7 +8183,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.IComparableTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/IComparableTests.cs"
+                    file: "Batch4\\IComparableTests.cs"
                 } );
             }
             return this.context;
@@ -8277,7 +8277,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.IDictionaryTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/IDictionaryTests.cs"
+                    file: "Batch4\\Collections\\Generic\\IDictionaryTests.cs"
                 } );
             }
             return this.context;
@@ -8336,7 +8336,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.IEnumerableTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/IEnumerableTests.cs"
+                    file: "Batch4\\Collections\\Generic\\IEnumerableTests.cs"
                 } );
             }
             return this.context;
@@ -8360,7 +8360,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.IEquatableTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/IEquatableTests.cs"
+                    file: "Batch4\\IEquatableTests.cs"
                 } );
             }
             return this.context;
@@ -8391,7 +8391,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.IFormattableTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/IFormattableTests.cs"
+                    file: "Batch4\\IFormattableTests.cs"
                 } );
             }
             return this.context;
@@ -8520,7 +8520,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.IListTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/IListTests.cs"
+                    file: "Batch4\\Collections\\Generic\\IListTests.cs"
                 } );
             }
             return this.context;
@@ -8719,7 +8719,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Int16ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/Int16ArrayTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\Int16ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -8869,7 +8869,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.Int16Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/Int16Tests.cs"
+                    file: "Batch4\\SimpleTypes\\Int16Tests.cs"
                 } );
             }
             return this.context;
@@ -9068,7 +9068,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Int32ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/Int32ArrayTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\Int32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -9267,7 +9267,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.Int32Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/Int32Tests.cs"
+                    file: "Batch4\\SimpleTypes\\Int32Tests.cs"
                 } );
             }
             return this.context;
@@ -9424,7 +9424,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.Int64Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/Int64Tests.cs"
+                    file: "Batch4\\SimpleTypes\\Int64Tests.cs"
                 } );
             }
             return this.context;
@@ -9623,7 +9623,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Int8ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/Int8ArrayTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\Int8ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -9668,7 +9668,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.InvalidCastExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/InvalidCastExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\InvalidCastExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -9713,7 +9713,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.InvalidOperationExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/InvalidOperationExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\InvalidOperationExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -9800,7 +9800,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.IteratorBlockTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/IteratorBlockTests.cs"
+                    file: "Batch4\\Collections\\Generic\\IteratorBlockTests.cs"
                 } );
             }
             return this.context;
@@ -9894,7 +9894,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Serialization.JsonTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Serialization/JsonTests.cs"
+                    file: "Batch4\\Serialization\\JsonTests.cs"
                 } );
             }
             return this.context;
@@ -9939,7 +9939,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.KeyNotFoundExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/KeyNotFoundExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\KeyNotFoundExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -9998,7 +9998,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.KeyValuePairTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/KeyValuePairTests.cs"
+                    file: "Batch4\\Collections\\Generic\\KeyValuePairTests.cs"
                 } );
             }
             return this.context;
@@ -10379,7 +10379,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.Generic.ListTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/Generic/ListTests.cs"
+                    file: "Batch4\\Collections\\Generic\\ListTests.cs"
                 } );
             }
             return this.context;
@@ -10865,7 +10865,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.MathTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/MathTests.cs"
+                    file: "Batch4\\MathTests.cs"
                 } );
             }
             return this.context;
@@ -10987,7 +10987,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.MultidimArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/MultidimArrayTests.cs"
+                    file: "Batch4\\MultidimArrayTests.cs"
                 } );
             }
             return this.context;
@@ -11032,7 +11032,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.NotImplementedExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/NotImplementedExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\NotImplementedExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11077,7 +11077,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.NotSupportedExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/NotSupportedExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\NotSupportedExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11388,7 +11388,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.NullableTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/NullableTests.cs"
+                    file: "Batch4\\NullableTests.cs"
                 } );
             }
             return this.context;
@@ -11440,7 +11440,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.NullReferenceExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/NullReferenceExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\NullReferenceExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11478,7 +11478,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.NumberFormatInfoTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/NumberFormatInfoTests.cs"
+                    file: "Batch4\\NumberFormatInfoTests.cs"
                 } );
             }
             return this.context;
@@ -11551,7 +11551,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.ObjectTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/ObjectTests.cs"
+                    file: "Batch4\\SimpleTypes\\ObjectTests.cs"
                 } );
             }
             return this.context;
@@ -11617,7 +11617,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.OperationCanceledExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/OperationCanceledExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\OperationCanceledExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11662,7 +11662,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.OverflowExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/OverflowExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\OverflowExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11707,7 +11707,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.PromiseExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/PromiseExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\PromiseExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -11766,7 +11766,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Threading.PromiseTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Threading/Tasks/PromiseTests.cs"
+                    file: "Batch4\\Threading\\Tasks\\PromiseTests.cs"
                 } );
             }
             return this.context;
@@ -11825,7 +11825,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.PropertyAccessorTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/PropertyAccessorTests.cs"
+                    file: "Batch4\\PropertyAccessorTests.cs"
                 } );
             }
             return this.context;
@@ -11898,7 +11898,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.RandomTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/RandomTests.cs"
+                    file: "Batch4\\RandomTests.cs"
                 } );
             }
             return this.context;
@@ -12034,7 +12034,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.ObjectModel.ReadOnlyCollectionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/ObjectModel/ReadOnlyCollectionTests.cs"
+                    file: "Batch4\\Collections\\ObjectModel\\ReadOnlyCollectionTests.cs"
                 } );
             }
             return this.context;
@@ -12695,7 +12695,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.ReflectionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Reflection/ReflectionTests.cs"
+                    file: "Batch4\\Reflection\\ReflectionTests.cs"
                 } );
             }
             return this.context;
@@ -12747,7 +12747,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.RefParameterTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/RefParameterTests.cs"
+                    file: "Batch4\\RefParameterTests.cs"
                 } );
             }
             return this.context;
@@ -12841,7 +12841,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Text.RegularExpressions.RegexTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Text/RegularExpressions/RegexTests.cs"
+                    file: "Batch4\\Text\\RegularExpressions\\RegexTests.cs"
                 } );
             }
             return this.context;
@@ -12872,7 +12872,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Runtime.CompilerServices.RuntimeHelpersTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Runtime/CompilerServices/RuntimeHelpersTests.cs"
+                    file: "Batch4\\Runtime\\CompilerServices\\RuntimeHelpersTests.cs"
                 } );
             }
             return this.context;
@@ -13022,7 +13022,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.SByteTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/SByteTests.cs"
+                    file: "Batch4\\SimpleTypes\\SByteTests.cs"
                 } );
             }
             return this.context;
@@ -13074,7 +13074,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.ScriptTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/ScriptTests.cs"
+                    file: "Batch4\\ScriptTests.cs"
                 } );
             }
             return this.context;
@@ -13273,7 +13273,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.SingleTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/SingleTests.cs"
+                    file: "Batch4\\SimpleTypes\\SingleTests.cs"
                 } );
             }
             return this.context;
@@ -13339,7 +13339,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.StopwatchTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/StopwatchTests.cs"
+                    file: "Batch4\\StopwatchTests.cs"
                 } );
             }
             return this.context;
@@ -13503,7 +13503,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Text.StringBuilderTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Text/StringBuilderTests.cs"
+                    file: "Batch4\\Text\\StringBuilderTests.cs"
                 } );
             }
             return this.context;
@@ -14122,7 +14122,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.StringTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/StringTests.cs"
+                    file: "Batch4\\SimpleTypes\\StringTests.cs"
                 } );
             }
             return this.context;
@@ -14174,7 +14174,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Exceptions.TaskCanceledExceptionTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Exceptions/TaskCanceledExceptionTests.cs"
+                    file: "Batch4\\Exceptions\\TaskCanceledExceptionTests.cs"
                 } );
             }
             return this.context;
@@ -14506,7 +14506,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Threading.TaskTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Threading/Tasks/TaskTests.cs"
+                    file: "Batch4\\Threading\\Tasks\\TaskTests.cs"
                 } );
             }
             return this.context;
@@ -14684,7 +14684,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.TimeSpanTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/TimeSpanTests.cs"
+                    file: "Batch4\\SimpleTypes\\TimeSpanTests.cs"
                 } );
             }
             return this.context;
@@ -14757,7 +14757,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.TupleTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/TupleTests.cs"
+                    file: "Batch4\\SimpleTypes\\TupleTests.cs"
                 } );
             }
             return this.context;
@@ -14823,7 +14823,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.TypeSystemLanguageSupportTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Reflection/TypeSystemLanguageSupportTests.cs"
+                    file: "Batch4\\Reflection\\TypeSystemLanguageSupportTests.cs"
                 } );
             }
             return this.context;
@@ -15204,7 +15204,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Reflection.TypeSystemTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Reflection/TypeSystemTests.cs"
+                    file: "Batch4\\Reflection\\TypeSystemTests.cs"
                 } );
             }
             return this.context;
@@ -15403,7 +15403,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint16ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/Uint16ArrayTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\Uint16ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -15553,7 +15553,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.UInt16Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/UInt16Tests.cs"
+                    file: "Batch4\\SimpleTypes\\UInt16Tests.cs"
                 } );
             }
             return this.context;
@@ -15752,7 +15752,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint32ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/Uint32ArrayTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\Uint32ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -15902,7 +15902,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.UInt32Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/UInt32Tests.cs"
+                    file: "Batch4\\SimpleTypes\\UInt32Tests.cs"
                 } );
             }
             return this.context;
@@ -16066,7 +16066,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.SimpleTypes.UInt64Tests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/SimpleTypes/UInt64Tests.cs"
+                    file: "Batch4\\SimpleTypes\\UInt64Tests.cs"
                 } );
             }
             return this.context;
@@ -16265,7 +16265,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint8ArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/Uint8ArrayTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\Uint8ArrayTests.cs"
                 } );
             }
             return this.context;
@@ -16478,7 +16478,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.Collections.TypedArrays.Uint8ClampedArrayTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/Collections/TypedArrays/Uint8ClampedArrayTests.cs"
+                    file: "Batch4\\Collections\\TypedArrays\\Uint8ClampedArrayTests.cs"
                 } );
             }
             return this.context;
@@ -16691,7 +16691,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch4", function ($asm, globals)
                 this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
                     project: "Batch4",
                     className: "Bridge.ClientTest.Batch4.UserDefinedStructTests",
-                    file: "file:///C:/NET/BridgeNew/Bridge/Tests/Batch4/UserDefinedStructTests.cs"
+                    file: "Batch4\\UserDefinedStructTests.cs"
                 } );
             }
             return this.context;

--- a/Tests/Runner/Batch4/code.js
+++ b/Tests/Runner/Batch4/code.js
@@ -1822,7 +1822,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("got " + enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
             }
 
-            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n");
+            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n");
         },
         prematureDisposalOfIEnumeratorIteratorExecutesFinallyBlocks_SPI_1555: function () {
             // #1555
@@ -1835,7 +1835,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             }
             enm.System$IDisposable$dispose();
 
-            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nin finally\n");
+            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nin finally\r\n");
         },
         exceptionInIEnumeratorIteratorBodyExecutesFinallyBlocks_SPI_1554: function () {
             var sb = new System.Text.StringBuilder();
@@ -1859,7 +1859,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("caught exception");
             }
 
-            this.assertEqual(sb.toString(), "yielding 1\ngot 1\nyielding 2\ngot 2\nthrowing\nin finally\ncaught exception\n");
+            this.assertEqual(sb.toString(), "yielding 1\r\ngot 1\r\nyielding 2\r\ngot 2\r\nthrowing\r\nin finally\r\ncaught exception\r\n");
         },
         typeReturnedByIteratorBlockReturningIEnumerableImplementsThatInterface_SPI_1554: function () {
             var enm = null;
@@ -1900,7 +1900,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                     $t1.System$IDisposable$dispose();
                 }
             }
-            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n-\nyielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n");
+            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n-\r\nyielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n");
         },
         prematureDisposalOfIEnumerableIteratorExecutesFinallyBlocks_SPI_1555: function () {
             var $t;
@@ -1921,7 +1921,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                     $t.System$IDisposable$dispose();
                 }
             }
-            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nin finally\n");
+            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nin finally\r\n");
         },
         exceptionInIEnumerableIteratorBodyExecutesFinallyBlocks_SPI_1554: function () {
             var sb = new System.Text.StringBuilder();
@@ -1946,7 +1946,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("caught exception");
             }
 
-            this.assertEqual(sb.toString(), "yielding 1\ngot 1\nyielding 2\ngot 2\nthrowing\nin finally\ncaught exception\n");
+            this.assertEqual(sb.toString(), "yielding 1\r\ngot 1\r\nyielding 2\r\ngot 2\r\nthrowing\r\nin finally\r\ncaught exception\r\n");
         },
         enumeratingAnIteratorBlockReturningIEnumerableMultipleTimesUsesTheInitialValuesForParameters: function () {
             var $t, $t1;
@@ -1974,7 +1974,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                     $t1.System$IDisposable$dispose();
                 }
             }
-            this.assertEqual(sb.toString(), "3\n2\n1\n3\n2\n1\n");
+            this.assertEqual(sb.toString(), "3\r\n2\r\n1\r\n3\r\n2\r\n1\r\n");
         },
         differentGetEnumeratorCallsOnIteratorBlockReturningIEnumerableGetOwnCopiesOfLocals: function () {
             var sb = new System.Text.StringBuilder();
@@ -1989,7 +1989,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine(enm2[Bridge.geti(enm2, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]().toString());
             }
 
-            this.assertEqual(sb.toString(), "0\n0\n1\n1\n2\n2\n-1\n-1\n");
+            this.assertEqual(sb.toString(), "0\r\n0\r\n1\r\n1\r\n2\r\n2\r\n-1\r\n-1\r\n");
         }
     });
 
@@ -13744,6 +13744,8 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         statics: {
             canConvert: function (T, arg) {
                 try { /// The variable `x' is assigned but its value is never used
+
+
                     var x = Bridge.cast(Bridge.unbox(arg), T);
                     return true;
                 }

--- a/Tests/Runner/Batch4/code.js
+++ b/Tests/Runner/Batch4/code.js
@@ -1822,7 +1822,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("got " + enm[Bridge.geti(enm, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]());
             }
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n");
         },
         prematureDisposalOfIEnumeratorIteratorExecutesFinallyBlocks_SPI_1555: function () {
             // #1555
@@ -1835,7 +1835,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
             }
             enm.System$IDisposable$dispose();
 
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nin finally\n");
         },
         exceptionInIEnumeratorIteratorBodyExecutesFinallyBlocks_SPI_1554: function () {
             var sb = new System.Text.StringBuilder();
@@ -1859,7 +1859,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("caught exception");
             }
 
-            this.assertEqual(sb.toString(), "yielding 1\r\ngot 1\r\nyielding 2\r\ngot 2\r\nthrowing\r\nin finally\r\ncaught exception\r\n");
+            this.assertEqual(sb.toString(), "yielding 1\ngot 1\nyielding 2\ngot 2\nthrowing\nin finally\ncaught exception\n");
         },
         typeReturnedByIteratorBlockReturningIEnumerableImplementsThatInterface_SPI_1554: function () {
             var enm = null;
@@ -1900,7 +1900,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                     $t1.System$IDisposable$dispose();
                 }
             }
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n-\r\nyielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nyielding -1\r\ngot -1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n-\nyielding 0\ngot 0\nyielding 1\ngot 1\nyielding -1\ngot -1\nin finally\n");
         },
         prematureDisposalOfIEnumerableIteratorExecutesFinallyBlocks_SPI_1555: function () {
             var $t;
@@ -1921,7 +1921,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                     $t.System$IDisposable$dispose();
                 }
             }
-            this.assertEqual(sb.toString(), "yielding 0\r\ngot 0\r\nyielding 1\r\ngot 1\r\nin finally\r\n");
+            this.assertEqual(sb.toString(), "yielding 0\ngot 0\nyielding 1\ngot 1\nin finally\n");
         },
         exceptionInIEnumerableIteratorBodyExecutesFinallyBlocks_SPI_1554: function () {
             var sb = new System.Text.StringBuilder();
@@ -1946,7 +1946,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine("caught exception");
             }
 
-            this.assertEqual(sb.toString(), "yielding 1\r\ngot 1\r\nyielding 2\r\ngot 2\r\nthrowing\r\nin finally\r\ncaught exception\r\n");
+            this.assertEqual(sb.toString(), "yielding 1\ngot 1\nyielding 2\ngot 2\nthrowing\nin finally\ncaught exception\n");
         },
         enumeratingAnIteratorBlockReturningIEnumerableMultipleTimesUsesTheInitialValuesForParameters: function () {
             var $t, $t1;
@@ -1974,7 +1974,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                     $t1.System$IDisposable$dispose();
                 }
             }
-            this.assertEqual(sb.toString(), "3\r\n2\r\n1\r\n3\r\n2\r\n1\r\n");
+            this.assertEqual(sb.toString(), "3\n2\n1\n3\n2\n1\n");
         },
         differentGetEnumeratorCallsOnIteratorBlockReturningIEnumerableGetOwnCopiesOfLocals: function () {
             var sb = new System.Text.StringBuilder();
@@ -1989,7 +1989,7 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
                 sb.appendLine(enm2[Bridge.geti(enm2, "System$Collections$Generic$IEnumerator$1$System$Int32$getCurrent$1", "getCurrent$1")]().toString());
             }
 
-            this.assertEqual(sb.toString(), "0\r\n0\r\n1\r\n1\r\n2\r\n2\r\n-1\r\n-1\r\n");
+            this.assertEqual(sb.toString(), "0\n0\n1\n1\n2\n2\n-1\n-1\n");
         }
     });
 
@@ -13744,8 +13744,6 @@ Bridge.assembly("Bridge.ClientTest.Batch4", {"Bridge.ClientTest.Batch4.Reflectio
         statics: {
             canConvert: function (T, arg) {
                 try { /// The variable `x' is assigned but its value is never used
-
-
                     var x = Bridge.cast(Bridge.unbox(arg), T);
                     return true;
                 }


### PR DESCRIPTION
Addresses #2427 Support JsonSettings for Bridge.Json (a part of #2418 Bridge.Json serialization and deserialization ) - https://github.com/bridgedotnet/Bridge/issues/2418#issuecomment-284032029

Changes proposed in this pull request:

- Assembly name is included to serialized type name