### PR TITLE
[2429] Bundled CSS files contain byte-order-marks within the combined output file

### DIFF
--- a/Compiler/Contract/Config/ResourceConfig.cs
+++ b/Compiler/Contract/Config/ResourceConfig.cs
@@ -101,6 +101,11 @@ namespace Bridge.Contract
             {
                 this.Silent = true;
             }
+
+            if (!this.RemoveBom.HasValue)
+            {
+                this.RemoveBom = true;
+            }
         }
 
         public string Header
@@ -119,6 +124,11 @@ namespace Bridge.Contract
         }
 
         public bool? Silent
+        {
+            get; set;
+        }
+
+        public bool? RemoveBom
         {
             get; set;
         }

--- a/Compiler/Translator/Translator/Translator.Resources.cs
+++ b/Compiler/Translator/Translator/Translator.Resources.cs
@@ -672,7 +672,9 @@ namespace Bridge.Translator
 
                         if (content.Length > 0)
                         {
-                            var bomLength = GetBomLength(content);
+                            var bomLength = !item.RemoveBom.HasValue || item.RemoveBom.Value
+                                ? GetBomLength(content)
+                                : 0;
 
                             if (bomLength > 0)
                             {

--- a/Compiler/TranslatorTests/TestProjects/18/Bridge/bridge.json
+++ b/Compiler/TranslatorTests/TestProjects/18/Bridge/bridge.json
@@ -74,6 +74,27 @@
         "Bridge\\output/testIssue599.js",
         "Bridge\\output/testIssue948.js"
       ]
+    },
+    // #2429 Check two css files with BOM encoding get BOM removed when combined by default
+    {
+      "name": "issue2429_NoBom.css",
+      "extract": true,
+      "output": "resources",
+      "files": [
+        "Bridge/res/style2429_1.css",
+        "Bridge/res/style2429_2.css"
+      ]
+    },
+    // #2429 Check two css files with BOM encoding do NOT get BOM removed when combined with RemoveBom = false
+    {
+      "name": "issue2429_Bom.css",
+      "extract": true,
+      "removeBom":  false,
+      "output": "resources",
+      "files": [
+        "Bridge/res/style2429_1.css",
+        "Bridge/res/style2429_2.css"
+      ]
     }
   ]
 }

--- a/Compiler/TranslatorTests/TestProjects/18/Bridge/reference/resources/issue2429_Bom.css
+++ b/Compiler/TranslatorTests/TestProjects/18/Bridge/reference/resources/issue2429_Bom.css
@@ -1,0 +1,19 @@
+﻿/*
+    style2429_1.css
+    This original file encoded with UTF-8 BOM
+    It is supposed to test resource combining (#2429) - to check if it removes BOM by default or persist by removeBom = false
+*/
+
+p {
+    text-align: center;
+    color: red;
+} ﻿/*
+    style2429_2.css
+    This original file encoded with UTF-8 BOM
+    It is supposed to test resource combining (#2429) - to check if it removes BOM by default or persist by removeBom = false
+*/
+
+p.one {
+    border-style: solid;
+    border-width: 5px;
+}

--- a/Compiler/TranslatorTests/TestProjects/18/Bridge/reference/resources/issue2429_NoBom.css
+++ b/Compiler/TranslatorTests/TestProjects/18/Bridge/reference/resources/issue2429_NoBom.css
@@ -1,0 +1,19 @@
+/*
+    style2429_1.css
+    This original file encoded with UTF-8 BOM
+    It is supposed to test resource combining (#2429) - to check if it removes BOM by default or persist by removeBom = false
+*/
+
+p {
+    text-align: center;
+    color: red;
+} /*
+    style2429_2.css
+    This original file encoded with UTF-8 BOM
+    It is supposed to test resource combining (#2429) - to check if it removes BOM by default or persist by removeBom = false
+*/
+
+p.one {
+    border-style: solid;
+    border-width: 5px;
+}

--- a/Compiler/TranslatorTests/TestProjects/18/Bridge/res/style2429_1.css
+++ b/Compiler/TranslatorTests/TestProjects/18/Bridge/res/style2429_1.css
@@ -1,0 +1,10 @@
+﻿/*
+    style2429_1.css
+    This original file encoded with UTF-8 BOM
+    It is supposed to test resource combining (#2429) - to check if it removes BOM by default or persist by removeBom = false
+*/
+
+p {
+    text-align: center;
+    color: red;
+} 

--- a/Compiler/TranslatorTests/TestProjects/18/Bridge/res/style2429_2.css
+++ b/Compiler/TranslatorTests/TestProjects/18/Bridge/res/style2429_2.css
@@ -1,0 +1,10 @@
+﻿/*
+    style2429_2.css
+    This original file encoded with UTF-8 BOM
+    It is supposed to test resource combining (#2429) - to check if it removes BOM by default or persist by removeBom = false
+*/
+
+p.one {
+    border-style: solid;
+    border-width: 5px;
+}

--- a/Compiler/TranslatorTests/TestProjects/18/test.csproj
+++ b/Compiler/TranslatorTests/TestProjects/18/test.csproj
@@ -85,6 +85,8 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Bridge\res\header.js" />
+    <Content Include="Bridge\res\style2429_1.css" />
+    <Content Include="Bridge\res\style2429_2.css" />
   </ItemGroup>
   <!-- Bridge Compiler -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Fixes #2429 

* Remove BOM when combining resources
* Config option for resource items with files **resources.removeBom** (default true):
```js
"resources": [
  {
    // new option
    "removeBom": false|true (true by default)

    "name": "combined.css",
    "files": [ "style1WithBom.css",  "style2WithBom2.css" ]
  }
]
```