### PR TITLE
[2486] Tests for generic interface where generic type is array caused runtime error

### DIFF
--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -527,6 +527,7 @@
     <Compile Include="BridgeIssues\2400\N2467.cs" />
     <Compile Include="BridgeIssues\2400\N2469.cs" />
     <Compile Include="BridgeIssues\2400\N2481.cs" />
+    <Compile Include="BridgeIssues\2400\N2486.cs" />
     <Compile Include="BridgeIssues\2400\N2489.cs" />
     <Compile Include="BridgeIssues\2400\N2497.cs" />
     <Compile Include="BridgeIssues\2400\N2499.cs" />

--- a/Tests/Batch3/BridgeIssues/2400/N2486.cs
+++ b/Tests/Batch3/BridgeIssues/2400/N2486.cs
@@ -18,6 +18,30 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             }
         }
 
+        public class Linear1 : IKernel<double[]>
+        {
+            public double Function(double[] x)
+            {
+                return x[0];
+            }
+        }
+
+        public class Linear2 : IKernel<double[,]>
+        {
+            public double Function(double[,] x)
+            {
+                return x[1, 1];
+            }
+        }
+        public class Linear3 : IKernel<List<double>>
+        {
+            public double Function(List<double> x)
+            {
+                return x[1];
+            }
+        }
+
+
         public interface IKernel<T>
         {
             double Function(T x);
@@ -30,6 +54,21 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             var r = x.Function(null);
 
             Assert.AreEqual(123, r);
+
+            var x1 = new Linear1();
+            var r1 = x1.Function(new[] { 1.1 });
+
+            Assert.AreEqual(1.1, r1);
+
+            var x2 = new Linear2();
+            var r2 = x2.Function(new double[,] { { 1.1, 2.2, 3.3 }, { 4.1, 5.1, 6.1 } });
+
+            Assert.AreEqual(5.1, r2);
+
+            var x3 = new Linear3();
+            var r3 = x3.Function(new List<double>(new[] { 1.1, 2.1 }));
+
+            Assert.AreEqual(2.1, r3);
         }
     }
 }

--- a/Tests/Batch3/BridgeIssues/2400/N2486.cs
+++ b/Tests/Batch3/BridgeIssues/2400/N2486.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Bridge.Test.NUnit;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#2486 - {0}")]
+    public class Bridge2486
+    {
+        public class Linear : IKernel<string[]>
+        {
+            public double Function(string[] x)
+            {
+                return 123;
+            }
+        }
+
+        public interface IKernel<T>
+        {
+            double Function(T x);
+        }
+
+        [Test]
+        public static void TestGenericArrayInterface()
+        {
+            var x = new Linear();
+            var r = x.Function(null);
+
+            Assert.AreEqual(123, r);
+        }
+    }
+}

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -10272,7 +10272,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             testGenericArrayInterface: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2486, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     method: "TestGenericArrayInterface()",
-                    line: "26"
+                    line: "50"
                 } ));
                 Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.testGenericArrayInterface();
             }

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -501,6 +501,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#2467 - TestPropertyInitializerInStruct", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2467.testPropertyInitializerInStruct);
             QUnit.test("#2469 - TestLambdaLiftingWithStaticGenericMember", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2469.testLambdaLiftingWithStaticGenericMember);
             QUnit.test("#2481 - TestReturnInAsyncUsing", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2481.testReturnInAsyncUsing);
+            QUnit.test("#2486 - TestGenericArrayInterface", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2486.testGenericArrayInterface);
             QUnit.test("#2489 - TestReflectableInherits", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2489.testReflectableInherits);
             QUnit.test("#2497 - TestPropertyInitializerWithDirective", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2497.testPropertyInitializerWithDirective);
             QUnit.test("#2499 - TestArraySortComparison", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2499.testArraySortComparison);
@@ -10259,6 +10260,30 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                     project: "Batch3",
                     className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2481",
                     file: "Batch3\\BridgeIssues\\2400\\N2481.cs"
+                } );
+            }
+            return this.context;
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2486", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486)],
+        statics: {
+            testGenericArrayInterface: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486).beforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge2486, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    method: "TestGenericArrayInterface()",
+                    line: "26"
+                } ));
+                Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.testGenericArrayInterface();
+            }
+        },
+        context: null,
+        getContext: function () {
+            if (this.context == null) {
+                this.context = Bridge.merge(new Bridge.Test.Runtime.FixtureContext(), {
+                    project: "Batch3",
+                    className: "Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486",
+                    file: "Batch3\\BridgeIssues\\2400\\N2486.cs"
                 } );
             }
             return this.context;

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -16513,6 +16513,21 @@ Bridge.$N1391Result =                 r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486", {
+        statics: {
+            testGenericArrayInterface: function () {
+                var x = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.Linear();
+                var r = x.function(null);
+
+                Bridge.Test.NUnit.Assert.areEqual(123, r);
+            }
+        }
+    });
+
+    Bridge.definei("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.IKernel$1", function (T) { return {
+        $kind: "interface"
+    }; });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2489", {
         statics: {
             testReflectableInherits: function () {
@@ -25526,6 +25541,18 @@ Bridge.$N1391Result =                 r;
         getString: function () {
             this.Data = (this.Data + 1) | 0;
             return "B";
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.Linear", {
+        inherits: [Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.IKernel$1(System.Array.type(System.String))],
+        config: {
+            alias: [
+            "function", "Bridge$ClientTest$Batch3$BridgeIssues$Bridge2486$IKernel$1$System$String$Array$function"
+            ]
+        },
+        function: function (x) {
+            return 123;
         }
     });
 

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -16520,6 +16520,21 @@ Bridge.$N1391Result =                 r;
                 var r = x.function(null);
 
                 Bridge.Test.NUnit.Assert.areEqual(123, r);
+
+                var x1 = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.Linear1();
+                var r1 = x1.function(System.Array.init([1.1], System.Double));
+
+                Bridge.Test.NUnit.Assert.areEqual(1.1, r1);
+
+                var x2 = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.Linear2();
+                var r2 = x2.function(System.Array.create(0, [[1.1, 2.2, 3.3], [4.1, 5.1, 6.1]], System.Double, 2, 3));
+
+                Bridge.Test.NUnit.Assert.areEqual(5.1, r2);
+
+                var x3 = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.Linear3();
+                var r3 = x3.function(new (System.Collections.Generic.List$1(System.Double))(System.Array.init([1.1, 2.1], System.Double)));
+
+                Bridge.Test.NUnit.Assert.areEqual(2.1, r3);
             }
         }
     });
@@ -25553,6 +25568,42 @@ Bridge.$N1391Result =                 r;
         },
         function: function (x) {
             return 123;
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.Linear1", {
+        inherits: [Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.IKernel$1(System.Array.type(System.Double))],
+        config: {
+            alias: [
+            "function", "Bridge$ClientTest$Batch3$BridgeIssues$Bridge2486$IKernel$1$System$Double$Array$function"
+            ]
+        },
+        function: function (x) {
+            return x[System.Array.index(0, x)];
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.Linear2", {
+        inherits: [Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.IKernel$1(System.Array.type(System.Double, 2))],
+        config: {
+            alias: [
+            "function", "Bridge$ClientTest$Batch3$BridgeIssues$Bridge2486$IKernel$1$System$Double$Array$2$function"
+            ]
+        },
+        function: function (x) {
+            return x.get([1, 1]);
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.Linear3", {
+        inherits: [Bridge.ClientTest.Batch3.BridgeIssues.Bridge2486.IKernel$1(System.Collections.Generic.List$1(System.Double))],
+        config: {
+            alias: [
+            "function", "Bridge$ClientTest$Batch3$BridgeIssues$Bridge2486$IKernel$1$System$Collections$Generic$List$1$System$Double$function"
+            ]
+        },
+        function: function (x) {
+            return x.getItem(1);
         }
     });
 


### PR DESCRIPTION
Fixes #2486 