### PR TITLE
+ added overloaded methods for Math.Min\Max and other methods

### DIFF
--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -46,6 +46,8 @@ namespace System
 
         public static extern double Max(params double[] values);
 
+		public static extern float Max(params float[] values);
+
         [Template("Bridge.Long.max({*values})")]
         public static extern long Max(params long[] values);
 
@@ -60,6 +62,8 @@ namespace System
         public static extern int Min(params uint[] values);
 
         public static extern double Min(params double[] values);
+
+		public static extern float Min(params float[] value);
 
         [Template("Bridge.Long.min({*values})")]
         public static extern long Min(params long[] values);
@@ -82,7 +86,11 @@ namespace System
         [Name("ceil")]
         public static extern double Ceiling(double d);
 
+		public static extern float Ceiling(float f);
+
         public static extern double Floor(double x);
+
+		public static extern float Floor(float f);
 
         [Template("{d}.floor()")]
         public static extern decimal Floor(decimal d);
@@ -90,11 +98,15 @@ namespace System
         [Template("Bridge.Decimal.round({x}, 6)")]
         public static extern decimal Round(decimal x);
 
+		public static extern float Round(float f);
+
         [Template("Bridge.Math.round({d}, 0, 6)")]
         public static extern double Round(double d);
 
         [Template("Math.round({d})")]
         public static extern double JsRound(double d);
+
+		public static extern float JsRound(float f);
 
         [Template("Bridge.Decimal.toDecimalPlaces({d}, {digits}, 6)")]
         public static extern decimal Round(decimal d, int digits);
@@ -102,11 +114,15 @@ namespace System
         [Template("Bridge.Math.round({d}, {digits}, 6)")]
         public static extern double Round(double d, int digits);
 
+		public static extern float Round(float f, int digits);
+
         [Template("Bridge.Decimal.round({d}, {method})")]
         public static extern decimal Round(decimal d, MidpointRounding method);
 
         [Template("Bridge.Math.round({d}, 0, {method})")]
         public static extern double Round(double d, MidpointRounding method);
+
+		public static extern float Round(float f, MidpointRounding method);
 
         [Template("Bridge.Decimal.toDecimalPlaces({d}, {digits}, {method})")]
         public static extern decimal Round(decimal d, int digits, MidpointRounding method);
@@ -114,10 +130,14 @@ namespace System
         [Template("Bridge.Math.round({d}, {digits}, {method})")]
         public static extern double Round(double d, int digits, MidpointRounding method);
 
+		public static extern float Round(float f, int digits, MidpointRounding method);
+
         [Template("{x} - ({y} * Math.round({x} / {y}))")]
         public static extern double IEEERemainder(double x, double y);
 
         public static extern double Exp(double x);
+
+		public static extern double Exp(float x);
 
         [Template("{x}.exponential()")]
         public static extern decimal Exp(decimal x);
@@ -136,26 +156,46 @@ namespace System
 
         public static extern double Log(double x);
 
+		public static extern double Log(float x);
+
         public static extern double Pow(double x, double y);
 
         public static extern double Pow(int x, int y);
 
+		public static extern double Pow(float x, float y);
+
         public static extern double Acos(double x);
+
+		public static extern double Acos(float x);
 
         public static extern double Asin(double x);
 
+		public static extern double Asin(float x);
+
         public static extern double Atan(double x);
+
+		public static extern double Atan(float f);
 
         public static extern double Atan2(double y, double x);
 
+		public static extern float Atan2(float y, float x);
+
         public static extern double Cos(double x);
+
+		public static extern double Cos(float f);
 
         public static extern double Sin(double x);
 
+		public static extern double Sin(float x);
+
         public static extern double Tan(double x);
+
+		public static extern double Tan(float f);
 
         [Template("Bridge.Int.trunc({d})")]
         public static extern double Truncate(double d);
+
+		public static extern float Truncate(float f);
 
         [Template("{d}.trunc()")]
         public static extern decimal Truncate(decimal d);

--- a/Tests/Runner/TypeScript/Batch1/0_Issues.js
+++ b/Tests/Runner/TypeScript/Batch1/0_Issues.js
@@ -1,4 +1,4 @@
-﻿/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
+/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\bridge.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\misc.a.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\misc.b.d.ts" />
@@ -6,28 +6,21 @@ QUnit.module("TypeScript - Issues");
 QUnit.test("#290", function (assert) {
     var c1 = new Misc.A.Class1();
     var c2 = new Misc.B.Class2();
-
     assert.deepEqual(c1.getInt(3), 3, "Misc.A.Class1.getInt");
     assert.deepEqual(c2.getInt(6), 6, "Use class declared in another namespace");
 });
-
 QUnit.test("#281", function (assert) {
     var t = new Misc.A.EnumTest();
-
     assert.deepEqual(t.doSomething(Misc.A.EnumTest.EnumA.m2), Misc.A.EnumTest.EnumA.m2, "Use enum declared inside a class");
 });
-
 QUnit.test("#336", function (assert) {
     var l1 = new (Bridge.List$1(String))(["4"]);
     var l2 = new (Bridge.List$1(String))(["1", "2"]);
-
     l1.insertRange(0, l2);
     assert.deepEqual(l1.toArray(), ["1", "2", "4"], "InsertRange works (1)");
 });
-
 QUnit.test("#338", function (assert) {
     var list = new (Bridge.List$1(String))(["4"]);
     var interfacedList = list;
-
     assert.deepEqual(interfacedList.get(0), "4", "Bridge.List$1(String) is Bridge.IList$1<String>");
 });

--- a/Tests/Runner/TypeScript/Batch1/1_BasicTypes.js
+++ b/Tests/Runner/TypeScript/Batch1/1_BasicTypes.js
@@ -1,52 +1,42 @@
-﻿/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
+/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\bridge.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\basicTypes.d.ts" />
 QUnit.module("TypeScript - Basic Types");
 QUnit.test("Fields of basic types", function (assert) {
     var instance = new BasicTypes.BasicTypes();
-
     assert.deepEqual(instance.boolValue, true, "boolValue");
     assert.deepEqual(instance.integerValue, -1000, "integerValue");
     assert.deepEqual(instance.floatValue, 2.3, "floatValue");
     assert.deepEqual(instance.stringValue, "Some string value", "stringValue");
     assert.deepEqual(instance.integerArray, [1, 2, 3], "integerArray");
     assert.deepEqual(instance.stringArray, ["1", "2", "3"], "stringArray");
-    assert.deepEqual(instance.colorArray, [2 /* blue */, 1 /* green */, 0 /* red */], "colorArray");
-    assert.deepEqual(instance.colorValue, 1 /* green */, "colorValue");
+    assert.deepEqual(instance.colorArray, [BasicTypes.Color.blue, BasicTypes.Color.green, BasicTypes.Color.red], "colorArray");
+    assert.deepEqual(instance.colorValue, BasicTypes.Color.green, "colorValue");
     assert.deepEqual(instance.anyValueString, "AnyValueString", "anyValueString");
     assert.deepEqual(instance.anyValueInteger, 1, "anyValueInteger");
     assert.deepEqual(instance.dynamicValueInteger, 7, "dynamicValueInteger");
     assert.deepEqual(instance.voidFunction(), instance.undefinedValue, "Void and undefined values");
 });
-
 QUnit.test("Issue #430", function (assert) {
     var instance = new BasicTypes.BasicTypes();
-
     assert.deepEqual(instance.twoDimensionalArray[0][0], 1, "Getting twoDimensionalArray[0][0] = 1");
     assert.deepEqual(instance.twoDimensionalArray[0][1], 2, "Getting twoDimensionalArray[0][1] = 2");
     assert.deepEqual(instance.twoDimensionalArray[0][2], 3, "Getting twoDimensionalArray[0][2] = 3");
     assert.deepEqual(instance.twoDimensionalArray[1][0], 5, "Getting twoDimensionalArray[1][0] = 5");
     assert.deepEqual(instance.twoDimensionalArray[1][1], 8, "Getting twoDimensionalArray[1][1] = 8");
-
     instance.twoDimensionalArray[0][0] = 10;
     assert.deepEqual(instance.twoDimensionalArray[0][0], 10, "Setting twoDimensionalArray[0][0] = 10");
-
     instance.twoDimensionalArray[0][1] = 20;
     assert.deepEqual(instance.twoDimensionalArray[0][1], 20, "Setting twoDimensionalArray[0][1] = 20");
-
     instance.twoDimensionalArray[0][2] = 30;
     assert.deepEqual(instance.twoDimensionalArray[0][2], 30, "Setting twoDimensionalArray[0][2] = 30");
-
     instance.twoDimensionalArray[1][0] = 50;
     assert.deepEqual(instance.twoDimensionalArray[1][0], 50, "Setting twoDimensionalArray[1][0] = 50");
-
     instance.twoDimensionalArray[1][1] = 80;
     assert.deepEqual(instance.twoDimensionalArray[1][1], 80, "Setting twoDimensionalArray[1][1] = 80");
 });
-
 QUnit.test("Reserved words", function (assert) {
     var k = new BasicTypes.Keywords();
-
     assert.deepEqual(k.$break, "break", "break");
     assert.deepEqual(k.$case, "case", "case");
     assert.deepEqual(k.$catch, "catch", "catch");

--- a/Tests/Runner/TypeScript/Batch1/2_Interfaces.js
+++ b/Tests/Runner/TypeScript/Batch1/2_Interfaces.js
@@ -1,122 +1,89 @@
-﻿/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
+/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\bridge.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\interfaces.d.ts" />
 QUnit.module("TypeScript - Interfaces");
 QUnit.test("Simple field and property", function (assert) {
     var instance = new Interfaces.Class1();
-
     TestInstance1(assert, instance);
 });
-
 QUnit.test("Four methods", function (assert) {
     var instance = new Interfaces.Class2();
-
     TestInstance1(assert, instance);
-
     TestInstance2(assert, instance);
 });
-
 QUnit.test("Fifth method through Interface3", function (assert) {
     var instance = new Interfaces.Class3();
-
     TestInstance1(assert, instance);
-
     TestInstance2(assert, instance);
-
     TestInstance3(assert, instance);
 });
-
 QUnit.test("Out and reference parameters", function (assert) {
     var instance = new Interfaces.Class4();
     TestInstance4(assert, instance);
 });
-
 QUnit.test("Property setter and getter with same names as methods", function (assert) {
     var instance = new Interfaces.Class6();
     TestInstance6(assert, instance);
 });
-
 function TestInstance1(assert, instance) {
     var interface1 = instance;
-
     assert.deepEqual(interface1.getProperty(), 100, "Interface1 Property getter");
     assert.deepEqual(instance.field, 200, "Class1 Field initial value");
-
     interface1.setProperty(300);
     assert.deepEqual(instance.getProperty(), 300, "Class1 Property setter");
 }
-
 function TestInstance2(assert, instance) {
     var interface2 = instance;
-
     interface2.method1();
     assert.deepEqual(interface2.getProperty(), 2, "Method1() through Property");
     assert.deepEqual(instance.field, 1, "Method1() through Fileld");
-
     interface2.method2("1234567");
     assert.deepEqual(instance.field, 7, "Method2() through Field");
-
     assert.deepEqual(interface2.method3(), instance.field, "Method3 through Field");
-
     assert.ok(interface2.method4(instance), "Method4 through return result");
     assert.deepEqual(instance.field, interface2.getProperty(), "Method4 through Field");
 }
-
 function TestInstance3(assert, instance) {
     var interface3 = instance;
-
     var interface2 = interface3.method5(interface3);
     assert.deepEqual(interface3.getProperty(), interface2.getProperty(), "Method5 through Property");
-
     var instance1 = instance;
     assert.deepEqual(instance1.field, instance.field, "Method5 through Field");
 }
-
 function TestInstance4(assert, instance) {
     var interface4 = instance;
-
     var boolValue = false;
     var boolRef = { v: boolValue };
-
     instance.method6(boolRef);
     assert.deepEqual(boolRef.v, true, "Method6() out bool parameter");
-
     boolRef.v = false;
     instance.method7(1, boolRef);
     assert.deepEqual(boolRef.v, true, "Method7() int, out bool parameter");
-
     var stringValue = "ABC_";
     var stringRef = { v: stringValue };
     instance.method8(stringRef);
     assert.deepEqual(stringRef.v, "ABC_Method8", "Method8() ref string parameter");
-
     stringRef.v = "ABC_";
     instance.method9(1, stringRef);
     assert.deepEqual(stringRef.v, "ABC_1", "Method9() int, ref string parameter");
-
     stringRef.v = "ABC_";
     boolRef.v = false;
     instance.method10(2, boolRef, stringRef);
     assert.deepEqual(boolRef.v, true, "Method10() int, ref bool, out bool parameter");
     assert.deepEqual(stringRef.v, "ABC_2", "Method10() int, ref bool, ref string parameter");
 }
-
 function TestInstance6(assert, instance) {
     var interface6 = instance;
-
     interface6.setProperty$3(1);
     assert.deepEqual(instance.getProperty$3(), 1, "Property getter and setter");
-
     interface6.setProperty$1("12");
     assert.deepEqual(instance.getMethodProperty(), 2, "setProperty$1(string) and MethodProperty");
     assert.deepEqual(instance.getProperty(), 2, "setPropert$1(string) and getProperty");
     assert.notDeepEqual(instance.getProperty(), instance.getProperty$3(), "getProperty and getProperty$3");
-
     interface6.setProperty(3);
     assert.deepEqual(instance.getMethodProperty(), 3, "setProperty(int) and MethodProperty");
     assert.deepEqual(instance.getProperty(), 3, "setPropert$1(int) and getProperty");
     assert.notDeepEqual(instance.getProperty$3(), instance.getProperty(), "getProperty$3 and getProperty");
-
     var interface61 = instance;
     var interface62 = instance;
 }

--- a/Tests/Runner/TypeScript/Batch1/3_Classes.js
+++ b/Tests/Runner/TypeScript/Batch1/3_Classes.js
@@ -1,71 +1,53 @@
-﻿/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
+/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\bridge.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\classes.d.ts" />
 QUnit.module("TypeScript - Classes");
 QUnit.test("Inheritance", function (assert) {
     var animal = new Classes.Animal.$constructor();
     QUnit.deepEqual(animal.getName(), "Animal", "Animal name parameterless constructor");
-
     animal = new Classes.Animal.constructor$1("A");
     QUnit.deepEqual(animal.getName(), "A", "Animal name");
-
     // TODO #292 Should not require optional parameters
     QUnit.deepEqual(animal.move(), 1, "Animal move");
-
     var snake = new Classes.Snake("S");
     QUnit.deepEqual(snake.getName(), "S", "Snake name");
-
     // TODO #292 Should not require optional parameters
     QUnit.deepEqual(snake.move(), 5, "Snake move");
-
     animal = snake;
     QUnit.deepEqual(animal.getName(), "S", "Snake as Animal name");
-
     // TODO #292 Should not require optional parameters
     QUnit.deepEqual(animal.move(), 5, "Snake as Animal move");
-
     var dog = new Classes.Dog("D");
     QUnit.deepEqual(dog.getName(), "D", "Dogname");
-
     // TODO #292 Should not require optional parameters
     QUnit.deepEqual(dog.move(), 1, "Dog move");
     QUnit.deepEqual(dog.move$1(), 20, "Dog another move");
-
     animal = dog;
     QUnit.deepEqual(animal.getName(), "D", "Dog as Animal name");
-
     // TODO #292 Should not require optional parameters
     QUnit.deepEqual(animal.move(), 1, "Dog as Animal move");
-
     var employee = new Classes.Employee("E", 1);
     QUnit.deepEqual(employee.getName(), "E", "Employee name");
-
     // TODO #292 Should not require optional parameters
     QUnit.deepEqual(employee.move(), 1, "Employee move");
-
     animal = employee;
     QUnit.deepEqual(animal.getName(), "E", "Employee as Animal name");
-
     // TODO #292 Should not require optional parameters
     QUnit.deepEqual(animal.move(), 1, "Employee as Animal move");
 });
-
 QUnit.test("Static", function (assert) {
     var point1 = new Classes.Point.constructor$1(10, 20);
     QUnit.deepEqual(point1.x, 10, "Point x field");
     QUnit.deepEqual(point1.y, 20, "Point y field");
-
     var point2 = Classes.StaticClass.move(point1, -20, -40);
     QUnit.deepEqual(point1.x, 10, "Point x field not changed");
     QUnit.deepEqual(point1.y, 20, "Point y field not changed");
     QUnit.deepEqual(point2.x, -10, "Point x field moved");
     QUnit.deepEqual(point2.y, -20, "Point y field moved");
-
     var movePoint = new Classes.MovePoint();
     movePoint.setPoint(point1);
     QUnit.deepEqual(movePoint.getPoint().x, 10, "MovePoint x field");
     QUnit.deepEqual(movePoint.getPoint().y, 20, "MovePoint y field");
-
     movePoint.move(5, 7);
     QUnit.deepEqual(point1.x, 10, "Point x field not changed");
     QUnit.deepEqual(point1.y, 20, "Point y field not changed");

--- a/Tests/Runner/TypeScript/Batch1/4_Functions.js
+++ b/Tests/Runner/TypeScript/Batch1/4_Functions.js
@@ -1,10 +1,9 @@
-﻿/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
+/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\bridge.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\functions.d.ts" />
 QUnit.module("TypeScript - Functions");
 QUnit.test("Parameters", function (assert) {
     var func = new Functions.Parameters();
-
     // TODO Bridge/#292
     // QUnit.deepEqual(func.getSomething(), 5, "Default parameter #292");
     //function buildName(firstName: string, lastName = "Smith") {
@@ -16,27 +15,16 @@ QUnit.test("Parameters", function (assert) {
     // #293
     QUnit.deepEqual(func.join([1, 2, 3]), "123", "params argument becomes Array #293");
 });
-
 QUnit.test("Function types", function (assert) {
     var d = new Functions.DelegateClass();
-
     var ds;
     var di;
-
-    d.methodVoidDelegate = function () {
-        return di = 7;
-    };
+    d.methodVoidDelegate = function () { return di = 7; };
     d.methodVoidDelegate();
     QUnit.deepEqual(di, 7, "methodVoidDelegate");
-
-    d.methodStringDelegate = function (s) {
-        return ds = s;
-    };
+    d.methodStringDelegate = function (s) { return ds = s; };
     d.methodStringDelegate("Privet");
     QUnit.deepEqual(ds, "Privet", "methodStringDelegate");
-
-    d.methodStringDelegateIntResult = function (s) {
-        return s.length;
-    };
+    d.methodStringDelegateIntResult = function (s) { return s.length; };
     QUnit.deepEqual(d.methodStringDelegateIntResult("Privet"), 6, "methodStringDelegateIntResult");
 });

--- a/Tests/Runner/TypeScript/Batch1/5_Generics.js
+++ b/Tests/Runner/TypeScript/Batch1/5_Generics.js
@@ -1,15 +1,13 @@
-﻿/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
+/// <reference path="..\..\Runner\resources\qunit\qunit.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\bridge.d.ts" />
 /// <reference path="..\..\Runner\TypeScript\App1\generics.d.ts" />
 QUnit.module("TypeScript - Generics");
 QUnit.test("Check predefined generic instances", function (assert) {
     var g1 = Generics.implementation.simpleGenericInt;
     QUnit.deepEqual(g1.getSomething(5), 5, "simpleGenericInt");
-
     var g2 = Generics.implementation.simpleDoubleGenericIntString;
     QUnit.deepEqual(g2.getSomething(5), 5, "simpleDoubleGenericIntString - int");
     QUnit.deepEqual(g2.getSomethingMore("25"), "25", "simpleDoubleGenericIntString - string");
-
     var g3 = Generics.implementation.genericINamedEntity;
     var i3 = new Generics.NamedEntity();
     i3.setName$1("Dove");
@@ -17,7 +15,6 @@ QUnit.test("Check predefined generic instances", function (assert) {
     QUnit.deepEqual(r3, i3, "genericINamedEntity");
     QUnit.deepEqual(r3 instanceof Generics.INamedEntity, true, "genericINamedEntity instance of INameEntity");
     QUnit.deepEqual(r3 instanceof Generics.NamedEntity, true, "genericINamedEntity instance of NameEntity");
-
     var g4 = Generics.implementation.genericNamedEntity;
     var i4 = new Generics.NamedEntity();
     i4.setName$1("Eagle");
@@ -25,12 +22,10 @@ QUnit.test("Check predefined generic instances", function (assert) {
     QUnit.deepEqual(r4, i4, "genericNamedEntity");
     QUnit.deepEqual(r4 instanceof Generics.INamedEntity, true, "genericNamedEntity instance of INameEntity");
     QUnit.deepEqual(r4 instanceof Generics.NamedEntity, true, "genericNamedEntity instance of NameEntity");
-
     var g5 = Generics.implementation.genericClassObject;
     var i5 = "class object";
     var r5 = g5.getSomething(i5);
     QUnit.deepEqual(r5, i5, "genericClassObject");
-
     // TODO #296
     //QUnit.deepEqual(r5 instanceof Object, true, "genericClassObject instance of Object");
     var g6 = Generics.implementation.genericClassNamedEntity;
@@ -40,14 +35,12 @@ QUnit.test("Check predefined generic instances", function (assert) {
     QUnit.deepEqual(r6, i6, "genericClassNamedEntity");
     QUnit.deepEqual(r6 instanceof Generics.INamedEntity, true, "genericClassNamedEntity instance of INameEntity");
     QUnit.deepEqual(r6 instanceof Generics.NamedEntity, true, "genericClassNamedEntity instance of NameEntity");
-
     var g7 = Generics.implementation.genericNew;
     var i7 = new Generics.NewClass();
     i7.data = 700;
     var r7 = g7.getSomething(i7);
     QUnit.deepEqual(r7, i7, "genericNew");
     QUnit.deepEqual(r7 instanceof Generics.NewClass, true, "genericNew instance of NewClass");
-
     var g8 = Generics.implementation.genericNewAndClass;
     var i8 = new Generics.NewClass();
     i8.data = 800;
@@ -55,61 +48,50 @@ QUnit.test("Check predefined generic instances", function (assert) {
     QUnit.deepEqual(r8, i8, "genericNewAndClass");
     QUnit.deepEqual(r8 instanceof Generics.NewClass, true, "genericNewAndClass instance of NewClass");
 });
-
 QUnit.test("Create generic instances", function (assert) {
     var name = "My name is Named Entity";
     var namedEntity = new Generics.NamedEntity();
     namedEntity.setName$1(name);
-
     var c10 = new (Generics.SimpleGeneric$1(Number))(5);
     QUnit.deepEqual(c10.getSomething(7), 7, "simpleGeneric$1(Number) getSomething");
     QUnit.deepEqual(c10.instance, 5, "simpleGeneric$1(Number) instance");
-
     var c11 = new (Generics.SimpleGeneric$1(Generics.NamedEntity))(namedEntity);
     QUnit.deepEqual(c11.getSomething(namedEntity).getName$1(), name, "SimpleGeneric$1(Generics.NamedEntity) getSomething");
     QUnit.deepEqual(c11.instance, namedEntity, "SimpleGeneric$1(Generics.NamedEntity) instance");
-
     var c20 = new (Generics.SimpleDoubleGeneric$2(Object, Number).constructor$1)("I'm object", 35);
     QUnit.deepEqual(c20.getSomething(5), 5, "SimpleDoubleGeneric$2(Object, Number) getSomething");
     QUnit.deepEqual(c20.getSomethingMore(25), 25, "SimpleDoubleGeneric$2(Object, Number) getSomethingMore");
     QUnit.deepEqual(c20.instanceT, "I'm object", "SimpleDoubleGeneric$2(Object, Number) instanceT");
     QUnit.deepEqual(c20.instanceK, 35, "SimpleDoubleGeneric$2(Object, Number) instanceK");
-
     var c21 = new (Generics.SimpleDoubleGeneric$2(Object, Number).$constructor)();
     QUnit.deepEqual(c21.getSomething(7), 7, "SimpleDoubleGeneric$2(Object, Number) parameterless constructor getSomething");
     QUnit.deepEqual(c21.getSomethingMore(35), 35, "SimpleDoubleGeneric$2(Object, Number) parameterless constructor getSomethingMore");
     QUnit.deepEqual(c21.instanceT, null, "SimpleDoubleGeneric$2(Object, Number) instanceT");
     QUnit.deepEqual(c21.instanceK, null, "SimpleDoubleGeneric$2(Object, Number) instanceK");
-
     var c30 = new (Generics.GenericINamedEntity$1(Generics.NamedEntity))(namedEntity);
     QUnit.deepEqual(c30.getSomething(namedEntity).getName$1(), name, "GenericINamedEntity$1(Generics.NamedEntity) getSomething");
     QUnit.deepEqual(c30.instance, namedEntity, "GenericINamedEntity$1(Generics.NamedEntity) instance");
-
     var c40 = new (Generics.GenericNamedEntity$1(Generics.NamedEntity))(namedEntity);
     QUnit.deepEqual(c40.getSomething(namedEntity).getName$1(), name, "GenericNamedEntity$1(Generics.NamedEntity) getSomething");
     QUnit.deepEqual(c40.instance, namedEntity, "GenericNamedEntity$1(Generics.NamedEntity) instance");
-
     var c50 = new (Generics.GenericClass$1(Generics.NamedEntity))(namedEntity);
     QUnit.deepEqual(c50.getSomething(namedEntity).getName$1(), name, "GenericClass$1(Generics.NamedEntity) getSomething");
     QUnit.deepEqual(c50.instance, namedEntity, "GenericClass$1(Generics.NamedEntity) instance");
     var c51 = new (Generics.GenericClass$1(String))("Trest");
     QUnit.deepEqual(c51.getSomething("Just string"), "Just string", "GenericClass$1(String) getSomething");
     QUnit.deepEqual(c51.instance, "Trest", "GenericClass$1(String) instance");
-
     var c60 = new (Generics.GenericStruct$1(Generics.NamedEntity))(namedEntity);
     QUnit.deepEqual(c60.getSomething(namedEntity).getName$1(), name, "GenericStruct$1(Generics.NamedEntity) getSomething");
     QUnit.deepEqual(c60.instance, namedEntity, "GenericStruct$1(Generics.NamedEntity) instance");
     var c61 = new (Generics.GenericStruct$1(String))("Trest");
     QUnit.deepEqual(c61.getSomething("Just string"), "Just string", "GenericStruct$1(String) getSomething");
     QUnit.deepEqual(c61.instance, "Trest", "GenericStruct$1(String) instance");
-
     var c70 = new (Generics.GenericNew$1(String))("New trest");
     QUnit.deepEqual(c70.getSomething("Just string"), "Just string", "GenericNew$1(String) getSomething");
     QUnit.deepEqual(c70.instance, "New trest", "GenericNew$1(String) instance");
     var c71 = new (Generics.GenericNew$1(Object))("New trest");
     QUnit.deepEqual(c71.getSomething("Just string"), "Just string", "GenericNew$1(Object) getSomething");
     QUnit.deepEqual(c71.instance, "New trest", "GenericNew$1(Object) instance");
-
     var c80 = new (Generics.GenericNewAndClass$1(String))("New trest80");
     QUnit.deepEqual(c80.getSomething("Just string80"), "Just string80", "GenericNewAndClass$1(String) getSomething");
     QUnit.deepEqual(c80.instance, "New trest80", "GenericNewAndClass$1(String) instance");


### PR DESCRIPTION
Fixes # .
There is an error when Math.Min\Max are given float arguments. One of our clients reported this bug to us.
Changes proposed in this pull request:
- Add overloaded methods for several math functions in order to prevent errors when using the math functions with float arguments