### PR TITLE
System.math overloaded methods

### DIFF
--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -82,8 +82,8 @@ namespace System
         [Template("Bridge.Math.round({d}, 0, 6)")]
         public static extern double Round(double d);
 
-		[Template("Bridge.Math.round({d}, 0, 6)")]
-		public static extern float Round(float f);
+        [Template("Bridge.Math.round({d}, 0, 6)")]
+        public static extern float Round(float f);
 
         [Template("Math.round({d})")]
         public static extern double JsRound(double d);
@@ -103,8 +103,8 @@ namespace System
         [Template("Bridge.Math.round({d}, 0, {method})")]
         public static extern double Round(double d, MidpointRounding method);
 
-		[Template("Bridge.Math.round({d}, 0, {method})")]
-		public static extern float Round(float f, MidpointRounding method);
+        [Template("Bridge.Math.round({d}, 0, {method})")]
+        public static extern float Round(float f, MidpointRounding method);
 
         [Template("System.Decimal.toDecimalPlaces({d}, {digits}, {method})")]
         public static extern decimal Round(decimal d, int digits, MidpointRounding method);

--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -7,10 +7,28 @@ namespace System
     public static class Math
     {
         [Name(false)]
-        public const double E = 2.7182818284590452354;
+        public static readonly double E = 0;
 
         [Name(false)]
-        public const double PI = 3.14159265358979323846;
+        public static readonly double LN10 = 0;
+
+        [Name(false)]
+        public static readonly double LN2 = 0;
+
+        [Name(false)]
+        public static readonly double LOG2E = 0;
+
+        [Name(false)]
+        public static readonly double LOG10E = 0;
+
+        [Name(false)]
+        public static readonly double PI = 0;
+
+        [Name(false)]
+        public static readonly double SQRT1_2 = 0;
+
+        [Name(false)]
+        public static readonly double SQRT2 = 0;
 
         public static extern int Abs(int x);
 
@@ -28,13 +46,15 @@ namespace System
 
         public static extern double Max(params double[] values);
 
-        [Template("System.Int64.max({*values})")]
+		public static extern float Max(params float[] values);
+
+        [Template("Bridge.Long.max({*values})")]
         public static extern long Max(params long[] values);
 
-        [Template("System.UInt64.max({*values})")]
+        [Template("Bridge.ULong.max({*values})")]
         public static extern ulong Max(params ulong[] values);
 
-        [Template("System.Decimal.max({*values})")]
+        [Template("Bridge.Decimal.max({*values})")]
         public static extern decimal Max(params decimal[] values);
 
         public static extern int Min(params int[] values);
@@ -43,16 +63,20 @@ namespace System
 
         public static extern double Min(params double[] values);
 
-        [Template("System.Int64.min({*values})")]
+		public static extern float Min(params float[] value);
+
+        [Template("Bridge.Long.min({*values})")]
         public static extern long Min(params long[] values);
 
-        [Template("System.UInt64.min({*values})")]
+        [Template("Bridge.ULong.min({*values})")]
         public static extern ulong Min(params ulong[] values);
 
-        [Template("System.Decimal.min({*values})")]
+        [Template("Bridge.Decimal.min({*values})")]
         public static extern decimal Min(params decimal[] values);
 
         public static extern double Random();
+
+        public static extern double Sqrt(int x);
 
         public static extern double Sqrt(double x);
 
@@ -62,78 +86,116 @@ namespace System
         [Name("ceil")]
         public static extern double Ceiling(double d);
 
+		public static extern float Ceiling(float f);
+
         public static extern double Floor(double x);
+
+		public static extern float Floor(float f);
 
         [Template("{d}.floor()")]
         public static extern decimal Floor(decimal d);
 
-        [Template("System.Decimal.round({x}, 6)")]
+        [Template("Bridge.Decimal.round({x}, 6)")]
         public static extern decimal Round(decimal x);
+
+		
 
         [Template("Bridge.Math.round({d}, 0, 6)")]
         public static extern double Round(double d);
 
+		public static extern float Round(float f);
+
         [Template("Math.round({d})")]
         public static extern double JsRound(double d);
 
-        [Template("System.Decimal.toDecimalPlaces({d}, {digits}, 6)")]
+        [Template("Bridge.Decimal.toDecimalPlaces({d}, {digits}, 6)")]
         public static extern decimal Round(decimal d, int digits);
 
         [Template("Bridge.Math.round({d}, {digits}, 6)")]
         public static extern double Round(double d, int digits);
 
-        [Template("System.Decimal.round({d}, {method})")]
+		public static extern float Round(float f, int digits);
+
+        [Template("Bridge.Decimal.round({d}, {method})")]
         public static extern decimal Round(decimal d, MidpointRounding method);
 
         [Template("Bridge.Math.round({d}, 0, {method})")]
         public static extern double Round(double d, MidpointRounding method);
 
-        [Template("System.Decimal.toDecimalPlaces({d}, {digits}, {method})")]
+		public static extern float Round(float f, MidpointRounding method);
+
+        [Template("Bridge.Decimal.toDecimalPlaces({d}, {digits}, {method})")]
         public static extern decimal Round(decimal d, int digits, MidpointRounding method);
 
         [Template("Bridge.Math.round({d}, {digits}, {method})")]
         public static extern double Round(double d, int digits, MidpointRounding method);
+
+		public static extern float Round(float f, int digits, MidpointRounding method);
 
         [Template("{x} - ({y} * Math.round({x} / {y}))")]
         public static extern double IEEERemainder(double x, double y);
 
         public static extern double Exp(double x);
 
+		public static extern double Exp(float x);
+
         [Template("{x}.exponential()")]
         public static extern decimal Exp(decimal x);
 
-        [Template("Bridge.Math.log({x})")]
-        public static extern double Log(double x);
+        [Template("{x}.ln()")]
+        public static extern decimal Ln(decimal x);
 
-        [Template("Bridge.Math.logWithBase({x}, {logBase})")]
-        public static extern double Log(double x, double logBase);
-
-        [Template("Bridge.Math.logWithBase({x}, 10.0)")]
-        public static extern double Log10(double x);
+        [Template("{x}.log({logBase})")]
+        public static extern decimal Log(decimal x, decimal logBase);
 
         [Template("{x}.pow({y})")]
         public static extern decimal Pow(decimal x, decimal y);
+
+        [Template("{x}.sqrt()")]
+        public static extern decimal Sqrt(decimal x);
+
+        public static extern double Log(double x);
+
+		public static extern double Log(float x);
 
         public static extern double Pow(double x, double y);
 
         public static extern double Pow(int x, int y);
 
+		public static extern double Pow(float x, float y);
+
         public static extern double Acos(double x);
+
+		public static extern double Acos(float x);
 
         public static extern double Asin(double x);
 
+		public static extern double Asin(float x);
+
         public static extern double Atan(double x);
+
+		public static extern double Atan(float f);
 
         public static extern double Atan2(double y, double x);
 
+		public static extern double Atan2(float y, float x);
+
         public static extern double Cos(double x);
+
+		public static extern double Cos(float f);
 
         public static extern double Sin(double x);
 
+		public static extern double Sin(float x);
+
         public static extern double Tan(double x);
+
+		public static extern double Tan(float f);
 
         [Template("Bridge.Int.trunc({d})")]
         public static extern double Truncate(double d);
+
+		public static extern float Truncate(float f);
 
         [Template("{d}.trunc()")]
         public static extern decimal Truncate(decimal d);
@@ -147,16 +209,7 @@ namespace System
         [Template("Bridge.Math.divRem({a}, {b}, {result})")]
         public static extern int DivRem(int a, int b, out int result);
 
-        [Template("System.Int64.divRem({a}, {b}, {result})")]
+        [Template("Bridge.Long.divRem({a}, {b}, {result})")]
         public static extern long DivRem(long a, long b, out long result);
-
-        [Template("Bridge.Math.sinh({value})")]
-        public static extern double Sinh(double value);
-
-        [Template("Bridge.Math.cosh({value})")]
-        public static extern double Cosh(double value);
-
-        [Template("Bridge.Math.tanh({value})")]
-        public static extern double Tanh(double value);
     }
 }

--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -26,10 +26,10 @@ namespace System
 
         public static extern int Max(params uint[] values);
 
-		public static extern float Max(params float[] values);
+        public static extern float Max(params float[] values);
 
-		public static extern double Max(params double[] values);
-	
+        public static extern double Max(params double[] values);
+
         [Template("System.Int64.max({*values})")]
         public static extern long Max(params long[] values);
 
@@ -66,6 +66,7 @@ namespace System
         [Name("ceil")]
         public static extern double Ceiling(double d);
 
+        [Name("ceil")]
         public static extern float Ceiling(float f);
 
         public static extern double Floor(double x);
@@ -81,7 +82,8 @@ namespace System
         [Template("Bridge.Math.round({d}, 0, 6)")]
         public static extern double Round(double d);
 
-        public static extern float Round(float f);
+		[Template("Bridge.Math.round({d}, 0, 6)")]
+		public static extern float Round(float f);
 
         [Template("Math.round({d})")]
         public static extern double JsRound(double d);
@@ -92,6 +94,7 @@ namespace System
         [Template("Bridge.Math.round({d}, {digits}, 6)")]
         public static extern double Round(double d, int digits);
 
+        [Template("Bridge.Math.round({d}, {digits}, 6)")]
         public static extern float Round(float f, int digits);
 
         [Template("System.Decimal.round({d}, {method})")]
@@ -100,7 +103,8 @@ namespace System
         [Template("Bridge.Math.round({d}, 0, {method})")]
         public static extern double Round(double d, MidpointRounding method);
 
-        public static extern float Round(float f, MidpointRounding method);
+		[Template("Bridge.Math.round({d}, 0, {method})")]
+		public static extern float Round(float f, MidpointRounding method);
 
         [Template("System.Decimal.toDecimalPlaces({d}, {digits}, {method})")]
         public static extern decimal Round(decimal d, int digits, MidpointRounding method);
@@ -108,6 +112,7 @@ namespace System
         [Template("Bridge.Math.round({d}, {digits}, {method})")]
         public static extern double Round(double d, int digits, MidpointRounding method);
 
+        [Template("Bridge.Math.round({d}, {digits}, {method})")]
         public static extern float Round(float f, int digits, MidpointRounding method);
 
         [Template("{x} - ({y} * Math.round({x} / {y}))")]

--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -7,28 +7,10 @@ namespace System
     public static class Math
     {
         [Name(false)]
-        public static readonly double E = 0;
+        public const double E = 2.7182818284590452354;
 
         [Name(false)]
-        public static readonly double LN10 = 0;
-
-        [Name(false)]
-        public static readonly double LN2 = 0;
-
-        [Name(false)]
-        public static readonly double LOG2E = 0;
-
-        [Name(false)]
-        public static readonly double LOG10E = 0;
-
-        [Name(false)]
-        public static readonly double PI = 0;
-
-        [Name(false)]
-        public static readonly double SQRT1_2 = 0;
-
-        [Name(false)]
-        public static readonly double SQRT2 = 0;
+        public const double PI = 3.14159265358979323846;
 
         public static extern int Abs(int x);
 
@@ -48,13 +30,13 @@ namespace System
 
 		public static extern float Max(params float[] values);
 
-        [Template("Bridge.Long.max({*values})")]
+        [Template("System.Int64.max({*values})")]
         public static extern long Max(params long[] values);
 
-        [Template("Bridge.ULong.max({*values})")]
+        [Template("System.UInt64.max({*values})")]
         public static extern ulong Max(params ulong[] values);
 
-        [Template("Bridge.Decimal.max({*values})")]
+        [Template("System.Decimal.max({*values})")]
         public static extern decimal Max(params decimal[] values);
 
         public static extern int Min(params int[] values);
@@ -65,18 +47,16 @@ namespace System
 
 		public static extern float Min(params float[] value);
 
-        [Template("Bridge.Long.min({*values})")]
+        [Template("System.Int64.min({*values})")]
         public static extern long Min(params long[] values);
 
-        [Template("Bridge.ULong.min({*values})")]
+        [Template("System.UInt64.min({*values})")]
         public static extern ulong Min(params ulong[] values);
 
-        [Template("Bridge.Decimal.min({*values})")]
+        [Template("System.Decimal.min({*values})")]
         public static extern decimal Min(params decimal[] values);
 
         public static extern double Random();
-
-        public static extern double Sqrt(int x);
 
         public static extern double Sqrt(double x);
 
@@ -86,24 +66,22 @@ namespace System
         [Name("ceil")]
         public static extern double Ceiling(double d);
 
-		public static extern float Ceiling(float f);
+        public static extern float Ceiling(float f);
 
         public static extern double Floor(double x);
 
-		public static extern float Floor(float f);
+        public static extern float Floor(float f);
 
         [Template("{d}.floor()")]
         public static extern decimal Floor(decimal d);
 
-        [Template("Bridge.Decimal.round({x}, 6)")]
+        [Template("System.Decimal.round({x}, 6)")]
         public static extern decimal Round(decimal x);
-
-		
 
         [Template("Bridge.Math.round({d}, 0, 6)")]
         public static extern double Round(double d);
 
-		public static extern float Round(float f);
+        public static extern float Round(float f);
 
         [Template("Math.round({d})")]
         public static extern double JsRound(double d);
@@ -114,36 +92,36 @@ namespace System
         [Template("Bridge.Math.round({d}, {digits}, 6)")]
         public static extern double Round(double d, int digits);
 
-		public static extern float Round(float f, int digits);
+        public static extern float Round(float f, int digits);
 
-        [Template("Bridge.Decimal.round({d}, {method})")]
+        [Template("System.Decimal.round({d}, {method})")]
         public static extern decimal Round(decimal d, MidpointRounding method);
 
         [Template("Bridge.Math.round({d}, 0, {method})")]
         public static extern double Round(double d, MidpointRounding method);
 
-		public static extern float Round(float f, MidpointRounding method);
+        public static extern float Round(float f, MidpointRounding method);
 
-        [Template("Bridge.Decimal.toDecimalPlaces({d}, {digits}, {method})")]
+        [Template("System.Decimal.toDecimalPlaces({d}, {digits}, {method})")]
         public static extern decimal Round(decimal d, int digits, MidpointRounding method);
 
         [Template("Bridge.Math.round({d}, {digits}, {method})")]
         public static extern double Round(double d, int digits, MidpointRounding method);
 
-		public static extern float Round(float f, int digits, MidpointRounding method);
+        public static extern float Round(float f, int digits, MidpointRounding method);
 
         [Template("{x} - ({y} * Math.round({x} / {y}))")]
         public static extern double IEEERemainder(double x, double y);
 
         public static extern double Exp(double x);
 
-		public static extern double Exp(float x);
+        public static extern double Exp(float x);
 
         [Template("{x}.exponential()")]
         public static extern decimal Exp(decimal x);
 
-        [Template("{x}.ln()")]
-        public static extern decimal Ln(decimal x);
+        [Template("Bridge.Math.log({x})")]
+        public static extern double Log(double x);
 
         [Template("{x}.log({logBase})")]
         public static extern decimal Log(decimal x, decimal logBase);
@@ -154,48 +132,46 @@ namespace System
         [Template("{x}.sqrt()")]
         public static extern decimal Sqrt(decimal x);
 
-        public static extern double Log(double x);
-
-		public static extern double Log(float x);
+        public static extern double Log(float x);
 
         public static extern double Pow(double x, double y);
 
         public static extern double Pow(int x, int y);
 
-		public static extern double Pow(float x, float y);
+        public static extern double Pow(float x, float y);
 
         public static extern double Acos(double x);
 
-		public static extern double Acos(float x);
+        public static extern double Acos(float x);
 
         public static extern double Asin(double x);
 
-		public static extern double Asin(float x);
+        public static extern double Asin(float x);
 
         public static extern double Atan(double x);
 
-		public static extern double Atan(float f);
+        public static extern double Atan(float f);
 
         public static extern double Atan2(double y, double x);
 
-		public static extern double Atan2(float y, float x);
+        public static extern double Atan2(float y, float x);
 
         public static extern double Cos(double x);
 
-		public static extern double Cos(float f);
+        public static extern double Cos(float f);
 
         public static extern double Sin(double x);
 
-		public static extern double Sin(float x);
+        public static extern double Sin(float x);
 
         public static extern double Tan(double x);
 
-		public static extern double Tan(float f);
+        public static extern double Tan(float f);
 
         [Template("Bridge.Int.trunc({d})")]
         public static extern double Truncate(double d);
 
-		public static extern float Truncate(float f);
+        public static extern float Truncate(float f);
 
         [Template("{d}.trunc()")]
         public static extern decimal Truncate(decimal d);
@@ -209,7 +185,16 @@ namespace System
         [Template("Bridge.Math.divRem({a}, {b}, {result})")]
         public static extern int DivRem(int a, int b, out int result);
 
-        [Template("Bridge.Long.divRem({a}, {b}, {result})")]
+        [Template("System.Int64.divRem({a}, {b}, {result})")]
         public static extern long DivRem(long a, long b, out long result);
-    }
+
+		[Template("Bridge.Math.sinh({value})")]
+         public static extern double Sinh(double value);
+
+         [Template("Bridge.Math.cosh({value})")]
+         public static extern double Cosh(double value);
+
+         [Template("Bridge.Math.tanh({value})")]
+         public static extern double Tanh(double value);
+	}
 }

--- a/Bridge/System/Math.cs
+++ b/Bridge/System/Math.cs
@@ -26,10 +26,10 @@ namespace System
 
         public static extern int Max(params uint[] values);
 
-        public static extern double Max(params double[] values);
-
 		public static extern float Max(params float[] values);
 
+		public static extern double Max(params double[] values);
+	
         [Template("System.Int64.max({*values})")]
         public static extern long Max(params long[] values);
 
@@ -43,9 +43,9 @@ namespace System
 
         public static extern int Min(params uint[] values);
 
-        public static extern double Min(params double[] values);
+        public static extern float Min(params float[] value);
 
-		public static extern float Min(params float[] value);
+        public static extern double Min(params double[] values);
 
         [Template("System.Int64.min({*values})")]
         public static extern long Min(params long[] values);
@@ -86,7 +86,7 @@ namespace System
         [Template("Math.round({d})")]
         public static extern double JsRound(double d);
 
-        [Template("Bridge.Decimal.toDecimalPlaces({d}, {digits}, 6)")]
+        [Template("System.Decimal.toDecimalPlaces({d}, {digits}, 6)")]
         public static extern decimal Round(decimal d, int digits);
 
         [Template("Bridge.Math.round({d}, {digits}, 6)")]
@@ -123,8 +123,11 @@ namespace System
         [Template("Bridge.Math.log({x})")]
         public static extern double Log(double x);
 
-        [Template("{x}.log({logBase})")]
-        public static extern decimal Log(decimal x, decimal logBase);
+        [Template("Bridge.Math.logWithBase({x}, {logBase})")]
+        public static extern double Log(double x, double logBase);
+
+        [Template("Bridge.Math.logWithBase({x}, 10.0)")]
+        public static extern double Log10(double x);
 
         [Template("{x}.pow({y})")]
         public static extern decimal Pow(decimal x, decimal y);
@@ -188,13 +191,13 @@ namespace System
         [Template("System.Int64.divRem({a}, {b}, {result})")]
         public static extern long DivRem(long a, long b, out long result);
 
-		[Template("Bridge.Math.sinh({value})")]
-         public static extern double Sinh(double value);
+        [Template("Bridge.Math.sinh({value})")]
+        public static extern double Sinh(double value);
 
-         [Template("Bridge.Math.cosh({value})")]
-         public static extern double Cosh(double value);
+        [Template("Bridge.Math.cosh({value})")]
+        public static extern double Cosh(double value);
 
-         [Template("Bridge.Math.tanh({value})")]
-         public static extern double Tanh(double value);
-	}
+        [Template("Bridge.Math.tanh({value})")]
+        public static extern double Tanh(double value);
+    }
 }


### PR DESCRIPTION
Fixes # .
Missing overloaded math methods for System.Math.Min\Max and a few other methods
Changes proposed in this pull request:
- Overloaded methods in System.Math with float arguments. We use Bridge in our product and one of clients reported that they can't use System.Math.Min\Max with float arguments. We decided to add overloaded methods for Min\Max and some others just to be safe
