### PR TITLE
[2536] Setting outputBy to be Project by default (before - Namespace)

### DIFF
--- a/Compiler/Translator/Utils/AssemblyInfo.cs
+++ b/Compiler/Translator/Utils/AssemblyInfo.cs
@@ -40,7 +40,7 @@ namespace Bridge.Translator
             get; set;
         }
 
-        private OutputBy outputBy = OutputBy.Namespace;
+        private OutputBy outputBy = OutputBy.Project;
 
         /// <summary>
         /// The option to manage JavaScript output folders and files.

--- a/Compiler/TranslatorTests/CompilerTests/AssemblyInfoTests.cs
+++ b/Compiler/TranslatorTests/CompilerTests/AssemblyInfoTests.cs
@@ -29,7 +29,7 @@ namespace Bridge.Translator.Tests
             // #2476 Assert.False(config.PreserveMemberCase, "PreserveMemberCase");
 
             Assert.Null(config.FileName, "FileName");
-            Assert.AreEqual(OutputBy.Namespace, config.OutputBy, "OutputBy");
+            Assert.AreEqual(OutputBy.Project, config.OutputBy, "OutputBy");
             Assert.AreEqual(FileNameCaseConvert.CamelCase, config.FileNameCasing, "FileNameCasing");
             Assert.AreEqual(JavaScriptOutputType.Both, config.OutputFormatting, "OutputFormatting");
             Assert.AreEqual(0, config.StartIndexInName, "StartIndexInName");

--- a/Compiler/TranslatorTests/TestProjects/03/Bridge/bridge.json
+++ b/Compiler/TranslatorTests/TestProjects/03/Bridge/bridge.json
@@ -1,5 +1,6 @@
 {
   "output": "Bridge\\output",
+  "outputBy": "Namespace",
   "cleanOutputFolderBeforeBuildPattern": "*.*",
   "outputFormatting": "Minified"
 }

--- a/Compiler/TranslatorTests/TestProjects/10/Bridge/bridge.json
+++ b/Compiler/TranslatorTests/TestProjects/10/Bridge/bridge.json
@@ -1,5 +1,6 @@
 {
   "output": "Bridge\\output",
+  "outputBy": "Namespace",
   "cleanOutputFolderBeforeBuildPattern": "*.*",
   "fileNameCasing": "None",
   "outputFormatting": "Formatted",

--- a/Compiler/TranslatorTests/TestProjects/11/Bridge/bridge.json
+++ b/Compiler/TranslatorTests/TestProjects/11/Bridge/bridge.json
@@ -1,5 +1,6 @@
 {
   "output": "Bridge\\output",
+  "outputBy": "Namespace",
   "cleanOutputFolderBeforeBuildPattern": "*.*",
   "generateTypeScript": "true",
   "outputFormatting": "Formatted"

--- a/Compiler/TranslatorTests/TestProjects/18/Bridge/bridge.json
+++ b/Compiler/TranslatorTests/TestProjects/18/Bridge/bridge.json
@@ -1,5 +1,6 @@
 {
   "output": "Bridge\\output",
+  "outputBy": "Namespace",
   "cleanOutputFolderBeforeBuildPattern": "*.*",
   // The combineScripts setting is incorrect in this file.
   // To test #1033 the correct combineScripts is set in bridge.release.json and bridge.debug.json

--- a/Compiler/TranslatorTests/TestProjects/19/Bridge/bridge.json
+++ b/Compiler/TranslatorTests/TestProjects/19/Bridge/bridge.json
@@ -1,5 +1,6 @@
 {
   "output": "Bridge\\output",
+  "outputBy": "Namespace",
   "cleanOutputFolderBeforeBuildPattern": "*.*",
   "outputFormatting": "Formatted",
   "logging": {


### PR DESCRIPTION
Fixes #2536 