### PR TITLE
[2224] Support for Environment class

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -11587,6 +11587,8 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 ]
             },
 
+            noKeyCheck: false,
+
             ctor: function (obj, comparer) {
                 this.$initialize();
                 this.comparer = comparer || System.Collections.Generic.EqualityComparer$1(TKey).def;
@@ -11690,6 +11692,10 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 var entry = this.findEntry(key);
 
                 if (!entry) {
+                    if (this.noKeyCheck){
+                        return Bridge.getDefaultValue(TValue);
+                    }
+
                     throw new System.Collections.Generic.KeyNotFoundException('Key ' + key + ' does not exist.');
                 }
 
@@ -19416,6 +19422,214 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
             this._k = r[System.Array.index(7, r)];
         },
         $clone: function (to) { return this; }
+    });
+
+    // @source environment.js
+
+    Bridge.define("System.Environment", {
+        statics: {
+            ctor: function () {
+                System.Environment.variables = new (System.Collections.Generic.Dictionary$2(System.String,System.String))();
+                System.Environment.patchDictionary(System.Environment.variables);
+            },
+            variables: null,
+            config: {
+                properties: {
+                    Location: {
+                        get: function () {
+                            var g = Bridge.global;
+
+                            if (g && g.location) {
+                                return g.location;
+                            }
+
+                            return null;
+                        }
+                    },
+                    CommandLine: {
+                        get: function () {
+                            return System.Environment.getCommandLineArgs().join(" ");
+                        }
+                    },
+                    CurrentDirectory: {
+                        get: function () {
+                            var l = System.Environment.Location;
+
+                            return l ? l.pathname : "";
+                        },
+                        set: function (value) {
+                            var l = System.Environment.Location;
+
+                            if (l) {
+                                l.pathname = value;
+                            }
+                        }
+                    },
+                    ExitCode: 0,
+                    Is64BitOperatingSystem: {
+                        get: function () {
+                            var g = Bridge.global;
+
+                            if (g && g.navigator && (!Bridge.referenceEquals(g.navigator.userAgent.indexOf("WOW64"), -1) || !Bridge.referenceEquals(g.navigator.userAgent.indexOf("Win64"), -1))) {
+                                return true;
+                            }
+
+                            return false;
+                        }
+                    },
+                    ProcessorCount: {
+                        get: function () {
+                            var g = Bridge.global;
+
+                            if (g && g.navigator && g.navigator.hardwareConcurrency) {
+                                return g.navigator.hardwareConcurrency;
+                            }
+
+                            return 1;
+                        }
+                    },
+                    StackTrace: {
+                        get: function () {
+                            var err = new Error();
+                            var s = err.stack;
+
+                            if (!System.String.isNullOrEmpty(s)) {
+                                if (System.String.indexOf(s, "at") >= 0) {
+                                    return s.substr(System.String.indexOf(s, "at"));
+                                }
+                            }
+
+                            return "";
+                        }
+                    },
+                    Version: {
+                        get: function () {
+                            var s = Bridge.SystemAssembly.compiler;
+
+                            var v = { };
+
+                            if (System.Version.tryParse(s, v)) {
+                                return v.v;
+                            }
+
+                            return new System.Version.ctor();
+                        }
+                    }
+                }
+            },
+            patchDictionary: function (d) {
+                d.noKeyCheck = true;
+
+                return d;
+            },
+            exit: function (exitCode) {
+                System.Environment.ExitCode = exitCode;
+            },
+            expandEnvironmentVariables: function (name) {
+                var $t;
+                if (name == null) {
+                    throw new System.ArgumentNullException(name);
+                }
+
+                // Case sensitive
+                $t = Bridge.getEnumerator(System.Environment.variables);
+                try {
+                    while ($t.moveNext()) {
+                        var pair = $t.Current;
+                        name = System.String.replaceAll(name, System.String.concat("%", pair.key, "%"), pair.value);
+                    }
+                }finally {
+                    if (Bridge.is($t, System.IDisposable)) {
+                        $t.System$IDisposable$dispose();
+                    }
+                }
+                return name;
+            },
+            failFast: function (message) {
+                throw new System.Exception(message);
+            },
+            failFast$1: function (message, exception) {
+                throw new System.Exception(message, exception);
+            },
+            getCommandLineArgs: function () {
+                var l = System.Environment.Location;
+
+                if (l) {
+                    var args = new (System.Collections.Generic.List$1(System.String))();
+
+                    var path = l.pathname;
+
+                    if (!System.String.isNullOrEmpty(path)) {
+                        args.add(path);
+                    }
+
+                    var search = l.search;
+
+                    if (!System.String.isNullOrEmpty(search) && search.length > 1) {
+                        var query = System.String.split(search.substr(1), [38].map(function(i) {{ return String.fromCharCode(i); }}));
+
+                        for (var i = 0; i < query.length; i = (i + 1) | 0) {
+                            var param = System.String.split(query[System.Array.index(i, query)], [61].map(function(i) {{ return String.fromCharCode(i); }}));
+
+                            for (var j = 0; j < param.length; j = (j + 1) | 0) {
+                                args.add(param[System.Array.index(j, param)]);
+                            }
+                        }
+                    }
+
+                    return args.toArray();
+                }
+
+                return System.Array.init(0, null, System.String);
+            },
+            getEnvironmentVariable: function (variable) {
+                if (variable == null) {
+                    throw new System.ArgumentNullException("variable");
+                }
+
+                var r = { };
+
+                if (System.Environment.variables.tryGetValue(variable.toLowerCase(), r)) {
+                    return r.v;
+                }
+
+                return null;
+            },
+            getEnvironmentVariable$1: function (variable, target) {
+                return System.Environment.getEnvironmentVariable(variable);
+            },
+            getEnvironmentVariables: function () {
+                return System.Environment.patchDictionary(new (System.Collections.Generic.Dictionary$2(System.String,System.String))(System.Environment.variables));
+            },
+            getEnvironmentVariables$1: function (target) {
+                return System.Environment.getEnvironmentVariables();
+            },
+            getLogicalDrives: function () {
+                return System.Array.init(0, null, System.String);
+            },
+            setEnvironmentVariable: function (variable, value) {
+                if (variable == null) {
+                    throw new System.ArgumentNullException("variable");
+                }
+
+                if (System.String.isNullOrEmpty(variable) || System.String.startsWith(variable, String.fromCharCode(0)) || System.String.contains(variable,"=") || variable.length > 32767) {
+                    throw new System.ArgumentException("Incorrect variable (cannot be empty, contain zero character nor equal sign, be longer than 32767).");
+                }
+
+                variable = variable.toLowerCase();
+
+                if (System.String.isNullOrEmpty(value)) {
+                    if (System.Environment.variables.containsKey(variable)) {
+                        System.Environment.variables.remove(variable);
+                    }
+                } else {
+                    System.Environment.variables.set(variable, value);
+                }
+            },
+            setEnvironmentVariable$1: function (variable, value, target) {
+                System.Environment.setEnvironmentVariable(variable, value);
+            }
+        }
     });
 
     // @source Regex.js

--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -19468,9 +19468,9 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
                     ExitCode: 0,
                     Is64BitOperatingSystem: {
                         get: function () {
-                            var g = Bridge.global;
+                            var n = Bridge.global ? Bridge.global.navigator : null;
 
-                            if (g && g.navigator && (!Bridge.referenceEquals(g.navigator.userAgent.indexOf("WOW64"), -1) || !Bridge.referenceEquals(g.navigator.userAgent.indexOf("Win64"), -1))) {
+                            if (n && (!Bridge.referenceEquals(n.userAgent.indexOf("WOW64"), -1) || !Bridge.referenceEquals(n.userAgent.indexOf("Win64"), -1))) {
                                 return true;
                             }
 
@@ -19479,10 +19479,10 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
                     },
                     ProcessorCount: {
                         get: function () {
-                            var g = Bridge.global;
+                            var n = Bridge.global ? Bridge.global.navigator : null;
 
-                            if (g && g.navigator && g.navigator.hardwareConcurrency) {
-                                return g.navigator.hardwareConcurrency;
+                            if (n && n.hardwareConcurrency) {
+                                return n.hardwareConcurrency;
                             }
 
                             return 1;

--- a/Bridge/Resources/.generated/system/environment.js
+++ b/Bridge/Resources/.generated/system/environment.js
@@ -40,9 +40,9 @@
                     ExitCode: 0,
                     Is64BitOperatingSystem: {
                         get: function () {
-                            var g = Bridge.global;
+                            var n = Bridge.global ? Bridge.global.navigator : null;
 
-                            if (g && g.navigator && (!Bridge.referenceEquals(g.navigator.userAgent.indexOf("WOW64"), -1) || !Bridge.referenceEquals(g.navigator.userAgent.indexOf("Win64"), -1))) {
+                            if (n && (!Bridge.referenceEquals(n.userAgent.indexOf("WOW64"), -1) || !Bridge.referenceEquals(n.userAgent.indexOf("Win64"), -1))) {
                                 return true;
                             }
 
@@ -51,10 +51,10 @@
                     },
                     ProcessorCount: {
                         get: function () {
-                            var g = Bridge.global;
+                            var n = Bridge.global ? Bridge.global.navigator : null;
 
-                            if (g && g.navigator && g.navigator.hardwareConcurrency) {
-                                return g.navigator.hardwareConcurrency;
+                            if (n && n.hardwareConcurrency) {
+                                return n.hardwareConcurrency;
                             }
 
                             return 1;

--- a/Bridge/Resources/.generated/system/environment.js
+++ b/Bridge/Resources/.generated/system/environment.js
@@ -1,0 +1,205 @@
+    Bridge.define("System.Environment", {
+        statics: {
+            ctor: function () {
+                System.Environment.variables = new (System.Collections.Generic.Dictionary$2(System.String,System.String))();
+                System.Environment.patchDictionary(System.Environment.variables);
+            },
+            variables: null,
+            config: {
+                properties: {
+                    Location: {
+                        get: function () {
+                            var g = Bridge.global;
+
+                            if (g && g.location) {
+                                return g.location;
+                            }
+
+                            return null;
+                        }
+                    },
+                    CommandLine: {
+                        get: function () {
+                            return System.Environment.getCommandLineArgs().join(" ");
+                        }
+                    },
+                    CurrentDirectory: {
+                        get: function () {
+                            var l = System.Environment.Location;
+
+                            return l ? l.pathname : "";
+                        },
+                        set: function (value) {
+                            var l = System.Environment.Location;
+
+                            if (l) {
+                                l.pathname = value;
+                            }
+                        }
+                    },
+                    ExitCode: 0,
+                    Is64BitOperatingSystem: {
+                        get: function () {
+                            var g = Bridge.global;
+
+                            if (g && g.navigator && (!Bridge.referenceEquals(g.navigator.userAgent.indexOf("WOW64"), -1) || !Bridge.referenceEquals(g.navigator.userAgent.indexOf("Win64"), -1))) {
+                                return true;
+                            }
+
+                            return false;
+                        }
+                    },
+                    ProcessorCount: {
+                        get: function () {
+                            var g = Bridge.global;
+
+                            if (g && g.navigator && g.navigator.hardwareConcurrency) {
+                                return g.navigator.hardwareConcurrency;
+                            }
+
+                            return 1;
+                        }
+                    },
+                    StackTrace: {
+                        get: function () {
+                            var err = new Error();
+                            var s = err.stack;
+
+                            if (!System.String.isNullOrEmpty(s)) {
+                                if (System.String.indexOf(s, "at") >= 0) {
+                                    return s.substr(System.String.indexOf(s, "at"));
+                                }
+                            }
+
+                            return "";
+                        }
+                    },
+                    Version: {
+                        get: function () {
+                            var s = Bridge.SystemAssembly.compiler;
+
+                            var v = { };
+
+                            if (System.Version.tryParse(s, v)) {
+                                return v.v;
+                            }
+
+                            return new System.Version.ctor();
+                        }
+                    }
+                }
+            },
+            patchDictionary: function (d) {
+                d.noKeyCheck = true;
+
+                return d;
+            },
+            exit: function (exitCode) {
+                System.Environment.ExitCode = exitCode;
+            },
+            expandEnvironmentVariables: function (name) {
+                var $t;
+                if (name == null) {
+                    throw new System.ArgumentNullException(name);
+                }
+
+                // Case sensitive
+                $t = Bridge.getEnumerator(System.Environment.variables);
+                try {
+                    while ($t.moveNext()) {
+                        var pair = $t.Current;
+                        name = System.String.replaceAll(name, System.String.concat("%", pair.key, "%"), pair.value);
+                    }
+                }finally {
+                    if (Bridge.is($t, System.IDisposable)) {
+                        $t.System$IDisposable$dispose();
+                    }
+                }
+                return name;
+            },
+            failFast: function (message) {
+                throw new System.Exception(message);
+            },
+            failFast$1: function (message, exception) {
+                throw new System.Exception(message, exception);
+            },
+            getCommandLineArgs: function () {
+                var l = System.Environment.Location;
+
+                if (l) {
+                    var args = new (System.Collections.Generic.List$1(System.String))();
+
+                    var path = l.pathname;
+
+                    if (!System.String.isNullOrEmpty(path)) {
+                        args.add(path);
+                    }
+
+                    var search = l.search;
+
+                    if (!System.String.isNullOrEmpty(search) && search.length > 1) {
+                        var query = System.String.split(search.substr(1), [38].map(function(i) {{ return String.fromCharCode(i); }}));
+
+                        for (var i = 0; i < query.length; i = (i + 1) | 0) {
+                            var param = System.String.split(query[System.Array.index(i, query)], [61].map(function(i) {{ return String.fromCharCode(i); }}));
+
+                            for (var j = 0; j < param.length; j = (j + 1) | 0) {
+                                args.add(param[System.Array.index(j, param)]);
+                            }
+                        }
+                    }
+
+                    return args.toArray();
+                }
+
+                return System.Array.init(0, null, System.String);
+            },
+            getEnvironmentVariable: function (variable) {
+                if (variable == null) {
+                    throw new System.ArgumentNullException("variable");
+                }
+
+                var r = { };
+
+                if (System.Environment.variables.tryGetValue(variable.toLowerCase(), r)) {
+                    return r.v;
+                }
+
+                return null;
+            },
+            getEnvironmentVariable$1: function (variable, target) {
+                return System.Environment.getEnvironmentVariable(variable);
+            },
+            getEnvironmentVariables: function () {
+                return System.Environment.patchDictionary(new (System.Collections.Generic.Dictionary$2(System.String,System.String))(System.Environment.variables));
+            },
+            getEnvironmentVariables$1: function (target) {
+                return System.Environment.getEnvironmentVariables();
+            },
+            getLogicalDrives: function () {
+                return System.Array.init(0, null, System.String);
+            },
+            setEnvironmentVariable: function (variable, value) {
+                if (variable == null) {
+                    throw new System.ArgumentNullException("variable");
+                }
+
+                if (System.String.isNullOrEmpty(variable) || System.String.startsWith(variable, String.fromCharCode(0)) || System.String.contains(variable,"=") || variable.length > 32767) {
+                    throw new System.ArgumentException("Incorrect variable (cannot be empty, contain zero character nor equal sign, be longer than 32767).");
+                }
+
+                variable = variable.toLowerCase();
+
+                if (System.String.isNullOrEmpty(value)) {
+                    if (System.Environment.variables.containsKey(variable)) {
+                        System.Environment.variables.remove(variable);
+                    }
+                } else {
+                    System.Environment.variables.set(variable, value);
+                }
+            },
+            setEnvironmentVariable$1: function (variable, value, target) {
+                System.Environment.setEnvironmentVariable(variable, value);
+            }
+        }
+    });

--- a/Bridge/Resources/Collections/Dictionary.js
+++ b/Bridge/Resources/Collections/Dictionary.js
@@ -66,6 +66,8 @@
                 ]
             },
 
+            noKeyCheck: false,
+
             ctor: function (obj, comparer) {
                 this.$initialize();
                 this.comparer = comparer || System.Collections.Generic.EqualityComparer$1(TKey).def;
@@ -169,6 +171,10 @@
                 var entry = this.findEntry(key);
 
                 if (!entry) {
+                    if (this.noKeyCheck){
+                        return Bridge.getDefaultValue(TValue);
+                    }
+
                     throw new System.Collections.Generic.KeyNotFoundException('Key ' + key + ' does not exist.');
                 }
 

--- a/Bridge/System/Environment.cs
+++ b/Bridge/System/Environment.cs
@@ -403,11 +403,9 @@ namespace System
         {
             get
             {
-                dynamic g = Global;
+                dynamic n = Global ? Global.navigator : null;
 
-                if (g && g.navigator
-                    && (g.navigator.userAgent.indexOf("WOW64") != -1 ||
-                        g.navigator.userAgent.indexOf("Win64") != -1))
+                if (n && (n.userAgent.indexOf("WOW64") != -1 || n.userAgent.indexOf("Win64") != -1))
                 {
                     return true;
                 }
@@ -463,11 +461,11 @@ namespace System
         {
             get
             {
-                dynamic g = Global;
+                dynamic n = Global ? Global.navigator : null;
 
-                if (g && g.navigator && g.navigator.hardwareConcurrency)
+                if (n && n.hardwareConcurrency)
                 {
-                    return g.navigator.hardwareConcurrency;
+                    return n.hardwareConcurrency;
                 }
 
                 return 1;

--- a/Bridge/System/Environment.cs
+++ b/Bridge/System/Environment.cs
@@ -1,21 +1,809 @@
 using Bridge;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace System
 {
+    /// <summary>
+    /// Specifies the location where an environment variable is stored or retrieved in a set or get operation.
+    /// </summary>
     [External]
-    [Name("System.Object")]
+    [Enum(Emit.Value)]
+    public enum EnvironmentVariableTarget
+    {
+        Process = 0,
+        User = 1,
+        Machine = 2,
+    }
+
+    /// <summary>
+    /// Provides information about, and means to manipulate, the current environment and platform. This class cannot be inherited.
+    /// Some methods have Bridge implementation that differ from .Net.
+    /// </summary>
     public static class Environment
     {
+        /// <summary>
+        /// Specifies enumerated constants used to retrieve directory paths to system special folders.
+        /// </summary>
+        [External]
+        [Enum(Emit.Value)]
+        public enum SpecialFolder
+        {
+            //
+            //      Represents the file system directory that serves as a common repository for
+            //       application-specific data for the current, roaming user.
+            //     A roaming user works on more than one computer on a network. A roaming user's
+            //       profile is kept on a server on the network and is loaded onto a system when the
+            //       user logs on.
+            //
+            ApplicationData = Win32Native.CSIDL_APPDATA,
+            //
+            //      Represents the file system directory that serves as a common repository for application-specific data that
+            //       is used by all users.
+            //
+            CommonApplicationData = Win32Native.CSIDL_COMMON_APPDATA,
+            //
+            //     Represents the file system directory that serves as a common repository for application specific data that
+            //       is used by the current, non-roaming user.
+            //
+            LocalApplicationData = Win32Native.CSIDL_LOCAL_APPDATA,
+            //
+            //     Represents the file system directory that serves as a common repository for Internet
+            //       cookies.
+            //
+            Cookies = Win32Native.CSIDL_COOKIES,
+            Desktop = Win32Native.CSIDL_DESKTOP,
+            //
+            //     Represents the file system directory that serves as a common repository for the user's
+            //       favorite items.
+            //
+            Favorites = Win32Native.CSIDL_FAVORITES,
+            //
+            //     Represents the file system directory that serves as a common repository for Internet
+            //       history items.
+            //
+            History = Win32Native.CSIDL_HISTORY,
+            //
+            //     Represents the file system directory that serves as a common repository for temporary
+            //       Internet files.
+            //
+            InternetCache = Win32Native.CSIDL_INTERNET_CACHE,
+            //
+            //      Represents the file system directory that contains
+            //       the user's program groups.
+            //
+            Programs = Win32Native.CSIDL_PROGRAMS,
+            MyComputer = Win32Native.CSIDL_DRIVES,
+            MyMusic = Win32Native.CSIDL_MYMUSIC,
+            MyPictures = Win32Native.CSIDL_MYPICTURES,
+            //      "My Videos" folder
+            MyVideos = Win32Native.CSIDL_MYVIDEO,
+            //
+            //     Represents the file system directory that contains the user's most recently used
+            //       documents.
+            //
+            Recent = Win32Native.CSIDL_RECENT,
+            //
+            //     Represents the file system directory that contains Send To menu items.
+            //
+            SendTo = Win32Native.CSIDL_SENDTO,
+            //
+            //     Represents the file system directory that contains the Start menu items.
+            //
+            StartMenu = Win32Native.CSIDL_STARTMENU,
+            //
+            //     Represents the file system directory that corresponds to the user's Startup program group. The system
+            //       starts these programs whenever any user logs on to Windows NT, or
+            //       starts Windows 95 or Windows 98.
+            //
+            Startup = Win32Native.CSIDL_STARTUP,
+            //
+            //     System directory.
+            //
+            System = Win32Native.CSIDL_SYSTEM,
+            //
+            //     Represents the file system directory that serves as a common repository for document
+            //       templates.
+            //
+            Templates = Win32Native.CSIDL_TEMPLATES,
+            //
+            //     Represents the file system directory used to physically store file objects on the desktop.
+            //       This should not be confused with the desktop folder itself, which is
+            //       a virtual folder.
+            //
+            DesktopDirectory = Win32Native.CSIDL_DESKTOPDIRECTORY,
+            //
+            //     Represents the file system directory that serves as a common repository for documents.
+            //
+            Personal = Win32Native.CSIDL_PERSONAL,
+            //
+            // "MyDocuments" is a better name than "Personal"
+            //
+            MyDocuments = Win32Native.CSIDL_PERSONAL,
+            //
+            //     Represents the program files folder.
+            //
+            ProgramFiles = Win32Native.CSIDL_PROGRAM_FILES,
+            //
+            //     Represents the folder for components that are shared across applications.
+            //
+            CommonProgramFiles = Win32Native.CSIDL_PROGRAM_FILES_COMMON,
+#if !FEATURE_CORECLR
+            //
+            //      <user name>\Start Menu\Programs\Administrative Tools
+            //
+            AdminTools = Win32Native.CSIDL_ADMINTOOLS,
+            //
+            //      USERPROFILE\Local Settings\Application Data\Microsoft\CD Burning
+            //
+            CDBurning = Win32Native.CSIDL_CDBURN_AREA,
+            //
+            //      All Users\Start Menu\Programs\Administrative Tools
+            //
+            CommonAdminTools = Win32Native.CSIDL_COMMON_ADMINTOOLS,
+            //
+            //      All Users\Documents
+            //
+            CommonDocuments = Win32Native.CSIDL_COMMON_DOCUMENTS,
+            //
+            //      All Users\My Music
+            //
+            CommonMusic = Win32Native.CSIDL_COMMON_MUSIC,
+            //
+            //      Links to All Users OEM specific apps
+            //
+            CommonOemLinks = Win32Native.CSIDL_COMMON_OEM_LINKS,
+            //
+            //      All Users\My Pictures
+            //
+            CommonPictures = Win32Native.CSIDL_COMMON_PICTURES,
+            //
+            //      All Users\Start Menu
+            //
+            CommonStartMenu = Win32Native.CSIDL_COMMON_STARTMENU,
+            //
+            //      All Users\Start Menu\Programs
+            //
+            CommonPrograms = Win32Native.CSIDL_COMMON_PROGRAMS,
+            //
+            //     All Users\Startup
+            //
+            CommonStartup = Win32Native.CSIDL_COMMON_STARTUP,
+            //
+            //      All Users\Desktop
+            //
+            CommonDesktopDirectory = Win32Native.CSIDL_COMMON_DESKTOPDIRECTORY,
+            //
+            //      All Users\Templates
+            //
+            CommonTemplates = Win32Native.CSIDL_COMMON_TEMPLATES,
+            //
+            //      All Users\My Video
+            //
+            CommonVideos = Win32Native.CSIDL_COMMON_VIDEO,
+            //
+            //      windows\fonts
+            //
+            Fonts = Win32Native.CSIDL_FONTS,
+            //
+            //      %APPDATA%\Microsoft\Windows\Network Shortcuts
+            //
+            NetworkShortcuts = Win32Native.CSIDL_NETHOOD,
+            //
+            //      %APPDATA%\Microsoft\Windows\Printer Shortcuts
+            //
+            PrinterShortcuts = Win32Native.CSIDL_PRINTHOOD,
+            //
+            //      USERPROFILE
+            //
+            UserProfile = Win32Native.CSIDL_PROFILE,
+            //
+            //      x86 Program Files\Common on RISC
+            //
+            CommonProgramFilesX86 = Win32Native.CSIDL_PROGRAM_FILES_COMMONX86,
+            //
+            //      x86 C:\Program Files on RISC
+            //
+            ProgramFilesX86 = Win32Native.CSIDL_PROGRAM_FILESX86,
+            //
+            //      Resource Directory
+            //
+            Resources = Win32Native.CSIDL_RESOURCES,
+            //
+            //      Localized Resource Directory
+            //
+            LocalizedResources = Win32Native.CSIDL_RESOURCES_LOCALIZED,
+            //
+            //      %windir%\System32 or %windir%\syswow64
+            //
+            SystemX86 = Win32Native.CSIDL_SYSTEMX86,
+            //
+            //      GetWindowsDirectory()
+            //
+            Windows = Win32Native.CSIDL_WINDOWS,
+#endif // !FEATURE_CORECLR
+        }
+
+        /// <summary>
+        /// Specifies options to use for getting the path to a special folder.
+        /// </summary>
+        [External]
+        [Enum(Emit.Value)]
+        public enum SpecialFolderOption
+        {
+            None = 0,
+            Create = Win32Native.CSIDL_FLAG_CREATE,
+            DoNotVerify = Win32Native.CSIDL_FLAG_DONT_VERIFY,
+        }
+
+        [External]
+        private static class Win32Native
+        {
+            // .NET Framework 4.0 and newer - all versions of windows ||| \public\sdk\inc\shlobj.h
+            internal const int CSIDL_FLAG_CREATE = 0x8000; // force folder creation in SHGetFolderPath
+            internal const int CSIDL_FLAG_DONT_VERIFY = 0x4000; // return an unverified folder path
+            internal const int CSIDL_ADMINTOOLS = 0x0030; // <user name>\Start Menu\Programs\Administrative Tools
+            internal const int CSIDL_CDBURN_AREA = 0x003b; // USERPROFILE\Local Settings\Application Data\Microsoft\CD Burning
+            internal const int CSIDL_COMMON_ADMINTOOLS = 0x002f; // All Users\Start Menu\Programs\Administrative Tools
+            internal const int CSIDL_COMMON_DOCUMENTS = 0x002e; // All Users\Documents
+            internal const int CSIDL_COMMON_MUSIC = 0x0035; // All Users\My Music
+            internal const int CSIDL_COMMON_OEM_LINKS = 0x003a; // Links to All Users OEM specific apps
+            internal const int CSIDL_COMMON_PICTURES = 0x0036; // All Users\My Pictures
+            internal const int CSIDL_COMMON_STARTMENU = 0x0016; // All Users\Start Menu
+            internal const int CSIDL_COMMON_PROGRAMS = 0X0017; // All Users\Start Menu\Programs
+            internal const int CSIDL_COMMON_STARTUP = 0x0018; // All Users\Startup
+            internal const int CSIDL_COMMON_DESKTOPDIRECTORY = 0x0019; // All Users\Desktop
+            internal const int CSIDL_COMMON_TEMPLATES = 0x002d; // All Users\Templates
+            internal const int CSIDL_COMMON_VIDEO = 0x0037; // All Users\My Video
+            internal const int CSIDL_FONTS = 0x0014; // windows\fonts
+            internal const int CSIDL_MYVIDEO = 0x000e; // "My Videos" folder
+            internal const int CSIDL_NETHOOD = 0x0013; // %APPDATA%\Microsoft\Windows\Network Shortcuts
+            internal const int CSIDL_PRINTHOOD = 0x001b; // %APPDATA%\Microsoft\Windows\Printer Shortcuts
+            internal const int CSIDL_PROFILE = 0x0028; // %USERPROFILE% (%SystemDrive%\Users\%USERNAME%)
+            internal const int CSIDL_PROGRAM_FILES_COMMONX86 = 0x002c; // x86 Program Files\Common on RISC
+            internal const int CSIDL_PROGRAM_FILESX86 = 0x002a; // x86 C:\Program Files on RISC
+            internal const int CSIDL_RESOURCES = 0x0038; // %windir%\Resources
+            internal const int CSIDL_RESOURCES_LOCALIZED = 0x0039; // %windir%\resources\0409 (code page)
+            internal const int CSIDL_SYSTEMX86 = 0x0029; // %windir%\system32
+            internal const int CSIDL_WINDOWS = 0x0024; // GetWindowsDirectory()
+
+            // .NET Framework 3.5 and earlier - all versions of windows
+            internal const int CSIDL_APPDATA = 0x001a;
+            internal const int CSIDL_COMMON_APPDATA = 0x0023;
+            internal const int CSIDL_LOCAL_APPDATA = 0x001c;
+            internal const int CSIDL_COOKIES = 0x0021;
+            internal const int CSIDL_FAVORITES = 0x0006;
+            internal const int CSIDL_HISTORY = 0x0022;
+            internal const int CSIDL_INTERNET_CACHE = 0x0020;
+            internal const int CSIDL_PROGRAMS = 0x0002;
+            internal const int CSIDL_RECENT = 0x0008;
+            internal const int CSIDL_SENDTO = 0x0009;
+            internal const int CSIDL_STARTMENU = 0x000b;
+            internal const int CSIDL_STARTUP = 0x0007;
+            internal const int CSIDL_SYSTEM = 0x0025;
+            internal const int CSIDL_TEMPLATES = 0x0015;
+            internal const int CSIDL_DESKTOPDIRECTORY = 0x0010;
+            internal const int CSIDL_PERSONAL = 0x0005;
+            internal const int CSIDL_PROGRAM_FILES = 0x0026;
+            internal const int CSIDL_PROGRAM_FILES_COMMON = 0x002b;
+            internal const int CSIDL_DESKTOP = 0x0000;
+            internal const int CSIDL_DRIVES = 0x0011;
+            internal const int CSIDL_MYMUSIC = 0x000d;
+            internal const int CSIDL_MYPICTURES = 0x0027;
+        }
+
+        /// <summary>
+        /// A helper property to get global scope
+        /// </summary>
+        private static dynamic Global
+        {
+            [Template("Bridge.global")]
+            get;
+        }
+
+        private static dynamic Location
+        {
+            get
+            {
+                var g = Global;
+
+                if (g && g.location)
+                {
+                    return g.location;
+                }
+
+                return null;
+            }
+        }
+
+        private static Dictionary<string, string> Variables;
+
+        private static Dictionary<string, string> PatchDictionary(Dictionary<string, string> d)
+        {
+            d.As<dynamic>().noKeyCheck = true;
+
+            return d;
+        }
+
+        static Environment()
+        {
+            Variables = new Dictionary<string, string>();
+            PatchDictionary(Variables);
+        }
+
+        /// <summary>
+        /// Gets the command line for this process.
+        /// The Bridge implementation returns location.pathname + " " + location.search
+        /// </summary>
+        public static string CommandLine
+        {
+            get
+            {
+                return string.Join(" ", GetCommandLineArgs());
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the fully qualified path of the current working directory.
+        /// The Bridge implementation controls window.location.pathname.
+        /// </summary>
+        public static string CurrentDirectory
+        {
+            get
+            {
+                var l = Location;
+
+                return l ? l.pathname : "";
+            }
+
+            set
+            {
+                var l = Location;
+
+                if (l)
+                {
+                    l.pathname = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a unique identifier for the current managed thread.
+        /// The Bridge implementation returns zero.
+        /// </summary>
+        public static extern int CurrentManagedThreadId
+        {
+            [Template("0")]
+            get;
+        }
+
+        /// <summary>
+        /// Gets or sets the exit code of the process.
+        /// </summary>
+        public static int ExitCode
+        {
+            get;
+            set;
+        } = 0;
+
+        /// <summary>
+        /// Gets a value that indicates whether the current application domain is being unloaded or the common language runtime (CLR) is shutting down.
+        /// The Bridge implementation returns false.
+        /// </summary>
+        public static bool HasShutdownStarted
+        {
+            [Template("false")]
+            get;
+        }
+
+        /// <summary>
+        /// Determines whether the current operating system is a 64-bit operating system.
+        /// </summary>
+        public static bool Is64BitOperatingSystem
+        {
+            get
+            {
+                dynamic g = Global;
+
+                if (g && g.navigator
+                    && (g.navigator.userAgent.indexOf("WOW64") != -1 ||
+                        g.navigator.userAgent.indexOf("Win64") != -1))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the current process is a 64-bit process.
+        /// The Bridge implementation returns false.
+        /// </summary>
+        public static bool Is64BitProcess
+        {
+            [Template("false")]
+            get;
+        }
+
+        /// <summary>
+        /// Gets the NetBIOS name of this local computer.
+        /// The Bridge implementation returns an empty string.
+        /// </summary>
+        public static string MachineName
+        {
+            [Template("\"\"")]
+            get;
+        }
+
+        /// <summary>
+        /// Gets the newline string defined for this environment.
+        /// The Bridge implementation returns "\n".
+        /// </summary>
         public static extern string NewLine
         {
             [Template("'\\n'")]
             get;
         }
 
-        public static extern int CurrentManagedThreadId
+        /// <summary>
+        /// The Bridge implementation returns null.
+        /// </summary>
+        public static object OSVersion
         {
-            [Template("0")]
+            [Template("null")]
             get;
+        }
+
+        /// <summary>
+        /// Gets the number of processors on the current machine.
+        /// The Bridge implementation returns navigator.hardwareConcurrency if exists, otherwise 1.
+        /// </summary>
+        public static int ProcessorCount
+        {
+            get
+            {
+                dynamic g = Global;
+
+                if (g && g.navigator && g.navigator.hardwareConcurrency)
+                {
+                    return g.navigator.hardwareConcurrency;
+                }
+
+                return 1;
+            }
+        }
+
+        /// <summary>
+        /// Gets current stack trace information.
+        /// </summary>
+        public static string StackTrace
+        {
+            get
+            {
+                var err = Script.Write<dynamic>("new Error()");
+                string s = err.stack;
+
+                if (!string.IsNullOrEmpty(s))
+                {
+                    if (s.IndexOf("at") >= 0)
+                    {
+                        return s.Substring(s.IndexOf("at"));
+                    }
+                }
+
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// Gets the fully qualified path of the system directory.
+        /// The Bridge implementation returns an empty string;
+        /// </summary>
+        public static string SystemDirectory
+        {
+            [Template("\"\"")]
+            get;
+        }
+
+
+        /// <summary>
+        /// Gets the number of bytes in the operating system's memory page.
+        /// The Bridge implementation returns 1.
+        /// </summary>
+        public static int SystemPageSize
+        {
+            [Template("1")]
+            get;
+        }
+
+        /// <summary>
+        /// Gets the number of milliseconds elapsed since the system started.
+        /// The Bridge implementation returns the number of milliseconds elapsed since 1 January 1970 00:00:00 UTC.
+        /// </summary>
+        public static int TickCount
+        {
+            [Template("Date.now()")]
+            get;
+        }
+
+        /// <summary>
+        /// Gets the network domain name associated with the current user.
+        /// The Bridge implementation returns an empty string;
+        /// </summary>
+        public static string UserDomainName
+        {
+            [Template("\"\"")]
+            get;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current process is running in user interactive mode.
+        /// The Bridge implementation returns true;
+        /// </summary>
+        public static bool UserInteractive
+        {
+            [Template("true")]
+            get;
+        }
+
+        /// <summary>
+        /// Gets the user name of the person who is currently logged on to the Windows operating system.
+        /// The Bridge implementation returns an empty string;
+        /// </summary>
+        public static string UserName
+        {
+            [Template("\"\"")]
+            get;
+        }
+
+        /// <summary>
+        /// Gets a Version object that describes the major, minor, build, and revision numbers of the common language runtime.
+        /// The Bridge implementation returns Bridge Compiler version.
+        /// </summary>
+        public static Version Version
+        {
+            get
+            {
+                var s = Bridge.Utils.SystemAssembly.Assembly.CompilerVersionString;
+
+                Version v;
+
+                if (Version.TryParse(s, out v))
+                {
+                    return v;
+                }
+
+                return new Version();
+            }
+        }
+
+        /// <summary>
+        /// Gets the amount of physical memory mapped to the process context.
+        /// The Bridge implementation returns zero.
+        /// </summary>
+        public static long WorkingSet
+        {
+            [Template("System.Int64(0)")]
+            get;
+        }
+
+        /// <summary>
+        /// Terminates this process and returns an exit code to the operating system.
+        /// The Bridge implementation just sets ExitCode.
+        /// </summary>
+        /// <param name="exitCode">The exit code to return to the operating system. Use 0 (zero) to indicate that the process completed successfully.</param>
+        public static void Exit(int exitCode)
+        {
+            ExitCode = exitCode;
+        }
+
+        /// <summary>
+        /// Replaces the name of each environment variable embedded in the specified string with the string equivalent of the value of the variable, then returns the resulting string.
+        /// </summary>
+        /// <param name="name">A string containing the names of zero or more environment variables. Each environment variable is quoted with the percent sign character (%).</param>
+        /// <returns>A string with each environment variable replaced by its value.</returns>
+        public static string ExpandEnvironmentVariables(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(name);
+            }
+
+            // Case sensitive
+            foreach (var pair in Variables)
+            {
+                name = name.Replace("%" + pair.Key + "%", pair.Value);
+            }
+
+            return name;
+        }
+
+        /// <summary>
+        /// Immediately terminates a process after writing a message to the Windows Application event log, and then includes the message in error reporting to Microsoft.
+        /// The Bridge implementation throws an exception with the message specified. Note it will run finally block if any.
+        /// </summary>
+        /// <param name="message">A message that explains why the process was terminated, or null if no explanation is provided.</param>
+        public static void FailFast(string message)
+        {
+            throw new Exception(message);
+        }
+
+        /// <summary>
+        /// Immediately terminates a process after writing a message to the Windows Application event log, and then includes the message and exception information in error reporting to Microsoft.
+        /// The Bridge implementation throws an exception with the message specified. Note it will run finally block if any.
+        /// </summary>
+        /// <param name="message">A message that explains why the process was terminated, or null if no explanation is provided.</param>
+        /// <param name="exception">An exception that represents the error that caused the termination. This is typically the exception in a catch block.</param>
+        public static void FailFast(string message, Exception exception)
+        {
+            throw new Exception(message, exception);
+        }
+
+        /// <summary>
+        /// Returns a string array containing the command-line arguments for the current process.
+        /// </summary>
+        /// <returns>The Bridge implementation returns location.pathname and query parameters.</returns>
+        public static string[] GetCommandLineArgs()
+        {
+            var l = Location;
+
+            if (l)
+            {
+                var args = new List<string>();
+
+                string path = l.pathname;
+
+                if (!string.IsNullOrEmpty(path))
+                {
+                    args.Add(path);
+                }
+
+                string search = l.search;
+
+                if (!string.IsNullOrEmpty(search) && search.Length > 1)
+                {
+                    var query = search.Substring(1).Split('&');
+
+                    for (int i = 0; i < query.Length; i++)
+                    {
+                        var param = query[i].Split('=');
+
+                        for (int j = 0; j < param.Length; j++)
+                        {
+                            args.Add(param[j]);
+                        }
+                    }
+                }
+
+                return args.ToArray();
+            }
+
+            return new string[0];
+        }
+
+        /// <summary>
+        /// Retrieves the value of an environment variable from the current process.
+        /// </summary>
+        /// <param name="variable">The name of the environment variable.</param>
+        /// <returns>The value of the environment variable specified by variable, or null if the environment variable is not found.</returns>
+        public static string GetEnvironmentVariable(string variable)
+        {
+            if (variable == null)
+            {
+                throw new ArgumentNullException("variable");
+            }
+
+            string r;
+
+            if (Variables.TryGetValue(variable.ToLower(), out r))
+            {
+                return r;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves the value of an environment variable from the current process or from the Windows operating system registry key for the current user or local machine.
+        /// </summary>
+        /// <param name="variable">The name of an environment variable.</param>
+        /// <param name="target">Ignored by Bridge. One of the EnvironmentVariableTarget values.</param>
+        /// <returns>The Bridge implementation ignores target. The value of the environment variable specified by variable, or null if the environment variable is not found.</returns>
+        public static string GetEnvironmentVariable(string variable, EnvironmentVariableTarget target)
+        {
+            return GetEnvironmentVariable(variable);
+        }
+
+        /// <summary>
+        /// Retrieves all environment variable names and their values from the current process.
+        /// </summary>
+        /// <returns>A dictionary that contains all environment variable names and their values; otherwise, an empty dictionary if no environment variables are found.</returns>
+        public static IDictionary GetEnvironmentVariables()
+        {
+            return PatchDictionary(new Dictionary<string, string>(Variables));
+        }
+
+        /// <summary>
+        /// Retrieves all environment variable names and their values from the current process, or from the Windows operating system registry key for the current user or local machine.
+        /// </summary>
+        /// <param name="target">One of the EnvironmentVariableTarget values.</param>
+        /// <returns>The Bridge implementation ignores target. A dictionary that contains all environment variable names and their values; otherwise, an empty dictionary if no environment variables are found.</returns>
+        public static IDictionary GetEnvironmentVariables(EnvironmentVariableTarget target)
+        {
+            return GetEnvironmentVariables();
+        }
+
+        /// <summary>
+        /// Gets the path to the system special folder that is identified by the specified enumeration.
+        /// </summary>
+        /// <param name="folder">An enumerated constant that identifies a system special folder.</param>
+        /// <returns>The Bridge implementation returns an empty string.</returns>
+        [Template("\"\"")]
+        public static extern string GetFolderPath(Environment.SpecialFolder folder);
+
+        /// <summary>
+        /// Gets the path to the system special folder that is identified by the specified enumeration, and uses a specified option for accessing special folders.
+        /// </summary>
+        /// <param name="folder">An enumerated constant that identifies a system special folder.</param>
+        /// <param name="option">Specifies options to use for accessing a special folder.</param>
+        /// <returns>The Bridge implementation returns an empty string.</returns>
+        [Template("\"\"")]
+        public static extern string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option);
+
+        /// <summary>
+        /// Returns an array of string containing the names of the logical drives on the current computer.
+        /// </summary>
+        /// <returns>The Bridge implementation returns an empty string[].</returns>
+        public static string[] GetLogicalDrives()
+        {
+            return new string[0];
+        }
+
+        /// <summary>
+        /// Creates, modifies, or deletes an environment variable stored in the current process.
+        /// </summary>
+        /// <param name="variable">The name of an environment variable.</param>
+        /// <param name="value">A value to assign to variable.</param>
+        public static void SetEnvironmentVariable(string variable, string value)
+        {
+            if (variable == null)
+            {
+                throw new ArgumentNullException("variable");
+            }
+
+            if (string.IsNullOrEmpty(variable)
+                || variable.StartsWith(char.MinValue.ToString())
+                || variable.Contains("=")
+                || variable.Length > 32767)
+            {
+                throw new ArgumentException("Incorrect variable (cannot be empty, contain zero character nor equal sign, be longer than 32767).");
+            }
+
+            variable = variable.ToLower();
+
+            if (string.IsNullOrEmpty(value))
+            {
+                if (Variables.ContainsKey(variable))
+                {
+                    Variables.Remove(variable);
+                }
+            }
+            else
+            {
+                Variables[variable] = value;
+            }
+        }
+
+        /// <summary>
+        /// Creates, modifies, or deletes an environment variable stored in the current process or in the Windows operating system registry key reserved for the current user or local machine.
+        /// </summary>
+        /// <param name="variable">The name of an environment variable.</param>
+        /// <param name="value">A value to assign to variable.</param>
+        /// <param name="target">Ignored by Bridge. One of the enumeration values that specifies the location of the environment variable.</param>
+        public static void SetEnvironmentVariable(string variable, string value, EnvironmentVariableTarget target)
+        {
+            SetEnvironmentVariable(variable, value);
         }
     }
 }

--- a/Bridge/bridge.json
+++ b/Bridge/bridge.json
@@ -72,6 +72,7 @@
         "Resources/Generator.js",
         "Resources/linq.js",
         "Resources/.generated/system/guid.js",
+        "Resources/.generated/system/environment.js",
         "Resources/Text/RegularExpressions/Regex.js",
         "Resources/Text/RegularExpressions/RegexCapture.js",
         "Resources/Text/RegularExpressions/RegexCaptureCollection.js",

--- a/Tests/Batch1/EnvironmentTests.cs
+++ b/Tests/Batch1/EnvironmentTests.cs
@@ -1,5 +1,7 @@
 ﻿using Bridge.Test.NUnit;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Bridge.ClientTest
 {
@@ -7,10 +9,384 @@ namespace Bridge.ClientTest
     [TestFixture(TestNameFormat = "Environment - {0}")]
     public class EnvironmentTests
     {
+        #region Helpers
+
+        private static dynamic Variables
+        {
+            [Template("System.Environment.variables")]
+            get;
+        }
+
+        private static void AssertVariables()
+        {
+            var variables = Variables as Dictionary<string, string>;
+
+            Assert.NotNull(variables, "Get EnvironmentVariable via internal code as a preparation step for the test");
+            variables.Clear();
+        }
+
+        private static Dictionary<string, string> SetupVariables()
+        {
+            var variables = Variables as Dictionary<string, string>;
+            variables.Add("variable1", "value1");
+            variables.Add("variable2", "value2");
+
+            return variables;
+        }
+
+        #endregion Helpers
+
+        [Test]
+        public void CommandLineNotEmpty()
+        {
+            Assert.NotNull(Environment.CommandLine);
+            Assert.True(Environment.CommandLine != string.Empty);
+        }
+
+        [Test]
+        public void CurrentDirectoryNotEmpty()
+        {
+            Assert.NotNull(Environment.CurrentDirectory);
+            Assert.True(Environment.CurrentDirectory != string.Empty);
+        }
+
+        [Test]
+        public void CurrentManagedThreadIdZero()
+        {
+            Assert.AreEqual(0, Environment.CurrentManagedThreadId);
+        }
+
+        [Test]
+        public void ExitCodeWorks()
+        {
+            Assert.NotNull(Environment.ExitCode);
+            Assert.AreEqual(0, Environment.ExitCode);
+
+            Environment.ExitCode = 1;
+            Assert.AreEqual(1, Environment.ExitCode);
+        }
+
+        [Test]
+        public void HasShutdownStartedFalse()
+        {
+            Assert.NotNull(Environment.HasShutdownStarted);
+            Assert.False(Environment.HasShutdownStarted);
+        }
+
+        [Test]
+        public void Is64BitOperatingSystemNotNull()
+        {
+            Assert.NotNull(Environment.Is64BitOperatingSystem);
+        }
+
+        [Test]
+        public void Is64BitProcessNotNull()
+        {
+            Assert.NotNull(Environment.Is64BitProcess);
+        }
+
+        [Test]
+        public void MachineNameEmpty()
+        {
+            Assert.NotNull(Environment.MachineName);
+            Assert.AreEqual("", Environment.MachineName);
+        }
+
         [Test]
         public void NewLineIsAStringContainingOnlyTheNewLineChar()
         {
             Assert.AreEqual("\n", Environment.NewLine);
         }
+
+        [Test]
+        public void OSVersionNull()
+        {
+            Assert.Null(Environment.OSVersion);
+        }
+
+        [Test]
+        public void ProcessorCountMoreThanZero()
+        {
+            Assert.NotNull(Environment.ProcessorCount);
+            Assert.True(Environment.ProcessorCount > 0);
+        }
+
+        [Test]
+        public void StackTraceNotEmpty()
+        {
+            Assert.NotNull(Environment.StackTrace);
+            Assert.True(Environment.StackTrace.Length > -1);
+        }
+
+        [Test]
+        public void SystemDirectoryEmpty()
+        {
+            Assert.AreEqual("", Environment.SystemDirectory);
+        }
+
+        [Test]
+        public void SystemPageSizeEqualsOne()
+        {
+            Assert.AreEqual(1, Environment.SystemPageSize);
+        }
+
+        [Test]
+        public void TickCountNotEmpty()
+        {
+            Assert.NotNull(Environment.TickCount);
+            Assert.True(Environment.TickCount != 0);
+            Assert.True((Environment.TickCount > 0) || (Environment.TickCount < 0));
+        }
+
+        [Test]
+        public void UserDomainNameEmpty()
+        {
+            Assert.AreEqual("", Environment.UserDomainName);
+        }
+
+        [Test]
+        public void UserInteractiveTrue()
+        {
+            Assert.NotNull(Environment.UserInteractive);
+            Assert.True(Environment.UserInteractive);
+        }
+
+        [Test]
+        public void UserNameEmpty()
+        {
+            Assert.AreEqual("", Environment.UserName);
+        }
+
+        [Test]
+        public void VersionWorks()
+        {
+            Assert.NotNull(Environment.Version);
+            Assert.True(Environment.Version.ToString().Length > 0, Environment.Version.ToString());
+        }
+
+        [Test]
+        public void WorkingSetZero()
+        {
+            Assert.NotNull(Environment.WorkingSet);
+            Assert.AreEqual("0", Environment.WorkingSet.ToString());
+            Assert.AreEqual(0L, Environment.WorkingSet);
+        }
+
+        [Test]
+        public void ExitSetsExitCode()
+        {
+            Environment.Exit(77);
+
+            Assert.AreEqual(77, Environment.ExitCode);
+        }
+
+        [Test]
+        public void ExpandEnvironmentVariablesWorks()
+        {
+            Assert.Throws<ArgumentNullException>(() => { Environment.ExpandEnvironmentVariables(null); });
+
+            AssertVariables();
+
+            SetupVariables();
+
+            var query = "First %variable1% Second: %variable2% Ignored %variable1";
+            var r = Environment.ExpandEnvironmentVariables(query);
+
+            Assert.AreEqual("First value1 Second: value2 Ignored %variable1", r);
+        }
+
+        [Test]
+        public void FailFastWorks()
+        {
+            try
+            {
+                Environment.FailFast("Some message");
+                Assert.Fail("Should have thrown 1");
+            }
+            catch(Exception ex)
+            {
+                Assert.True(ex.Message == "Some message", "Message correct");
+            }
+
+            try
+            {
+                Environment.FailFast("1", new ArgumentException("2"));
+                Assert.Fail("Should have thrown 2");
+            }
+            catch (Exception ex)
+            {
+                Assert.True(ex.Message == "1", "Message correct");
+            }
+        }
+
+        [Test]
+        public void GetCommandLineArgsWorks()
+        {
+            var args = Environment.GetCommandLineArgs();
+
+            Assert.NotNull(args);
+            Assert.True(args.Length > 0);
+            Assert.True(args is string[]);
+            Assert.NotNull(args[0]);
+            Assert.True(args[0].Length > 0);
+        }
+
+        [Test]
+        public void GetEnvironmentVariableOneParameterWorks()
+        {
+            Assert.Throws<ArgumentNullException>(() => { Environment.GetEnvironmentVariable(null); });
+
+            AssertVariables();
+
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("variable1"));
+
+            SetupVariables();
+
+            Assert.AreEqual("value1", Environment.GetEnvironmentVariable("variable1"));
+            Assert.AreEqual("value1", Environment.GetEnvironmentVariable("VARIable1"));
+            Assert.AreEqual("value2", Environment.GetEnvironmentVariable("variable2"));
+            Assert.AreEqual("value2", Environment.GetEnvironmentVariable("VARIable2"));
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("variable3"));
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("VARIable3"));
+        }
+
+        [Test]
+        public void GetEnvironmentVariableRwoParametersWorks()
+        {
+            Assert.Throws<ArgumentNullException>(() => { Environment.GetEnvironmentVariable(null, EnvironmentVariableTarget.Process); });
+
+            AssertVariables();
+
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("variable1", EnvironmentVariableTarget.Process));
+
+            SetupVariables();
+
+            Assert.AreEqual("value1", Environment.GetEnvironmentVariable("variable1", EnvironmentVariableTarget.Process));
+            Assert.AreEqual("value1", Environment.GetEnvironmentVariable("VARIable1", EnvironmentVariableTarget.Process));
+            Assert.AreEqual("value2", Environment.GetEnvironmentVariable("variable2", EnvironmentVariableTarget.Process));
+            Assert.AreEqual("value2", Environment.GetEnvironmentVariable("VARIable2", EnvironmentVariableTarget.Process));
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("variable3", EnvironmentVariableTarget.Process));
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("VARIable3", EnvironmentVariableTarget.Process));
+        }
+
+
+        [Test]
+        public void GetEnvironmentVariablesWorks()
+        {
+            AssertVariables();
+
+            var ens = Environment.GetEnvironmentVariables();
+
+            Assert.NotNull(ens);
+            Assert.AreEqual(0, ens.Count);
+
+            SetupVariables();
+
+            ens = Environment.GetEnvironmentVariables();
+
+            Assert.AreEqual(2, ens.Count);
+            Assert.AreEqual("value1", ens["variable1"]);
+            Assert.AreEqual("value2", ens["variable2"]);
+            Assert.AreEqual(null, ens["variable3"]);
+        }
+
+        [Test]
+        public void GetEnvironmentVariablesOneParameterWorks()
+        {
+            AssertVariables();
+
+            var ens = Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Process);
+
+            Assert.NotNull(ens);
+            Assert.True(ens is IDictionary);
+            Assert.AreEqual(0, ens.Count);
+
+            SetupVariables();
+
+            ens = Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Process);
+
+            Assert.AreEqual(2, ens.Count);
+            Assert.AreEqual("value1", ens["variable1"]);
+            Assert.AreEqual("value2", ens["variable2"]);
+            Assert.AreEqual(null, ens["variable3"]);
+        }
+
+        [Test]
+        public void GetFolderPathOneParameterEmpty()
+        {
+            Assert.AreEqual("", Environment.GetFolderPath(Environment.SpecialFolder.AdminTools));
+        }
+
+        [Test]
+        public void GetFolderPathTwoParametersEmpty()
+        {
+            Assert.AreEqual("", Environment.GetFolderPath(Environment.SpecialFolder.AdminTools, Environment.SpecialFolderOption.Create));
+        }
+
+
+        [Test]
+        public void GetLogicalDrivesEmpty()
+        {
+            Assert.NotNull(Environment.GetLogicalDrives());
+            Assert.True(Environment.GetLogicalDrives() is string[]);
+            Assert.AreEqual(0, Environment.GetLogicalDrives().Length);
+        }
+
+        [Test]
+        public void SetEnvironmentVariableTwoParametersWorks()
+        {
+            Assert.Throws<ArgumentNullException>(() => { Environment.SetEnvironmentVariable(null, "1"); });
+            Assert.Throws<ArgumentException>(() => { Environment.SetEnvironmentVariable("", "1"); });
+            Assert.Throws<ArgumentException>(() => { Environment.SetEnvironmentVariable("=", "1"); });
+            Assert.Throws<ArgumentException>(() => { Environment.SetEnvironmentVariable("a=", "1"); });
+            Assert.Throws<ArgumentException>(() => { Environment.SetEnvironmentVariable(char.MinValue.ToString(), "1"); });
+
+            AssertVariables();
+
+            Environment.SetEnvironmentVariable("1", "one");
+            Assert.AreEqual("one", Environment.GetEnvironmentVariable("1"));
+            Assert.AreEqual(1, Environment.GetEnvironmentVariables().Count);
+
+            Environment.SetEnvironmentVariable("2", "two");
+            Assert.AreEqual("two", Environment.GetEnvironmentVariable("2"));
+            Assert.AreEqual(2, Environment.GetEnvironmentVariables().Count);
+
+            Environment.SetEnvironmentVariable("1", null);
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("1"));
+            Assert.AreEqual(1, Environment.GetEnvironmentVariables().Count);
+
+            Environment.SetEnvironmentVariable("2", "");
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("2"));
+            Assert.AreEqual(0, Environment.GetEnvironmentVariables().Count);
+        }
+
+        [Test]
+        public void SetEnvironmentVariableThreeParametersWorks()
+        {
+            Assert.Throws<ArgumentNullException>(() => { Environment.SetEnvironmentVariable(null, "1", EnvironmentVariableTarget.Process); });
+            Assert.Throws<ArgumentException>(() => { Environment.SetEnvironmentVariable("", "1", EnvironmentVariableTarget.Process); });
+            Assert.Throws<ArgumentException>(() => { Environment.SetEnvironmentVariable("=", "1", EnvironmentVariableTarget.Process); });
+            Assert.Throws<ArgumentException>(() => { Environment.SetEnvironmentVariable("a=", "1", EnvironmentVariableTarget.Process); });
+            Assert.Throws<ArgumentException>(() => { Environment.SetEnvironmentVariable(char.MinValue.ToString(), "1", EnvironmentVariableTarget.Process); });
+
+            AssertVariables();
+
+            Environment.SetEnvironmentVariable("1", "one", EnvironmentVariableTarget.Process);
+            Assert.AreEqual("one", Environment.GetEnvironmentVariable("1"));
+            Assert.AreEqual(1, Environment.GetEnvironmentVariables().Count);
+
+            Environment.SetEnvironmentVariable("2", "two", EnvironmentVariableTarget.Process);
+            Assert.AreEqual("two", Environment.GetEnvironmentVariable("2"));
+            Assert.AreEqual(2, Environment.GetEnvironmentVariables().Count);
+
+            Environment.SetEnvironmentVariable("1", null, EnvironmentVariableTarget.Process);
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("1"));
+            Assert.AreEqual(1, Environment.GetEnvironmentVariables().Count);
+
+            Environment.SetEnvironmentVariable("2", "", EnvironmentVariableTarget.Process);
+            Assert.AreEqual(null, Environment.GetEnvironmentVariable("2"));
+            Assert.AreEqual(0, Environment.GetEnvironmentVariables().Count);
+        }
+
     }
 }

--- a/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
+++ b/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
@@ -2774,7 +2774,39 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
             QUnit.test("Uint8ClampedArrayTests - ICollectionIsReadOnlyWorks", Bridge.Test.Runtime.BridgeClientTestRunner.Uint8ClampedArrayTests.ICollectionIsReadOnlyWorks);
             QUnit.test("Uint8ClampedArrayTests - ICollectionCopyTo", Bridge.Test.Runtime.BridgeClientTestRunner.Uint8ClampedArrayTests.ICollectionCopyTo);
             QUnit.module("Utilities");
+            QUnit.test("Environment - CommandLineNotEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.CommandLineNotEmpty);
+            QUnit.test("Environment - CurrentDirectoryNotEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.CurrentDirectoryNotEmpty);
+            QUnit.test("Environment - CurrentManagedThreadIdZero", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.CurrentManagedThreadIdZero);
+            QUnit.test("Environment - ExitCodeWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.ExitCodeWorks);
+            QUnit.test("Environment - HasShutdownStartedFalse", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.HasShutdownStartedFalse);
+            QUnit.test("Environment - Is64BitOperatingSystemNotNull", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.Is64BitOperatingSystemNotNull);
+            QUnit.test("Environment - Is64BitProcessNotNull", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.Is64BitProcessNotNull);
+            QUnit.test("Environment - MachineNameEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.MachineNameEmpty);
             QUnit.test("Environment - NewLineIsAStringContainingOnlyTheNewLineChar", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.NewLineIsAStringContainingOnlyTheNewLineChar);
+            QUnit.test("Environment - OSVersionNull", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.OSVersionNull);
+            QUnit.test("Environment - ProcessorCountMoreThanZero", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.ProcessorCountMoreThanZero);
+            QUnit.test("Environment - StackTraceNotEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.StackTraceNotEmpty);
+            QUnit.test("Environment - SystemDirectoryEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.SystemDirectoryEmpty);
+            QUnit.test("Environment - SystemPageSizeEqualsOne", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.SystemPageSizeEqualsOne);
+            QUnit.test("Environment - TickCountNotEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.TickCountNotEmpty);
+            QUnit.test("Environment - UserDomainNameEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.UserDomainNameEmpty);
+            QUnit.test("Environment - UserInteractiveTrue", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.UserInteractiveTrue);
+            QUnit.test("Environment - UserNameEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.UserNameEmpty);
+            QUnit.test("Environment - VersionWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.VersionWorks);
+            QUnit.test("Environment - WorkingSetZero", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.WorkingSetZero);
+            QUnit.test("Environment - ExitSetsExitCode", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.ExitSetsExitCode);
+            QUnit.test("Environment - ExpandEnvironmentVariablesWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.ExpandEnvironmentVariablesWorks);
+            QUnit.test("Environment - FailFastWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.FailFastWorks);
+            QUnit.test("Environment - GetCommandLineArgsWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.GetCommandLineArgsWorks);
+            QUnit.test("Environment - GetEnvironmentVariableOneParameterWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.GetEnvironmentVariableOneParameterWorks);
+            QUnit.test("Environment - GetEnvironmentVariableRwoParametersWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.GetEnvironmentVariableRwoParametersWorks);
+            QUnit.test("Environment - GetEnvironmentVariablesWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.GetEnvironmentVariablesWorks);
+            QUnit.test("Environment - GetEnvironmentVariablesOneParameterWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.GetEnvironmentVariablesOneParameterWorks);
+            QUnit.test("Environment - GetFolderPathOneParameterEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.GetFolderPathOneParameterEmpty);
+            QUnit.test("Environment - GetFolderPathTwoParametersEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.GetFolderPathTwoParametersEmpty);
+            QUnit.test("Environment - GetLogicalDrivesEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.GetLogicalDrivesEmpty);
+            QUnit.test("Environment - SetEnvironmentVariableTwoParametersWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.SetEnvironmentVariableTwoParametersWorks);
+            QUnit.test("Environment - SetEnvironmentVariableThreeParametersWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.SetEnvironmentVariableThreeParametersWorks);
             QUnit.module("СultureInfo");
             QUnit.test("TypePropertiesAreCorrect", Bridge.Test.Runtime.BridgeClientTestRunner.CultureInfoTests.TypePropertiesAreCorrect);
             QUnit.test("GetFormatWorks", Bridge.Test.Runtime.BridgeClientTestRunner.CultureInfoTests.GetFormatWorks);
@@ -9358,12 +9390,236 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
     Bridge.define("Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests", {
         inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests)],
         statics: {
+            CommandLineNotEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "CommandLineNotEmpty()",
+                    Line: "40"
+                } ));
+                t.Fixture.CommandLineNotEmpty();
+            },
+            CurrentDirectoryNotEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "CurrentDirectoryNotEmpty()",
+                    Line: "47"
+                } ));
+                t.Fixture.CurrentDirectoryNotEmpty();
+            },
+            CurrentManagedThreadIdZero: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "CurrentManagedThreadIdZero()",
+                    Line: "54"
+                } ));
+                t.Fixture.CurrentManagedThreadIdZero();
+            },
+            ExitCodeWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "ExitCodeWorks()",
+                    Line: "60"
+                } ));
+                t.Fixture.ExitCodeWorks();
+            },
+            HasShutdownStartedFalse: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "HasShutdownStartedFalse()",
+                    Line: "70"
+                } ));
+                t.Fixture.HasShutdownStartedFalse();
+            },
+            Is64BitOperatingSystemNotNull: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "Is64BitOperatingSystemNotNull()",
+                    Line: "77"
+                } ));
+                t.Fixture.Is64BitOperatingSystemNotNull();
+            },
+            Is64BitProcessNotNull: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "Is64BitProcessNotNull()",
+                    Line: "83"
+                } ));
+                t.Fixture.Is64BitProcessNotNull();
+            },
+            MachineNameEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "MachineNameEmpty()",
+                    Line: "89"
+                } ));
+                t.Fixture.MachineNameEmpty();
+            },
             NewLineIsAStringContainingOnlyTheNewLineChar: function (assert) {
                 var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
                     Method: "NewLineIsAStringContainingOnlyTheNewLineChar()",
-                    Line: "10"
+                    Line: "96"
                 } ));
                 t.Fixture.NewLineIsAStringContainingOnlyTheNewLineChar();
+            },
+            OSVersionNull: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "OSVersionNull()",
+                    Line: "102"
+                } ));
+                t.Fixture.OSVersionNull();
+            },
+            ProcessorCountMoreThanZero: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "ProcessorCountMoreThanZero()",
+                    Line: "108"
+                } ));
+                t.Fixture.ProcessorCountMoreThanZero();
+            },
+            StackTraceNotEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "StackTraceNotEmpty()",
+                    Line: "115"
+                } ));
+                t.Fixture.StackTraceNotEmpty();
+            },
+            SystemDirectoryEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "SystemDirectoryEmpty()",
+                    Line: "122"
+                } ));
+                t.Fixture.SystemDirectoryEmpty();
+            },
+            SystemPageSizeEqualsOne: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "SystemPageSizeEqualsOne()",
+                    Line: "128"
+                } ));
+                t.Fixture.SystemPageSizeEqualsOne();
+            },
+            TickCountNotEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "TickCountNotEmpty()",
+                    Line: "134"
+                } ));
+                t.Fixture.TickCountNotEmpty();
+            },
+            UserDomainNameEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "UserDomainNameEmpty()",
+                    Line: "142"
+                } ));
+                t.Fixture.UserDomainNameEmpty();
+            },
+            UserInteractiveTrue: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "UserInteractiveTrue()",
+                    Line: "148"
+                } ));
+                t.Fixture.UserInteractiveTrue();
+            },
+            UserNameEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "UserNameEmpty()",
+                    Line: "155"
+                } ));
+                t.Fixture.UserNameEmpty();
+            },
+            VersionWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "VersionWorks()",
+                    Line: "161"
+                } ));
+                t.Fixture.VersionWorks();
+            },
+            WorkingSetZero: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "WorkingSetZero()",
+                    Line: "168"
+                } ));
+                t.Fixture.WorkingSetZero();
+            },
+            ExitSetsExitCode: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "ExitSetsExitCode()",
+                    Line: "176"
+                } ));
+                t.Fixture.ExitSetsExitCode();
+            },
+            ExpandEnvironmentVariablesWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "ExpandEnvironmentVariablesWorks()",
+                    Line: "184"
+                } ));
+                t.Fixture.ExpandEnvironmentVariablesWorks();
+            },
+            FailFastWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "FailFastWorks()",
+                    Line: "199"
+                } ));
+                t.Fixture.FailFastWorks();
+            },
+            GetCommandLineArgsWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "GetCommandLineArgsWorks()",
+                    Line: "223"
+                } ));
+                t.Fixture.GetCommandLineArgsWorks();
+            },
+            GetEnvironmentVariableOneParameterWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "GetEnvironmentVariableOneParameterWorks()",
+                    Line: "235"
+                } ));
+                t.Fixture.GetEnvironmentVariableOneParameterWorks();
+            },
+            GetEnvironmentVariableRwoParametersWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "GetEnvironmentVariableRwoParametersWorks()",
+                    Line: "254"
+                } ));
+                t.Fixture.GetEnvironmentVariableRwoParametersWorks();
+            },
+            GetEnvironmentVariablesWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "GetEnvironmentVariablesWorks()",
+                    Line: "274"
+                } ));
+                t.Fixture.GetEnvironmentVariablesWorks();
+            },
+            GetEnvironmentVariablesOneParameterWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "GetEnvironmentVariablesOneParameterWorks()",
+                    Line: "294"
+                } ));
+                t.Fixture.GetEnvironmentVariablesOneParameterWorks();
+            },
+            GetFolderPathOneParameterEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "GetFolderPathOneParameterEmpty()",
+                    Line: "315"
+                } ));
+                t.Fixture.GetFolderPathOneParameterEmpty();
+            },
+            GetFolderPathTwoParametersEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "GetFolderPathTwoParametersEmpty()",
+                    Line: "321"
+                } ));
+                t.Fixture.GetFolderPathTwoParametersEmpty();
+            },
+            GetLogicalDrivesEmpty: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "GetLogicalDrivesEmpty()",
+                    Line: "328"
+                } ));
+                t.Fixture.GetLogicalDrivesEmpty();
+            },
+            SetEnvironmentVariableTwoParametersWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "SetEnvironmentVariableTwoParametersWorks()",
+                    Line: "336"
+                } ));
+                t.Fixture.SetEnvironmentVariableTwoParametersWorks();
+            },
+            SetEnvironmentVariableThreeParametersWorks: function (assert) {
+                var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.EnvironmentTests).BeforeTest(true, assert, Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests, void 0, Bridge.merge(new Bridge.Test.Runtime.TestContext(), {
+                    Method: "SetEnvironmentVariableThreeParametersWorks()",
+                    Line: "364"
+                } ));
+                t.Fixture.SetEnvironmentVariableThreeParametersWorks();
             }
         },
         context: null,

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -11587,6 +11587,8 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 ]
             },
 
+            noKeyCheck: false,
+
             ctor: function (obj, comparer) {
                 this.$initialize();
                 this.comparer = comparer || System.Collections.Generic.EqualityComparer$1(TKey).def;
@@ -11690,6 +11692,10 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 var entry = this.findEntry(key);
 
                 if (!entry) {
+                    if (this.noKeyCheck){
+                        return Bridge.getDefaultValue(TValue);
+                    }
+
                     throw new System.Collections.Generic.KeyNotFoundException('Key ' + key + ' does not exist.');
                 }
 
@@ -19416,6 +19422,214 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
             this._k = r[System.Array.index(7, r)];
         },
         $clone: function (to) { return this; }
+    });
+
+    // @source environment.js
+
+    Bridge.define("System.Environment", {
+        statics: {
+            ctor: function () {
+                System.Environment.variables = new (System.Collections.Generic.Dictionary$2(System.String,System.String))();
+                System.Environment.patchDictionary(System.Environment.variables);
+            },
+            variables: null,
+            config: {
+                properties: {
+                    Location: {
+                        get: function () {
+                            var g = Bridge.global;
+
+                            if (g && g.location) {
+                                return g.location;
+                            }
+
+                            return null;
+                        }
+                    },
+                    CommandLine: {
+                        get: function () {
+                            return System.Environment.getCommandLineArgs().join(" ");
+                        }
+                    },
+                    CurrentDirectory: {
+                        get: function () {
+                            var l = System.Environment.Location;
+
+                            return l ? l.pathname : "";
+                        },
+                        set: function (value) {
+                            var l = System.Environment.Location;
+
+                            if (l) {
+                                l.pathname = value;
+                            }
+                        }
+                    },
+                    ExitCode: 0,
+                    Is64BitOperatingSystem: {
+                        get: function () {
+                            var g = Bridge.global;
+
+                            if (g && g.navigator && (!Bridge.referenceEquals(g.navigator.userAgent.indexOf("WOW64"), -1) || !Bridge.referenceEquals(g.navigator.userAgent.indexOf("Win64"), -1))) {
+                                return true;
+                            }
+
+                            return false;
+                        }
+                    },
+                    ProcessorCount: {
+                        get: function () {
+                            var g = Bridge.global;
+
+                            if (g && g.navigator && g.navigator.hardwareConcurrency) {
+                                return g.navigator.hardwareConcurrency;
+                            }
+
+                            return 1;
+                        }
+                    },
+                    StackTrace: {
+                        get: function () {
+                            var err = new Error();
+                            var s = err.stack;
+
+                            if (!System.String.isNullOrEmpty(s)) {
+                                if (System.String.indexOf(s, "at") >= 0) {
+                                    return s.substr(System.String.indexOf(s, "at"));
+                                }
+                            }
+
+                            return "";
+                        }
+                    },
+                    Version: {
+                        get: function () {
+                            var s = Bridge.SystemAssembly.compiler;
+
+                            var v = { };
+
+                            if (System.Version.tryParse(s, v)) {
+                                return v.v;
+                            }
+
+                            return new System.Version.ctor();
+                        }
+                    }
+                }
+            },
+            patchDictionary: function (d) {
+                d.noKeyCheck = true;
+
+                return d;
+            },
+            exit: function (exitCode) {
+                System.Environment.ExitCode = exitCode;
+            },
+            expandEnvironmentVariables: function (name) {
+                var $t;
+                if (name == null) {
+                    throw new System.ArgumentNullException(name);
+                }
+
+                // Case sensitive
+                $t = Bridge.getEnumerator(System.Environment.variables);
+                try {
+                    while ($t.moveNext()) {
+                        var pair = $t.Current;
+                        name = System.String.replaceAll(name, System.String.concat("%", pair.key, "%"), pair.value);
+                    }
+                }finally {
+                    if (Bridge.is($t, System.IDisposable)) {
+                        $t.System$IDisposable$dispose();
+                    }
+                }
+                return name;
+            },
+            failFast: function (message) {
+                throw new System.Exception(message);
+            },
+            failFast$1: function (message, exception) {
+                throw new System.Exception(message, exception);
+            },
+            getCommandLineArgs: function () {
+                var l = System.Environment.Location;
+
+                if (l) {
+                    var args = new (System.Collections.Generic.List$1(System.String))();
+
+                    var path = l.pathname;
+
+                    if (!System.String.isNullOrEmpty(path)) {
+                        args.add(path);
+                    }
+
+                    var search = l.search;
+
+                    if (!System.String.isNullOrEmpty(search) && search.length > 1) {
+                        var query = System.String.split(search.substr(1), [38].map(function(i) {{ return String.fromCharCode(i); }}));
+
+                        for (var i = 0; i < query.length; i = (i + 1) | 0) {
+                            var param = System.String.split(query[System.Array.index(i, query)], [61].map(function(i) {{ return String.fromCharCode(i); }}));
+
+                            for (var j = 0; j < param.length; j = (j + 1) | 0) {
+                                args.add(param[System.Array.index(j, param)]);
+                            }
+                        }
+                    }
+
+                    return args.toArray();
+                }
+
+                return System.Array.init(0, null, System.String);
+            },
+            getEnvironmentVariable: function (variable) {
+                if (variable == null) {
+                    throw new System.ArgumentNullException("variable");
+                }
+
+                var r = { };
+
+                if (System.Environment.variables.tryGetValue(variable.toLowerCase(), r)) {
+                    return r.v;
+                }
+
+                return null;
+            },
+            getEnvironmentVariable$1: function (variable, target) {
+                return System.Environment.getEnvironmentVariable(variable);
+            },
+            getEnvironmentVariables: function () {
+                return System.Environment.patchDictionary(new (System.Collections.Generic.Dictionary$2(System.String,System.String))(System.Environment.variables));
+            },
+            getEnvironmentVariables$1: function (target) {
+                return System.Environment.getEnvironmentVariables();
+            },
+            getLogicalDrives: function () {
+                return System.Array.init(0, null, System.String);
+            },
+            setEnvironmentVariable: function (variable, value) {
+                if (variable == null) {
+                    throw new System.ArgumentNullException("variable");
+                }
+
+                if (System.String.isNullOrEmpty(variable) || System.String.startsWith(variable, String.fromCharCode(0)) || System.String.contains(variable,"=") || variable.length > 32767) {
+                    throw new System.ArgumentException("Incorrect variable (cannot be empty, contain zero character nor equal sign, be longer than 32767).");
+                }
+
+                variable = variable.toLowerCase();
+
+                if (System.String.isNullOrEmpty(value)) {
+                    if (System.Environment.variables.containsKey(variable)) {
+                        System.Environment.variables.remove(variable);
+                    }
+                } else {
+                    System.Environment.variables.set(variable, value);
+                }
+            },
+            setEnvironmentVariable$1: function (variable, value, target) {
+                System.Environment.setEnvironmentVariable(variable, value);
+            }
+        }
     });
 
     // @source Regex.js

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -19468,9 +19468,9 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
                     ExitCode: 0,
                     Is64BitOperatingSystem: {
                         get: function () {
-                            var g = Bridge.global;
+                            var n = Bridge.global ? Bridge.global.navigator : null;
 
-                            if (g && g.navigator && (!Bridge.referenceEquals(g.navigator.userAgent.indexOf("WOW64"), -1) || !Bridge.referenceEquals(g.navigator.userAgent.indexOf("Win64"), -1))) {
+                            if (n && (!Bridge.referenceEquals(n.userAgent.indexOf("WOW64"), -1) || !Bridge.referenceEquals(n.userAgent.indexOf("Win64"), -1))) {
                                 return true;
                             }
 
@@ -19479,10 +19479,10 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
                     },
                     ProcessorCount: {
                         get: function () {
-                            var g = Bridge.global;
+                            var n = Bridge.global ? Bridge.global.navigator : null;
 
-                            if (g && g.navigator && g.navigator.hardwareConcurrency) {
-                                return g.navigator.hardwareConcurrency;
+                            if (n && n.hardwareConcurrency) {
+                                return n.hardwareConcurrency;
                             }
 
                             return 1;

--- a/Tests/Runner/Batch1/code.js
+++ b/Tests/Runner/Batch1/code.js
@@ -16045,8 +16045,313 @@ Bridge.assembly("Bridge.ClientTest", {"Bridge.ClientTest.Batch1.Reflection.Resou
     });
 
     Bridge.define("Bridge.ClientTest.EnvironmentTests", {
+        statics: {
+            AssertVariables: function () {
+                var variables = Bridge.as(System.Environment.variables, System.Collections.Generic.Dictionary$2(System.String,System.String));
+
+                Bridge.Test.NUnit.Assert.NotNull$1(variables, "Get EnvironmentVariable via internal code as a preparation step for the test");
+                variables.clear();
+            },
+            SetupVariables: function () {
+                var variables = Bridge.as(System.Environment.variables, System.Collections.Generic.Dictionary$2(System.String,System.String));
+                variables.add("variable1", "value1");
+                variables.add("variable2", "value2");
+
+                return variables;
+            }
+        },
+        CommandLineNotEmpty: function () {
+            Bridge.Test.NUnit.Assert.NotNull(System.Environment.CommandLine);
+            Bridge.Test.NUnit.Assert.True(!Bridge.referenceEquals(System.Environment.CommandLine, ""));
+        },
+        CurrentDirectoryNotEmpty: function () {
+            Bridge.Test.NUnit.Assert.NotNull(System.Environment.CurrentDirectory);
+            Bridge.Test.NUnit.Assert.True(!Bridge.referenceEquals(System.Environment.CurrentDirectory, ""));
+        },
+        CurrentManagedThreadIdZero: function () {
+            Bridge.Test.NUnit.Assert.AreEqual(0, 0);
+        },
+        ExitCodeWorks: function () {
+            Bridge.Test.NUnit.Assert.NotNull(System.Environment.ExitCode);
+            Bridge.Test.NUnit.Assert.AreEqual(0, System.Environment.ExitCode);
+
+            System.Environment.ExitCode = 1;
+            Bridge.Test.NUnit.Assert.AreEqual(1, System.Environment.ExitCode);
+        },
+        HasShutdownStartedFalse: function () {
+            Bridge.Test.NUnit.Assert.NotNull(false);
+            Bridge.Test.NUnit.Assert.False(false);
+        },
+        Is64BitOperatingSystemNotNull: function () {
+            Bridge.Test.NUnit.Assert.NotNull(System.Environment.Is64BitOperatingSystem);
+        },
+        Is64BitProcessNotNull: function () {
+            Bridge.Test.NUnit.Assert.NotNull(false);
+        },
+        MachineNameEmpty: function () {
+            Bridge.Test.NUnit.Assert.NotNull("");
+            Bridge.Test.NUnit.Assert.AreEqual("", "");
+        },
         NewLineIsAStringContainingOnlyTheNewLineChar: function () {
             Bridge.Test.NUnit.Assert.AreEqual("\n", '\n');
+        },
+        OSVersionNull: function () {
+            Bridge.Test.NUnit.Assert.Null(Bridge.unbox(null));
+        },
+        ProcessorCountMoreThanZero: function () {
+            Bridge.Test.NUnit.Assert.NotNull(System.Environment.ProcessorCount);
+            Bridge.Test.NUnit.Assert.True(System.Environment.ProcessorCount > 0);
+        },
+        StackTraceNotEmpty: function () {
+            Bridge.Test.NUnit.Assert.NotNull(System.Environment.StackTrace);
+            Bridge.Test.NUnit.Assert.True(System.Environment.StackTrace.length > -1);
+        },
+        SystemDirectoryEmpty: function () {
+            Bridge.Test.NUnit.Assert.AreEqual("", "");
+        },
+        SystemPageSizeEqualsOne: function () {
+            Bridge.Test.NUnit.Assert.AreEqual(1, 1);
+        },
+        TickCountNotEmpty: function () {
+            Bridge.Test.NUnit.Assert.NotNull(Date.now());
+            Bridge.Test.NUnit.Assert.True(Date.now() !== 0);
+            Bridge.Test.NUnit.Assert.True((Date.now() > 0) || (Date.now() < 0));
+        },
+        UserDomainNameEmpty: function () {
+            Bridge.Test.NUnit.Assert.AreEqual("", "");
+        },
+        UserInteractiveTrue: function () {
+            Bridge.Test.NUnit.Assert.NotNull(true);
+            Bridge.Test.NUnit.Assert.True(true);
+        },
+        UserNameEmpty: function () {
+            Bridge.Test.NUnit.Assert.AreEqual("", "");
+        },
+        VersionWorks: function () {
+            Bridge.Test.NUnit.Assert.NotNull(System.Environment.Version);
+            Bridge.Test.NUnit.Assert.True$1(System.Environment.Version.toString().length > 0, System.Environment.Version.toString());
+        },
+        WorkingSetZero: function () {
+            Bridge.Test.NUnit.Assert.NotNull(System.Int64(0));
+            Bridge.Test.NUnit.Assert.AreEqual("0", System.Int64(0).toString());
+            Bridge.Test.NUnit.Assert.AreEqual(System.Int64(0), System.Int64(0));
+        },
+        ExitSetsExitCode: function () {
+            System.Environment.exit(77);
+
+            Bridge.Test.NUnit.Assert.AreEqual(77, System.Environment.ExitCode);
+        },
+        ExpandEnvironmentVariablesWorks: function () {
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.EnvironmentTests.f1);
+
+            Bridge.ClientTest.EnvironmentTests.AssertVariables();
+
+            Bridge.ClientTest.EnvironmentTests.SetupVariables();
+
+            var query = "First %variable1% Second: %variable2% Ignored %variable1";
+            var r = System.Environment.expandEnvironmentVariables(query);
+
+            Bridge.Test.NUnit.Assert.AreEqual("First value1 Second: value2 Ignored %variable1", r);
+        },
+        FailFastWorks: function () {
+            try {
+                System.Environment.failFast("Some message");
+                Bridge.Test.NUnit.Assert.Fail$1("Should have thrown 1");
+            }
+            catch (ex) {
+                ex = System.Exception.create(ex);
+                Bridge.Test.NUnit.Assert.True$1(Bridge.referenceEquals(ex.Message, "Some message"), "Message correct");
+            }
+
+            try {
+                System.Environment.failFast$1("1", new System.ArgumentException("2"));
+                Bridge.Test.NUnit.Assert.Fail$1("Should have thrown 2");
+            }
+            catch (ex1) {
+                ex1 = System.Exception.create(ex1);
+                Bridge.Test.NUnit.Assert.True$1(Bridge.referenceEquals(ex1.Message, "1"), "Message correct");
+            }
+        },
+        GetCommandLineArgsWorks: function () {
+            var args = System.Environment.getCommandLineArgs();
+
+            Bridge.Test.NUnit.Assert.NotNull(args);
+            Bridge.Test.NUnit.Assert.True(args.length > 0);
+            Bridge.Test.NUnit.Assert.True(Bridge.hasValue(args));
+            Bridge.Test.NUnit.Assert.NotNull(args[System.Array.index(0, args)]);
+            Bridge.Test.NUnit.Assert.True(args[System.Array.index(0, args)].length > 0);
+        },
+        GetEnvironmentVariableOneParameterWorks: function () {
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.EnvironmentTests.f2);
+
+            Bridge.ClientTest.EnvironmentTests.AssertVariables();
+
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable("variable1"));
+
+            Bridge.ClientTest.EnvironmentTests.SetupVariables();
+
+            Bridge.Test.NUnit.Assert.AreEqual("value1", System.Environment.getEnvironmentVariable("variable1"));
+            Bridge.Test.NUnit.Assert.AreEqual("value1", System.Environment.getEnvironmentVariable("VARIable1"));
+            Bridge.Test.NUnit.Assert.AreEqual("value2", System.Environment.getEnvironmentVariable("variable2"));
+            Bridge.Test.NUnit.Assert.AreEqual("value2", System.Environment.getEnvironmentVariable("VARIable2"));
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable("variable3"));
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable("VARIable3"));
+        },
+        GetEnvironmentVariableRwoParametersWorks: function () {
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.EnvironmentTests.f3);
+
+            Bridge.ClientTest.EnvironmentTests.AssertVariables();
+
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable$1("variable1", 0));
+
+            Bridge.ClientTest.EnvironmentTests.SetupVariables();
+
+            Bridge.Test.NUnit.Assert.AreEqual("value1", System.Environment.getEnvironmentVariable$1("variable1", 0));
+            Bridge.Test.NUnit.Assert.AreEqual("value1", System.Environment.getEnvironmentVariable$1("VARIable1", 0));
+            Bridge.Test.NUnit.Assert.AreEqual("value2", System.Environment.getEnvironmentVariable$1("variable2", 0));
+            Bridge.Test.NUnit.Assert.AreEqual("value2", System.Environment.getEnvironmentVariable$1("VARIable2", 0));
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable$1("variable3", 0));
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable$1("VARIable3", 0));
+        },
+        GetEnvironmentVariablesWorks: function () {
+            Bridge.ClientTest.EnvironmentTests.AssertVariables();
+
+            var ens = System.Environment.getEnvironmentVariables();
+
+            Bridge.Test.NUnit.Assert.NotNull(ens);
+            Bridge.Test.NUnit.Assert.AreEqual(0, System.Array.getCount(ens));
+
+            Bridge.ClientTest.EnvironmentTests.SetupVariables();
+
+            ens = System.Environment.getEnvironmentVariables();
+
+            Bridge.Test.NUnit.Assert.AreEqual(2, System.Array.getCount(ens));
+            Bridge.Test.NUnit.Assert.AreEqual("value1", Bridge.unbox(ens.System$Collections$IDictionary$getItem("variable1")));
+            Bridge.Test.NUnit.Assert.AreEqual("value2", Bridge.unbox(ens.System$Collections$IDictionary$getItem("variable2")));
+            Bridge.Test.NUnit.Assert.AreEqual(null, Bridge.unbox(ens.System$Collections$IDictionary$getItem("variable3")));
+        },
+        GetEnvironmentVariablesOneParameterWorks: function () {
+            Bridge.ClientTest.EnvironmentTests.AssertVariables();
+
+            var ens = System.Environment.getEnvironmentVariables$1(0);
+
+            Bridge.Test.NUnit.Assert.NotNull(ens);
+            Bridge.Test.NUnit.Assert.True(Bridge.hasValue(ens));
+            Bridge.Test.NUnit.Assert.AreEqual(0, System.Array.getCount(ens));
+
+            Bridge.ClientTest.EnvironmentTests.SetupVariables();
+
+            ens = System.Environment.getEnvironmentVariables$1(0);
+
+            Bridge.Test.NUnit.Assert.AreEqual(2, System.Array.getCount(ens));
+            Bridge.Test.NUnit.Assert.AreEqual("value1", Bridge.unbox(ens.System$Collections$IDictionary$getItem("variable1")));
+            Bridge.Test.NUnit.Assert.AreEqual("value2", Bridge.unbox(ens.System$Collections$IDictionary$getItem("variable2")));
+            Bridge.Test.NUnit.Assert.AreEqual(null, Bridge.unbox(ens.System$Collections$IDictionary$getItem("variable3")));
+        },
+        GetFolderPathOneParameterEmpty: function () {
+            Bridge.Test.NUnit.Assert.AreEqual("", "");
+        },
+        GetFolderPathTwoParametersEmpty: function () {
+            Bridge.Test.NUnit.Assert.AreEqual("", "");
+        },
+        GetLogicalDrivesEmpty: function () {
+            Bridge.Test.NUnit.Assert.NotNull(System.Environment.getLogicalDrives());
+            Bridge.Test.NUnit.Assert.True(Bridge.hasValue(System.Environment.getLogicalDrives()));
+            Bridge.Test.NUnit.Assert.AreEqual(0, System.Environment.getLogicalDrives().length);
+        },
+        SetEnvironmentVariableTwoParametersWorks: function () {
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.EnvironmentTests.f4);
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentException, $asm.$.Bridge.ClientTest.EnvironmentTests.f5);
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentException, $asm.$.Bridge.ClientTest.EnvironmentTests.f6);
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentException, $asm.$.Bridge.ClientTest.EnvironmentTests.f7);
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentException, $asm.$.Bridge.ClientTest.EnvironmentTests.f8);
+
+            Bridge.ClientTest.EnvironmentTests.AssertVariables();
+
+            System.Environment.setEnvironmentVariable("1", "one");
+            Bridge.Test.NUnit.Assert.AreEqual("one", System.Environment.getEnvironmentVariable("1"));
+            Bridge.Test.NUnit.Assert.AreEqual(1, System.Array.getCount(System.Environment.getEnvironmentVariables()));
+
+            System.Environment.setEnvironmentVariable("2", "two");
+            Bridge.Test.NUnit.Assert.AreEqual("two", System.Environment.getEnvironmentVariable("2"));
+            Bridge.Test.NUnit.Assert.AreEqual(2, System.Array.getCount(System.Environment.getEnvironmentVariables()));
+
+            System.Environment.setEnvironmentVariable("1", null);
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable("1"));
+            Bridge.Test.NUnit.Assert.AreEqual(1, System.Array.getCount(System.Environment.getEnvironmentVariables()));
+
+            System.Environment.setEnvironmentVariable("2", "");
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable("2"));
+            Bridge.Test.NUnit.Assert.AreEqual(0, System.Array.getCount(System.Environment.getEnvironmentVariables()));
+        },
+        SetEnvironmentVariableThreeParametersWorks: function () {
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentNullException, $asm.$.Bridge.ClientTest.EnvironmentTests.f9);
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentException, $asm.$.Bridge.ClientTest.EnvironmentTests.f10);
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentException, $asm.$.Bridge.ClientTest.EnvironmentTests.f11);
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentException, $asm.$.Bridge.ClientTest.EnvironmentTests.f12);
+            Bridge.Test.NUnit.Assert.Throws$6(System.ArgumentException, $asm.$.Bridge.ClientTest.EnvironmentTests.f13);
+
+            Bridge.ClientTest.EnvironmentTests.AssertVariables();
+
+            System.Environment.setEnvironmentVariable$1("1", "one", 0);
+            Bridge.Test.NUnit.Assert.AreEqual("one", System.Environment.getEnvironmentVariable("1"));
+            Bridge.Test.NUnit.Assert.AreEqual(1, System.Array.getCount(System.Environment.getEnvironmentVariables()));
+
+            System.Environment.setEnvironmentVariable$1("2", "two", 0);
+            Bridge.Test.NUnit.Assert.AreEqual("two", System.Environment.getEnvironmentVariable("2"));
+            Bridge.Test.NUnit.Assert.AreEqual(2, System.Array.getCount(System.Environment.getEnvironmentVariables()));
+
+            System.Environment.setEnvironmentVariable$1("1", null, 0);
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable("1"));
+            Bridge.Test.NUnit.Assert.AreEqual(1, System.Array.getCount(System.Environment.getEnvironmentVariables()));
+
+            System.Environment.setEnvironmentVariable$1("2", "", 0);
+            Bridge.Test.NUnit.Assert.AreEqual(null, System.Environment.getEnvironmentVariable("2"));
+            Bridge.Test.NUnit.Assert.AreEqual(0, System.Array.getCount(System.Environment.getEnvironmentVariables()));
+        }
+    });
+
+    Bridge.ns("Bridge.ClientTest.EnvironmentTests", $asm.$);
+
+    Bridge.apply($asm.$.Bridge.ClientTest.EnvironmentTests, {
+        f1: function () {
+            System.Environment.expandEnvironmentVariables(null);
+        },
+        f2: function () {
+            System.Environment.getEnvironmentVariable(null);
+        },
+        f3: function () {
+            System.Environment.getEnvironmentVariable$1(null, 0);
+        },
+        f4: function () {
+            System.Environment.setEnvironmentVariable(null, "1");
+        },
+        f5: function () {
+            System.Environment.setEnvironmentVariable("", "1");
+        },
+        f6: function () {
+            System.Environment.setEnvironmentVariable("=", "1");
+        },
+        f7: function () {
+            System.Environment.setEnvironmentVariable("a=", "1");
+        },
+        f8: function () {
+            System.Environment.setEnvironmentVariable(String.fromCharCode(0), "1");
+        },
+        f9: function () {
+            System.Environment.setEnvironmentVariable$1(null, "1", 0);
+        },
+        f10: function () {
+            System.Environment.setEnvironmentVariable$1("", "1", 0);
+        },
+        f11: function () {
+            System.Environment.setEnvironmentVariable$1("=", "1", 0);
+        },
+        f12: function () {
+            System.Environment.setEnvironmentVariable$1("a=", "1", 0);
+        },
+        f13: function () {
+            System.Environment.setEnvironmentVariable$1(String.fromCharCode(0), "1", 0);
         }
     });
 


### PR DESCRIPTION
Addresses #2224, #2553

This is not an exact copy of .Net behavior:
 - Enrironment variables are stored in **Environment** static field. I.e. it does not contain OS environment variables. However the API allows adding, storing, handling (for example, **public static string ExpandEnvironmentVariables(string name)**) and removing in .Net-like way;
- Things related to **command line** - `location.pathname` and `location.search`;
- **CurrentDirectory** - `location.pathname`
- **ExitCode** is stored as a property, allows setting by the property and by `Exit(int exitCode)`;
- **Is64BitOperatingSystem** tries to get it analizing `(n.userAgent.indexOf("WOW64") != -1 || n.userAgent.indexOf("Win64") != -1))`
- **ProcessorCount** - `navigator.hardwareConcurrency`
- **StackTrace** - an apporach like `(new Error()).stack`
- **TickCount** - `Date.now()`;
- **Version** returns Bridge Compiler version;
- **FailFast** just throws an exception (i.e. not a .Net behavior as a **finally** will be executed);
- the rest is just templates returning `""`, `false` etc.