### PR TITLE
16.0 upgrade experience: VS task assembly caching

### DIFF
--- a/.build/files/Bridge.Min.targets
+++ b/.build/files/Bridge.Min.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="GenerateScript" AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Bridge.Builder.dll" />
+  <UsingTask TaskName="BridgeCompilerTask" AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Bridge.Builder.v16.dll" />
 
   <PropertyGroup>
     <NoStdLib>True</NoStdLib>
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);BridgeGenerateScript</PrepareForRunDependsOn>
+    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);BridgeNetGenerateScript</PrepareForRunDependsOn>
   </PropertyGroup>
 
-  <Target Name="BridgeGenerateScript">
-    <Message Text="------ BridgeGenerateScript task started: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) OutputPath: $(OutputPath) ------" Importance="high" />
+  <Target Name="BridgeNetGenerateScript">
+    <Message Text="------ BridgeNetGenerateScript task started: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) OutputPath: $(OutputPath) ------" Importance="high" />
 
-    <GenerateScript
+    <BridgeCompilerTask
       Assembly="@(IntermediateAssembly)"
       AssemblyName="$(AssemblyName)"
       AssembliesPath="$(OutDir)"
@@ -30,6 +30,6 @@
       RootNamespace="$(RootNamespace)"
       Sources="@(Compile)" />
 
-    <Message Text="------ BridgeGenerateScript task done: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) OutputPath: $(OutputPath) ------" Importance="high" />
+    <Message Text="------ BridgeNetGenerateScript task done: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) OutputPath: $(OutputPath) ------" Importance="high" />
   </Target>
 </Project>

--- a/.build/specs/Bridge.Min.nuspec
+++ b/.build/specs/Bridge.Min.nuspec
@@ -28,7 +28,7 @@
     <file src="../../.build/files/Bridge.Min.targets" target="build/Bridge.Min.targets" />
 
     <!--tools-->
-    <file src="../../Compiler/Build/bin/Release/Bridge.Build.dll" target="tools/Bridge.Builder.dll" />
+    <file src="../../Compiler/Build/bin/Release/Bridge.Build.dll" target="tools/Bridge.Builder.v16.dll" />
     <file src="../../Compiler/Build/bin/Release/Bridge.Contract.dll" target="tools/Bridge.Contract.dll" />
     <file src="../../Compiler/Build/bin/Release/Bridge.Translator.dll" target="tools/Bridge.Translator.dll" />
     <file src="../../Compiler/Build/bin/Release/AjaxMin.dll" target="tools/AjaxMin.dll" />

--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Bridge.Build
 {
-    public class GenerateScript : Task
+    public class BridgeCompilerTask : Task
     {
         [Required]
         public ITaskItem Assembly

--- a/Compiler/TranslatorTests/TestProjects/02/test.csproj
+++ b/Compiler/TranslatorTests/TestProjects/02/test.csproj
@@ -67,10 +67,10 @@
   </ItemGroup>
   <!-- Bridge Compiler -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <UsingTask Condition="$(UseBridgeTask) == true" TaskName="GenerateScript" AssemblyFile="$(ProjectDir)..\..\..\Build\bin\$(Configuration)\Bridge.Build.dll" />
+  <UsingTask Condition="$(UseBridgeTask) == true" TaskName="BridgeCompilerTask" AssemblyFile="$(ProjectDir)..\..\..\Build\bin\$(Configuration)\Bridge.Build.dll" />
   <Target Condition="$(UseBridgeTask) == true" Name="AfterBuild">
     <Message Text="Using Bridge Task" Importance="high" />
-    <GenerateScript
+    <BridgeCompilerTask
       Assembly="@(IntermediateAssembly)"
       AssemblyName="$(AssemblyName)"
       AssembliesPath="$(OutDir)"


### PR DESCRIPTION
Addresses #2668:

To prevent Visual Studio from caching task assembly when upgrading from 15.7 -> 16.0:
* Visual Studio task renamed **GenerateScript** -> **BridgeCompilerTask**
* nuspec task assembly renamed **Bridge.Builder.dll** -> **Bridge.Builder.v16.dll**