### PR TITLE
[2660] Element.QuerySelector returns a Node rather than an Element

### DIFF
--- a/Html5/Document.cs
+++ b/Html5/Document.cs
@@ -1273,21 +1273,21 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="selectors">selectors is a string containing one or more CSS selectors separated by commas.</param>
         /// <returns></returns>
-        public static extern HTMLElement QuerySelector(string selectors);
+        public static extern Element QuerySelector(string selectors);
 
         /// <summary>
         /// Returns the first element within the document (using depth-first pre-order traversal of the document's nodes) that matches the specified group of selectors.
         /// </summary>
         /// <param name="selectors">selectors is a string containing one or more CSS selectors separated by commas.</param>
         /// <returns></returns>
-        public static extern T QuerySelector<T>(string selectors) where T : HTMLElement;
+        public static extern T QuerySelector<T>(string selectors) where T : Element;
 
         /// <summary>
         /// Returns a list of the elements within the document (using depth-first pre-order traversal of the document's nodes) that match the specified group of selectors. The object returned is a NodeList.
         /// </summary>
         /// <param name="selectors">selectors is a string containing one or more CSS selectors separated by commas.</param>
         /// <returns></returns>
-        public static extern ElementList QuerySelectorAll(string selectors);
+        public static extern NodeList QuerySelectorAll(string selectors);
 
         /// <summary>
         /// Closes a document stream for writing.
@@ -1323,7 +1323,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="name">name is the value of the name attribute of the element.</param>
         /// <returns>elements is an HTMLCollection of elements.</returns>
-        public static extern ElementList GetElementsByName(string name);
+        public static extern NodeList GetElementsByName(string name);
 
         /// <summary>
         /// The DOM getSelection() method is available on the Window and Document interfaces.

--- a/Html5/DocumentFragment.cs
+++ b/Html5/DocumentFragment.cs
@@ -29,14 +29,14 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="selectors">String containing one or more CSS selectors separated by commas.</param>
         /// <returns></returns>
-        public virtual extern HTMLElement QuerySelector(string selectors);
+        public virtual extern Element QuerySelector(string selectors);
 
         /// <summary>
         /// Returns the first Element node within the DocumentFragment, in document order, that matches the specified selectors.
         /// </summary>
         /// <param name="selectors">selectors is a string containing one or more CSS selectors separated by commas.</param>
         /// <returns></returns>
-        public virtual extern T QuerySelector<T>(string selectors) where T : HTMLElement;
+        public virtual extern T QuerySelector<T>(string selectors) where T : Element;
 
         /// <summary>
         /// Returns a NodeList of all the Element nodes within the DocumentFragment that match the specified selectors.

--- a/Html5/DocumentInstance.cs
+++ b/Html5/DocumentInstance.cs
@@ -869,21 +869,21 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="selectors">selectors is a string containing one or more CSS selectors separated by commas.</param>
         /// <returns></returns>
-        public virtual extern HTMLElement QuerySelector(string selectors);
+        public virtual extern Element QuerySelector(string selectors);
 
         /// <summary>
         /// Returns the first element within the document (using depth-first pre-order traversal of the document's nodes) that matches the specified group of selectors.
         /// </summary>
         /// <param name="selectors">selectors is a string containing one or more CSS selectors separated by commas.</param>
         /// <returns></returns>
-        public virtual extern T QuerySelector<T>(string selectors) where T : HTMLElement;
+        public virtual extern T QuerySelector<T>(string selectors) where T : Element;
 
         /// <summary>
         /// Returns a list of the elements within the document (using depth-first pre-order traversal of the document's nodes) that match the specified group of selectors. The object returned is a NodeList.
         /// </summary>
         /// <param name="selectors">selectors is a string containing one or more CSS selectors separated by commas.</param>
         /// <returns></returns>
-        public virtual extern ElementList QuerySelectorAll(string selectors);
+        public virtual extern NodeList QuerySelectorAll(string selectors);
 
         /// <summary>
         /// Closes a document stream for writing.
@@ -919,7 +919,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="name">name is the value of the name attribute of the element.</param>
         /// <returns>elements is an HTMLCollection of elements.</returns>
-        public virtual extern ElementList GetElementsByName(string name);
+        public virtual extern NodeList GetElementsByName(string name);
 
         /// <summary>
         /// The DOM getSelection() method is available on the Window and Document interfaces.

--- a/Html5/Elements/Element.cs
+++ b/Html5/Elements/Element.cs
@@ -212,7 +212,7 @@ namespace Bridge.Html5
         /// </summary>
         /// <param name="selectors">selectors is a group of selectors to match on.</param>
         /// <returns></returns>
-        public virtual extern Node QuerySelector(string selectors);
+        public virtual extern Element QuerySelector(string selectors);
 
         /// <summary>
         /// Returns a non-live NodeList of all elements descended from the element on which it is invoked that match the specified group of CSS selectors.


### PR DESCRIPTION
Fixes #2660. 

Changes **QuerySelector** return type to **Element**:
* https://developer.mozilla.org/en/docs/Web/API/Document/querySelector
* https://developer.mozilla.org/en/docs/Web/API/Element/querySelector  
> Returns the first Element within the document that matches the specified selector, or group of selectors.

**QuerySelectorAll** to **NodeList**
* https://developer.mozilla.org/en/docs/Web/API/Document/querySelectorAll
> Returns a list of the elements within the document (using depth-first pre-order traversal of the document's nodes) that match the specified group of selectors. The object returned is a NodeList.

**GetElementsByName** to **NodeList**:
* https://developer.mozilla.org/en/docs/Web/API/Document/getElementsByName
> Returns a NodeList collection with a given name in the (X)HTML document.

