### PR TITLE
Visual Studio logger enhancement

### DIFF
--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -151,7 +151,15 @@ namespace Bridge.Build
             }
             catch (EmitterException e)
             {
-                this.Log.LogError(null, null, null, e.FileName, e.StartLine + 1, e.StartColumn + 1, e.EndLine + 1, e.EndColumn + 1, "Error: {0} {1}", e.Message, e.StackTrace);
+                if (logger != null)
+                {
+                    logger.Error(e.ToString());
+                }
+                else
+                {
+                    this.Log.LogError(null, null, null, e.FileName, e.StartLine + 1, e.StartColumn + 1, e.EndLine + 1, e.EndColumn + 1, "Error: {0} {1}", e.Message, e.StackTrace);
+                }
+
                 success = false;
             }
             catch (Exception e)
@@ -160,11 +168,23 @@ namespace Bridge.Build
 
                 if (ee != null)
                 {
+                    if (logger != null)
+                    {
+                        logger.Error(e.ToString());
+                    }
+
                     this.Log.LogError(null, null, null, ee.FileName, ee.StartLine + 1, ee.StartColumn + 1, ee.EndLine + 1, ee.EndColumn + 1, "Error: {0} {1}", e.Message, e.StackTrace);
                 }
                 else
                 {
-                    this.Log.LogError("Error: {0} {1}", e.Message, e.StackTrace);
+                    if (logger != null)
+                    {
+                        logger.Error(e.ToString());
+                    }
+                    else
+                    {
+                        this.Log.LogError("Bridge.NET Compiler error: {0} {1}", e.Message, e.StackTrace);
+                    }
                 }
 
                 success = false;

--- a/Compiler/Build/VSLoggerWriter.cs
+++ b/Compiler/Build/VSLoggerWriter.cs
@@ -1,8 +1,8 @@
 ﻿using Bridge.Contract;
-
 using Microsoft.Build.Utilities;
 
 using System;
+using System.Diagnostics;
 
 namespace Bridge.Build
 {
@@ -37,6 +37,7 @@ namespace Bridge.Build
                 return;
             }
 
+            DebugMessage(message);
             this.Log.LogError(message);
         }
 
@@ -47,20 +48,40 @@ namespace Bridge.Build
                 return;
             }
 
+            DebugMessage(message);
             this.Log.LogWarning(message);
         }
 
         public void Info(string message)
         {
+            if (!this.CheckLoggerLevel(LoggerLevel.Info))
+            {
+                return;
+            }
+
+            DebugMessage(message);
+            this.Log.LogMessage(Microsoft.Build.Framework.MessageImportance.High, message);
         }
 
         public void Trace(string message)
         {
+            if (!this.CheckLoggerLevel(LoggerLevel.Trace))
+            {
+                return;
+            }
+
+            DebugMessage(message);
+            this.Log.LogMessage(Microsoft.Build.Framework.MessageImportance.High, message);
         }
 
         private bool CheckLoggerLevel(LoggerLevel level)
         {
             return (level <= this.LoggerLevel) || (level == LoggerLevel.Error && this.AlwaysLogErrors);
+        }
+
+        private void DebugMessage(string message)
+        {
+            //Debug.WriteLine(message);
         }
     }
 }

--- a/Compiler/Builder/Program.cs
+++ b/Compiler/Builder/Program.cs
@@ -51,7 +51,7 @@ namespace Bridge.Builder
             }
             catch (EmitterException ex)
             {
-                logger.Error(string.Format("Error: {2} ({3}, {4}) {0} {1}", ex.Message, ex.StackTrace, ex.FileName, ex.StartLine, ex.StartColumn, ex.EndLine, ex.EndColumn));
+                logger.Error(string.Format("Bridge.NET Compiler error: {2} ({3}, {4}) {0} {1}", ex.Message, ex.StackTrace, ex.FileName, ex.StartLine, ex.StartColumn, ex.EndLine, ex.EndColumn));
                 return 1;
             }
             catch (Exception ex)
@@ -60,7 +60,7 @@ namespace Bridge.Builder
 
                 if (ee != null)
                 {
-                    logger.Error(string.Format("Error: {2} ({3}, {4}) {0} {1}", ex.Message, ex.StackTrace, ee.FileName, ee.StartLine, ee.StartColumn, ee.EndLine, ee.EndColumn));
+                    logger.Error(string.Format("Bridge.NET Compiler error: {2} ({3}, {4}) {0} {1}", ex.Message, ex.StackTrace, ee.FileName, ee.StartLine, ee.StartColumn, ee.EndLine, ee.EndColumn));
                 }
                 else
                 {
@@ -69,7 +69,7 @@ namespace Bridge.Builder
                     var elvl = 0;
                     while (ine != null)
                     {
-                        logger.Error(string.Format("Error: exception level: {0} - {1}\nStack trace:\n{2}", elvl++, ine.Message, ine.StackTrace));
+                        logger.Error(string.Format("Bridge.NET Compiler error: exception level: {0} - {1}\nStack trace:\n{2}", elvl++, ine.Message, ine.StackTrace));
                         ine = ine.InnerException;
                     }
                 }


### PR DESCRIPTION
Addresses log issue specified [here](http://https//forums.bridge.net/forum/bridge-net-pro/bugs/4368-closed-2816-16-0-compile-error-with-combinescripts-and-extract-bridge-console-js?p=4382#post4382) by @ProductiveRage:
* Info and Trace messages into VS output window (before only into log file);
* Error level message goes into log file as well (before only into VS error/output window)