### PR TITLE
[1582] Nullable decimal casting to ulong or long does not create InvalidOperationException.

### DIFF
--- a/Bridge/Resources/Decimal.js
+++ b/Bridge/Resources/Decimal.js
@@ -242,6 +242,8 @@
     };
 
     System.Decimal.toInt = function (v, tp) {
+        if (v == null)
+            throw new System.InvalidOperationException("Nullable object must have a value.");
         if (!v) {
             return null;
         }


### PR DESCRIPTION
Fixes #1582.