### PR TITLE
Pulls NuSpec files' dependency version up to 16.4.0.

### DIFF
--- a/.build/common/CommonAssemblyInfo.cs
+++ b/.build/common/CommonAssemblyInfo.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("16.3")]
+[assembly: AssemblyVersion("16.4")]
 [assembly: AssemblyFileVersion("16.4.0")]
 // Remember to update NuGet.Build.Package.targets with the same version value
 // <DefaultPackageVersion>16.4.0</DefaultPackageVersion>

--- a/.build/specs/Bridge.Compiler.nuspec
+++ b/.build/specs/Bridge.Compiler.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright (c) 2008-2017, Object.NET, Inc. (http://object.net/). All rights reserved.</copyright>
     <tags>bridge bridge.net bridge js javascript C# csharp mobile ios asp.net aspnet mvc aspnetmvc web transpiler compiler object.net</tags>
     <dependencies>
-      <dependency id="Bridge.Contract" version="16.3.2" />
+      <dependency id="Bridge.Contract" version="16.4.0" />
       <dependency id="AjaxMin" version="5.14.5506.26202" />
       <dependency id="Bridge.NRefactory" version="5.5.8" />
       <dependency id="Microsoft.CodeAnalysis.CSharp" version="2.2.0" />

--- a/.build/specs/Bridge.Html5.nuspec
+++ b/.build/specs/Bridge.Html5.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright (c) 2008-2017, Object.NET, Inc. (http://object.net/). All rights reserved.</copyright>
     <tags>bridge bridge.net bridge js javascript C# csharp mobile ios asp.net aspnet mvc aspnetmvc web transpiler compiler object.net</tags>
     <dependencies>
-      <dependency id="Bridge.Core" version="16.3.2" />
+      <dependency id="Bridge.Core" version="16.4.0" />
     </dependencies>
     <frameworkAssemblies>
     </frameworkAssemblies>

--- a/.build/specs/Bridge.Min.nuspec
+++ b/.build/specs/Bridge.Min.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright (c) 2008-2017, Object.NET, Inc. (http://object.net/). All rights reserved.</copyright>
     <tags>bridge bridge.net bridge js javascript C# csharp mobile ios asp.net aspnet mvc aspnetmvc web transpiler compiler object.net</tags>
     <dependencies>
-      <dependency id="Bridge.Core" version="16.3.2" />
+      <dependency id="Bridge.Core" version="16.4.0" />
     </dependencies>
     <frameworkAssemblies>
     </frameworkAssemblies>

--- a/.build/specs/Bridge.nuspec
+++ b/.build/specs/Bridge.nuspec
@@ -15,8 +15,8 @@
     <copyright>Copyright (c) 2008-2017, Object.NET, Inc. (http://object.net/). All rights reserved.</copyright>
     <tags>bridge bridge.net bridge js javascript C# csharp mobile ios asp.net aspnet mvc aspnetmvc web transpiler compiler object.net</tags>
     <dependencies>
-      <dependency id="Bridge.Min" version="16.3.2" />
-      <dependency id="Bridge.Html5" version="16.3.2" />
+      <dependency id="Bridge.Min" version="16.4.0" />
+      <dependency id="Bridge.Html5" version="16.4.0" />
     </dependencies>
     <frameworkAssemblies>
     </frameworkAssemblies>


### PR DESCRIPTION
Bridge .nuspec dependency for other bridge NuGet packages was not
properly changed to 16.4.0. This commit sets them up to the right
version.