### PR TITLE
[3155] Default logging of Bridge compiler is super-verbose

### DIFF
--- a/.build/files/Bridge.Min.targets
+++ b/.build/files/Bridge.Min.targets
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <Target Name="BridgeNetCompilerTask">
-    <Message Text="BridgeNetCompilerTask started: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) OutputPath: $(OutputPath)" Importance="high" />
+    <Message Text="Bridge started: OutputPath: $(OutputPath)" Importance="high" />
 
     <BridgeCompilerTask
       Assembly="@(IntermediateAssembly)"
@@ -34,7 +34,7 @@
       RootNamespace="$(RootNamespace)"
       Sources="@(Compile)" />
 
-    <Message Text="BridgeNetCompilerTask done: Project: $(MSBuildProjectName), Configuration: $(Configuration) $(Platform) OutputPath: $(OutputPath)" Importance="high" />
+    <Message Text="Bridge done" Importance="high" />
   </Target>
 
   <Target Name="BridgeNetCompilerUtil">
@@ -50,7 +50,7 @@
     <Message Text="   BridgePath:                  $(BridgePath)" Importance="high" />
     <Message Text="   Command:                     $(BridgeUtilCommand)" Importance="high" />
 
-    <Exec Command="$(BridgeUtilCommand)" LogStandardErrorAsError="true" WorkingDirectory="$(BridgeUtilWorkDir)"/>
+    <Exec Command="$(BridgeUtilCommand)" LogStandardErrorAsError="true" WorkingDirectory="$(BridgeUtilWorkDir)" />
 
     <Message Text="BridgeNetCompilerUtil done: Project: $(MSBuildProjectName)" Importance="high" />
   </Target>

--- a/.build/files/Bridge.Min.targets
+++ b/.build/files/Bridge.Min.targets
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <Target Name="BridgeNetCompilerTask">
-    <Message Text="Bridge started: OutputPath: $(OutputPath)" Importance="high" />
+    <Message Text="Bridge started" Importance="high" />
 
     <BridgeCompilerTask
       Assembly="@(IntermediateAssembly)"

--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -135,34 +135,28 @@ namespace Bridge.Build
 
             var processor = new TranslatorProcessor(bridgeOptions, logger);
 
-            var result = processor.PreProcess();
-
-            if (result != null)
-            {
-                processor = null;
-                return false;
-            }
-
             try
             {
+                processor.PreProcess();
+
                 processor.Process();
 
                 processor.PostProcess();
             }
-            catch (EmitterException e)
+            catch (EmitterException ex)
             {
                 if (logger != null)
                 {
-                    logger.Error(e.ToString());
+                    logger.Error(ex.ToString());
                 }
                 else
                 {
-                    this.Log.LogError(null, null, null, e.FileName, e.StartLine + 1, e.StartColumn + 1, e.EndLine + 1, e.EndColumn + 1, "Error: {0} {1}", e.Message, e.StackTrace);
+                    this.Log.LogError(null, null, null, ex.FileName, ex.StartLine + 1, ex.StartColumn + 1, ex.EndLine + 1, ex.EndColumn + 1, ex.ToString());
                 }
 
                 success = false;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
                 var ee = processor.Translator != null ? processor.Translator.CreateExceptionFromLastNode() : null;
 
@@ -170,20 +164,20 @@ namespace Bridge.Build
                 {
                     if (logger != null)
                     {
-                        logger.Error(e.ToString());
+                        logger.Error(ee.ToString());
                     }
 
-                    this.Log.LogError(null, null, null, ee.FileName, ee.StartLine + 1, ee.StartColumn + 1, ee.EndLine + 1, ee.EndColumn + 1, "Error: {0} {1}", e.Message, e.StackTrace);
+                    this.Log.LogError(null, null, null, ee.FileName, ee.StartLine + 1, ee.StartColumn + 1, ee.EndLine + 1, ee.EndColumn + 1, ee.ToString());
                 }
                 else
                 {
                     if (logger != null)
                     {
-                        logger.Error(e.ToString());
+                        logger.Error(ex.ToString());
                     }
                     else
                     {
-                        this.Log.LogError("Bridge.NET Compiler error: {0} {1}", e.Message, e.StackTrace);
+                        this.Log.LogError(ex.ToString());
                     }
                 }
 

--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -129,7 +129,7 @@ namespace Bridge.Build
 #endif
             var logger = new Translator.Logging.Logger(null, false, LoggerLevel.Info, true, new VSLoggerWriter(this.Log), new FileLoggerWriter());
 
-            logger.Info("Executing Bridge.Build.Task...");
+            logger.Error("Executing Bridge.Build.Task...");
 
             var bridgeOptions = this.GetBridgeOptions();
 

--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -129,7 +129,6 @@ namespace Bridge.Build
 #endif
             var logger = new Translator.Logging.Logger(null, false, LoggerLevel.Info, true, new VSLoggerWriter(this.Log), new FileLoggerWriter());
 
-            logger.Trace("123 ABC");
             logger.Trace("Executing Bridge.Build.Task...");
 
             var bridgeOptions = this.GetBridgeOptions();

--- a/Compiler/Build/GenerateScript.cs
+++ b/Compiler/Build/GenerateScript.cs
@@ -129,7 +129,8 @@ namespace Bridge.Build
 #endif
             var logger = new Translator.Logging.Logger(null, false, LoggerLevel.Info, true, new VSLoggerWriter(this.Log), new FileLoggerWriter());
 
-            logger.Error("Executing Bridge.Build.Task...");
+            logger.Trace("123 ABC");
+            logger.Trace("Executing Bridge.Build.Task...");
 
             var bridgeOptions = this.GetBridgeOptions();
 
@@ -245,6 +246,7 @@ namespace Bridge.Build
             }
 
             bool b;
+
             if (bool.TryParse(this.CheckForOverflowUnderflow, out b))
             {
                 return b;

--- a/Compiler/Build/VSLoggerWriter.cs
+++ b/Compiler/Build/VSLoggerWriter.cs
@@ -1,8 +1,6 @@
 ﻿using Bridge.Contract;
 using Microsoft.Build.Utilities;
-
 using System;
-using System.Diagnostics;
 
 namespace Bridge.Build
 {

--- a/Compiler/Builder/Program.cs
+++ b/Compiler/Builder/Program.cs
@@ -31,8 +31,8 @@ namespace Bridge.Builder
                 return 0;
             }
 
-            logger.Info("Command line arguments:");
-            logger.Info("\t" + (string.Join(" ", args) ?? ""));
+            logger.Trace("Command line arguments:");
+            logger.Trace("\t" + (string.Join(" ", args) ?? ""));
 
             var processor = new TranslatorProcessor(bridgeOptions, logger);
 

--- a/Compiler/Builder/Program.cs
+++ b/Compiler/Builder/Program.cs
@@ -36,22 +36,17 @@ namespace Bridge.Builder
 
             var processor = new TranslatorProcessor(bridgeOptions, logger);
 
-            var result = processor.PreProcess();
-
-            if (result != null)
-            {
-                return 1;
-            }
-
             try
             {
+                processor.PreProcess();
+
                 processor.Process();
 
                 processor.PostProcess();
             }
             catch (EmitterException ex)
             {
-                logger.Error(string.Format("Bridge.NET Compiler error: {2} ({3}, {4}) {0} {1}", ex.Message, ex.StackTrace, ex.FileName, ex.StartLine, ex.StartColumn, ex.EndLine, ex.EndColumn));
+                logger.Error(string.Format("Bridge.NET Compiler error: {1} ({2}, {3}) {0}", ex.ToString(), ex.FileName, ex.StartLine, ex.StartColumn));
                 return 1;
             }
             catch (Exception ex)
@@ -60,19 +55,13 @@ namespace Bridge.Builder
 
                 if (ee != null)
                 {
-                    logger.Error(string.Format("Bridge.NET Compiler error: {2} ({3}, {4}) {0} {1}", ex.Message, ex.StackTrace, ee.FileName, ee.StartLine, ee.StartColumn, ee.EndLine, ee.EndColumn));
+                    logger.Error(string.Format("Bridge.NET Compiler error: {1} ({2}, {3}) {0}", ee.ToString(), ee.FileName, ee.StartLine, ee.StartColumn));
                 }
                 else
                 {
-                    // Iteractively print inner exceptions
-                    var ine = ex;
-                    var elvl = 0;
-                    while (ine != null)
-                    {
-                        logger.Error(string.Format("Bridge.NET Compiler error: exception level: {0} - {1}\nStack trace:\n{2}", elvl++, ine.Message, ine.StackTrace));
-                        ine = ine.InnerException;
-                    }
+                    logger.Error(string.Format("Bridge.NET Compiler error: {0}", ex.ToString()));
                 }
+
                 return 1;
             }
 

--- a/Compiler/Contract/Bridge.Contract.csproj
+++ b/Compiler/Contract/Bridge.Contract.csproj
@@ -87,6 +87,7 @@
     </Compile>
     <Compile Include="AbstractPlugin.cs" />
     <Compile Include="BridgeType.cs" />
+    <Compile Include="Config\StringBoolJsonConverter.cs" />
     <Compile Include="Config\NamedFunctionMode.cs" />
     <Compile Include="Config\HtmlConfig.cs" />
     <Compile Include="Config\ConsoleConfig.cs" />

--- a/Compiler/Contract/Config/ConfigHelper.cs
+++ b/Compiler/Contract/Config/ConfigHelper.cs
@@ -152,7 +152,7 @@ namespace Bridge.Contract
             string configPath = null;
             string mergePath = null;
 
-            Logger.Info("Reading configuration file " + (configFileName ?? "") + " at " + (location ?? "") + " for configuration " + (configuration ?? "") + " ...");
+            Logger.Trace("Reading configuration file " + (configFileName ?? "") + " at " + (location ?? "") + " for configuration " + (configuration ?? "") + " ...");
 
             if (!string.IsNullOrWhiteSpace(configuration))
             {
@@ -182,19 +182,19 @@ namespace Bridge.Contract
 
             if (configPath == null)
             {
-                Logger.Info("Config path is not found. Returning default config");
+                Logger.Info("Bridge config file is not found. Returning default config");
                 return default(T);
             }
 
             try
             {
-                this.Logger.Info("Reading base configuration at " + (configPath ?? "") + " ...");
+                this.Logger.Trace("Reading base configuration at " + (configPath ?? "") + " ...");
                 var json = File.ReadAllText(configPath);
 
                 T config;
                 if (mergePath != null)
                 {
-                    this.Logger.Info("Reading merge configuration at " + (mergePath ?? "") + " ...");
+                    this.Logger.Trace("Reading merge configuration at " + (mergePath ?? "") + " ...");
                     var jsonMerge = File.ReadAllText(mergePath);
 
                     var cfgMain = JObject.Parse(json);
@@ -223,7 +223,7 @@ namespace Bridge.Contract
 
         public string GetConfigPath(string configFileName, bool folderMode, string location)
         {
-            this.Logger.Info("Getting configuration by file path " + (configFileName ?? "") + " at " + (location ?? "") + " ...");
+            this.Logger.Trace("Getting configuration by file path " + (configFileName ?? "") + " at " + (location ?? "") + " ...");
 
             var folder = folderMode ? location : Path.GetDirectoryName(location);
             var path = folder + Path.DirectorySeparatorChar + "Bridge" + Path.DirectorySeparatorChar + configFileName;
@@ -240,11 +240,11 @@ namespace Bridge.Contract
 
             if (!File.Exists(path))
             {
-                this.Logger.Info("Skipping " + configFileName + " (not found)");
+                this.Logger.Trace("Skipping " + configFileName + " (not found)");
                 return null;
             }
 
-            this.Logger.Info("Found configuration file " + (path ?? ""));
+            this.Logger.Trace("Found configuration file " + (path ?? ""));
 
             return path;
         }

--- a/Compiler/Contract/Config/ConfigHelper.cs
+++ b/Compiler/Contract/Config/ConfigHelper.cs
@@ -217,7 +217,7 @@ namespace Bridge.Contract
             }
             catch (Exception e)
             {
-                throw new InvalidOperationException("Cannot read " + configFileName, e);
+                throw new InvalidOperationException("Cannot read configuration file " + configFileName, e);
             }
         }
 

--- a/Compiler/Contract/Config/IAssemblyInfo.cs
+++ b/Compiler/Contract/Config/IAssemblyInfo.cs
@@ -1,3 +1,4 @@
+using Bridge.Contract.Constants;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -99,7 +100,8 @@ namespace Bridge.Contract
         /// Deletes files from output directory using pattern "*.js|*.d.ts" before build (before extracting scripts after translation).
         /// It is useful to replace BeforeBuild event if it just contain commands to clean the output folder.
         /// </summary>
-        bool CleanOutputFolderBeforeBuild
+        [JsonConverter(typeof(StringBoolJsonConverter), "*" + Files.Extensions.JS + "|*" + Files.Extensions.DTS)]
+        string CleanOutputFolderBeforeBuild
         {
             get; set;
         }

--- a/Compiler/Contract/Config/StringBoolJsonConverter.cs
+++ b/Compiler/Contract/Config/StringBoolJsonConverter.cs
@@ -1,0 +1,106 @@
+using System;
+using Bridge.Contract.Constants;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Bridge.Contract
+{
+    public class StringBoolJsonConverter : JsonConverter
+    {
+        protected string DefaultForTrue
+        {
+            get; set;
+        }
+
+        protected string DefaultForFalse
+        {
+            get; set;
+        }
+
+        public StringBoolJsonConverter()
+        {
+            DefaultForTrue = null;
+            DefaultForFalse = null;
+        }
+
+        public StringBoolJsonConverter(string defaultForTrue)
+        {
+            DefaultForTrue = defaultForTrue;
+            DefaultForFalse = null;
+        }
+
+        public StringBoolJsonConverter(string defaultForTrue, string defaultForFalse)
+        {
+            DefaultForTrue = defaultForTrue;
+            DefaultForFalse = defaultForFalse;
+        }
+
+        #region Overrides of JsonConverter
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        /// <c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            // Handle only bool and string types.
+            return objectType == typeof(bool) || objectType == typeof(string);
+        }
+
+        /// <summary>
+        /// Reads the JSON representation of the object.
+        /// </summary>
+        /// <param name="reader">The <see cref="T:Newtonsoft.Json.JsonReader"/> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>
+        /// The object value.
+        /// </returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Boolean)
+            {
+                var b = serializer.Deserialize<bool>(reader);
+
+                if (b)
+                {
+                    return DefaultForTrue;
+                }
+                else
+                {
+                    return DefaultForFalse;
+                }
+            }
+
+            return serializer.Deserialize<string>(reader);
+        }
+
+        /// <summary>
+        /// Writes the JSON representation of the object.
+        /// </summary>
+        /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter"/> to write to.</param><param name="value">The value.</param><param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var s = value as string;
+
+            if (s == DefaultForTrue)
+            {
+                serializer.Serialize(writer, true);
+            }
+            else if (s == DefaultForFalse)
+            {
+                serializer.Serialize(writer, false);
+            }
+            else
+            {
+                serializer.Serialize(writer, s);
+            }
+        }
+
+        #endregion Overrides of JsonConverter
+    }
+}

--- a/Compiler/Translator/Translator/Translator.Build.cs
+++ b/Compiler/Translator/Translator/Translator.Build.cs
@@ -80,7 +80,7 @@ namespace Bridge.Translator
                             }
                         }, new Logger(null, false, LoggerLevel.Info, true, new ConsoleLoggerWriter(), new FileLoggerWriter()));
 
-                        var result = processor.PreProcess();
+                        processor.PreProcess();
 
                         var projectAssembly = processor.Translator.AssemblyLocation;
 

--- a/Compiler/Translator/Translator/Translator.Build.cs
+++ b/Compiler/Translator/Translator/Translator.Build.cs
@@ -33,7 +33,7 @@ namespace Bridge.Translator
                 XNamespace msbuild = "http://schemas.microsoft.com/developer/msbuild/2003";
                 XDocument projDefinition = XDocument.Load(this.Location);
                 var helper = new ConfigHelper<AssemblyInfo>(this.Log);
-                var tokens = this.ProjectProperties.GetValues();                
+                var tokens = this.ProjectProperties.GetValues();
 
                 referencesPathes = projDefinition
                     .Element(msbuild + "Project")
@@ -64,16 +64,18 @@ namespace Bridge.Translator
                     {
                         var isBuilt = this.ProjectProperties.BuildProjects.Contains(projectRef);
 
-                        if(!isBuilt)
+                        if (!isBuilt)
                         {
                             this.ProjectProperties.BuildProjects.Add(projectRef);
                         }
 
-                        var processor = new TranslatorProcessor(new BridgeOptions {
+                        var processor = new TranslatorProcessor(new BridgeOptions
+                        {
                             Rebuild = this.Rebuild,
                             ProjectLocation = projectRef,
                             BridgeLocation = this.BridgeLocation,
-                            ProjectProperties = new Contract.ProjectProperties {
+                            ProjectProperties = new Contract.ProjectProperties
+                            {
                                 BuildProjects = this.ProjectProperties.BuildProjects,
                                 Configuration = this.ProjectProperties.Configuration,
                                 Platform = this.ProjectProperties.Platform
@@ -84,7 +86,7 @@ namespace Bridge.Translator
 
                         var projectAssembly = processor.Translator.AssemblyLocation;
 
-                        if(!File.Exists(projectAssembly) || this.Rebuild && !isBuilt)
+                        if (!File.Exists(projectAssembly) || this.Rebuild && !isBuilt)
                         {
                             processor.Process();
                             processor.PostProcess();
@@ -129,7 +131,7 @@ namespace Bridge.Translator
 
                 var packagesConfigPath = Path.Combine(this.Location, "packages.config");
 
-                if(File.Exists(packagesConfigPath))
+                if (File.Exists(packagesConfigPath))
                 {
                     var doc = new System.Xml.XmlDocument();
                     doc.LoadXml(File.ReadAllText(packagesConfigPath));
@@ -156,7 +158,7 @@ namespace Bridge.Translator
                         var packageLib = Path.Combine(packageFolder, "lib");
                         AddPackageAssembly(list, packageLib);
                     }
-                }                
+                }
             }
 
             var arr = referencesPathes.ToArray();
@@ -175,7 +177,7 @@ namespace Bridge.Translator
             var references = new List<MetadataReference>();
             var outputDir = Path.GetDirectoryName(this.AssemblyLocation);
             var di = new DirectoryInfo(outputDir);
-            if(!di.Exists)
+            if (!di.Exists)
             {
                 di.Create();
             }
@@ -194,7 +196,7 @@ namespace Bridge.Translator
                 {
                     this.BridgeLocation = path;
                 }
-                
+
                 references.Add(MetadataReference.CreateFromFile(path, new MetadataReferenceProperties(MetadataImageKind.Assembly, ImmutableArray.Create("global"))));
             }
 
@@ -204,7 +206,7 @@ namespace Bridge.Translator
             using (var outputStream = new FileStream(this.AssemblyLocation, FileMode.Create))
             {
                 emitResult = compilation.Emit(outputStream, options: new Microsoft.CodeAnalysis.Emit.EmitOptions(false, Microsoft.CodeAnalysis.Emit.DebugInformationFormat.Embedded, runtimeMetadataVersion: "v4.0.30319", includePrivateMembers: true));
-            }                
+            }
 
             if (!emitResult.Success)
             {

--- a/Compiler/Translator/Translator/Translator.Output.cs
+++ b/Compiler/Translator/Translator/Translator.Output.cs
@@ -222,10 +222,10 @@ namespace Bridge.Translator
         public void CleanOutputFolderIfRequired(string outputPath)
         {
             if (this.AssemblyInfo != null
-                && (this.AssemblyInfo.CleanOutputFolderBeforeBuild || !string.IsNullOrEmpty(this.AssemblyInfo.CleanOutputFolderBeforeBuildPattern)))
+                && (!string.IsNullOrEmpty(this.AssemblyInfo.CleanOutputFolderBeforeBuild) || !string.IsNullOrEmpty(this.AssemblyInfo.CleanOutputFolderBeforeBuildPattern)))
             {
                 var searchPattern = string.IsNullOrEmpty(this.AssemblyInfo.CleanOutputFolderBeforeBuildPattern)
-                    ? "*" + Files.Extensions.JS + "|*" + Files.Extensions.DTS
+                    ? this.AssemblyInfo.CleanOutputFolderBeforeBuild
                     : this.AssemblyInfo.CleanOutputFolderBeforeBuildPattern;
 
                 string logFileFullPath = null;

--- a/Compiler/Translator/Translator/Translator.ProjectReader.cs
+++ b/Compiler/Translator/Translator/Translator.ProjectReader.cs
@@ -31,7 +31,7 @@ namespace Bridge.Translator
 
         internal virtual void EnsureProjectProperties()
         {
-            this.Log.Info("EnsureProjectProperties at " + (Location ?? "") + " ...");
+            this.Log.Trace("EnsureProjectProperties at " + (Location ?? "") + " ...");
 
             ShouldReadProjectFile = !this.FromTask;
 
@@ -52,17 +52,17 @@ namespace Bridge.Translator
 
             this.EnsureDefineConstants(doc);
 
-            this.Log.Info("EnsureProjectProperties done");
+            this.Log.Trace("EnsureProjectProperties done");
         }
 
         internal virtual void ReadFolderFiles()
         {
-            this.Log.Info("Reading folder files...");
+            this.Log.Trace("Reading folder files...");
 
             this.SourceFiles = this.GetSourceFiles(this.Location);
             this.ParsedSourceFiles = new List<ParsedSourceFile>();
 
-            this.Log.Info("Reading folder files done");
+            this.Log.Trace("Reading folder files done");
         }
 
         /// <summary>
@@ -188,14 +188,14 @@ namespace Bridge.Translator
             {
                 var fullOutputPath = this.GetOutputPaths(doc);
 
-                this.Log.Info("    FullOutputPath:" + fullOutputPath);
+                this.Log.Trace("    FullOutputPath:" + fullOutputPath);
 
                 this.AssemblyLocation = Path.Combine(fullOutputPath, this.ProjectProperties.AssemblyName + ".dll");
             }
 
-            this.Log.Info("    OutDir:" + this.ProjectProperties.OutDir);
-            this.Log.Info("    OutputPath:" + this.ProjectProperties.OutputPath);
-            this.Log.Info("    AssemblyLocation:" + this.AssemblyLocation);
+            this.Log.Trace("    OutDir:" + this.ProjectProperties.OutDir);
+            this.Log.Trace("    OutputPath:" + this.ProjectProperties.OutputPath);
+            this.Log.Trace("    AssemblyLocation:" + this.AssemblyLocation);
 
             this.Log.Trace("BuildAssemblyLocation done");
         }
@@ -372,7 +372,7 @@ namespace Bridge.Translator
 
         protected virtual void EnsureDefineConstants(XDocument doc)
         {
-            this.Log.Info("EnsureDefineConstants...");
+            this.Log.Trace("EnsureDefineConstants...");
 
             if (this.DefineConstants == null)
             {
@@ -381,7 +381,7 @@ namespace Bridge.Translator
 
             if (this.ProjectProperties.DefineConstants == null && this.ShouldReadProjectFile)
             {
-                this.Log.Info("Reading define constants...");
+                this.Log.Trace("Reading define constants...");
 
                 var nodeList = doc.Descendants().Where(n =>
                 {
@@ -422,7 +422,7 @@ namespace Bridge.Translator
 
             this.DefineConstants = this.DefineConstants.Distinct().ToList();
 
-            this.Log.Info("EnsureDefineConstants done");
+            this.Log.Trace("EnsureDefineConstants done");
         }
 
         protected virtual void EnsureAssemblyName(XDocument doc)

--- a/Compiler/Translator/Translator/TranslatorProcessor.cs
+++ b/Compiler/Translator/Translator/TranslatorProcessor.cs
@@ -204,18 +204,18 @@ namespace Bridge.Translator
                 return;
             }
 
-            logger.Info("Applying logger configuration parameters...");
+            logger.Trace("Applying logger configuration parameters...");
 
             logger.Name = bridgeOptions.Name;
 
             if (!string.IsNullOrEmpty(logger.Name))
             {
-                logger.Info("Logger name: " + logger.Name);
+                logger.Trace("Logger name: " + logger.Name);
             }
 
             var loggerLevel = assemblyConfig.Logging.Level ?? LoggerLevel.None;
 
-            logger.Info("Logger level: " + loggerLevel);
+            logger.Trace("Logger level: " + loggerLevel);
 
             if (loggerLevel <= LoggerLevel.None)
             {
@@ -224,7 +224,7 @@ namespace Bridge.Translator
 
             logger.LoggerLevel = loggerLevel;
 
-            logger.Info("Read config file: " + AssemblyConfigHelper.ConfigToString(assemblyConfig));
+            logger.Trace("Read config file: " + AssemblyConfigHelper.ConfigToString(assemblyConfig));
 
             logger.BufferedMode = false;
 
@@ -252,7 +252,7 @@ namespace Bridge.Translator
 
             logger.Flush();
 
-            logger.Info("Setting logger configuration parameters done");
+            logger.Trace("Setting logger configuration parameters done");
         }
 
         private string GetLoggerFolder(IAssemblyInfo assemblyConfig)
@@ -276,7 +276,7 @@ namespace Bridge.Translator
             var bridgeOptions = this.BridgeOptions;
             var assemblyConfig = this.TranslatorConfiguration;
 
-            logger.Info("Setting translator properties...");
+            logger.Trace("Setting translator properties...");
 
             Bridge.Translator.Translator translator = null;
 
@@ -289,7 +289,7 @@ namespace Bridge.Translator
             {
                 if (string.IsNullOrWhiteSpace(bridgeOptions.Lib))
                 {
-                    throw new Exception("Please define path to assembly using -lib option");
+                    throw new InvalidOperationException("Please define path to assembly using -lib option");
                 }
 
                 bridgeOptions.Lib = Path.Combine(bridgeOptions.Folder, bridgeOptions.Lib);
@@ -322,12 +322,12 @@ namespace Bridge.Translator
                 translator.DefineConstants = translator.DefineConstants.Distinct().ToList();
             }
 
-            translator.Log.Info("Translator properties:");
-            translator.Log.Info("\tBridgeLocation:" + translator.BridgeLocation);
-            translator.Log.Info("\tBuildArguments:" + translator.BuildArguments);
-            translator.Log.Info("\tDefineConstants:" + (translator.DefineConstants != null ? string.Join(" ", translator.DefineConstants) : ""));
-            translator.Log.Info("\tRebuild:" + translator.Rebuild);
-            translator.Log.Info("\tProjectProperties:" + translator.ProjectProperties);
+            translator.Log.Trace("Translator properties:");
+            translator.Log.Trace("\tBridgeLocation:" + translator.BridgeLocation);
+            translator.Log.Trace("\tBuildArguments:" + translator.BuildArguments);
+            translator.Log.Trace("\tDefineConstants:" + (translator.DefineConstants != null ? string.Join(" ", translator.DefineConstants) : ""));
+            translator.Log.Trace("\tRebuild:" + translator.Rebuild);
+            translator.Log.Trace("\tProjectProperties:" + translator.ProjectProperties);
 
             if (translator.FolderMode)
             {
@@ -349,7 +349,7 @@ namespace Bridge.Translator
 
             translator.ApplyProjectPropertiesToConfig();
 
-            logger.Info("Setting translator properties done");
+            logger.Trace("Setting translator properties done");
 
             return translator;
         }

--- a/Compiler/Translator/Translator/TranslatorProcessor.cs
+++ b/Compiler/Translator/Translator/TranslatorProcessor.cs
@@ -219,7 +219,8 @@ namespace Bridge.Translator
 
             if (loggerLevel <= LoggerLevel.None)
             {
-                logger.Info("To enable further logging use configuration setting \"logging\" in bridge.json. See https://github.com/bridgedotnet/Bridge/wiki/global-configuration#logging");
+                logger.Info("    To enable further logging use config setting \"logging\" in bridge.json.");
+                logger.Info("    https://github.com/bridgedotnet/Bridge/wiki/global-configuration#logging");
             }
 
             logger.LoggerLevel = loggerLevel;
@@ -299,6 +300,7 @@ namespace Bridge.Translator
             translator.ProjectProperties = bridgeOptions.ProjectProperties;
 
             translator.AssemblyInfo = assemblyConfig;
+
             if (this.BridgeOptions.ReferencesPath != null)
             {
                 translator.AssemblyInfo.ReferencesPath = this.BridgeOptions.ReferencesPath;

--- a/Compiler/Translator/Translator/TranslatorProcessor.cs
+++ b/Compiler/Translator/Translator/TranslatorProcessor.cs
@@ -12,7 +12,9 @@ namespace Bridge.Translator
     public class TranslatorProcessor
     {
         public BridgeOptions BridgeOptions { get; private set; }
+
         public Logger Logger { get; private set; }
+
         public IAssemblyInfo TranslatorConfiguration { get; private set; }
 
         public Translator Translator { get; private set; }
@@ -219,7 +221,7 @@ namespace Bridge.Translator
 
             if (loggerLevel <= LoggerLevel.None)
             {
-                logger.Info("    To enable further logging use config setting \"logging\" in bridge.json.");
+                logger.Info("    To enable detailed logging, configure \"logging\" in bridge.json.");
                 logger.Info("    https://github.com/bridgedotnet/Bridge/wiki/global-configuration#logging");
             }
 
@@ -259,6 +261,7 @@ namespace Bridge.Translator
         private string GetLoggerFolder(IAssemblyInfo assemblyConfig)
         {
             var logFileFolder = assemblyConfig.Logging.Folder;
+
             if (string.IsNullOrWhiteSpace(logFileFolder))
             {
                 logFileFolder = this.GetOutputFolder(false, false);
@@ -305,7 +308,7 @@ namespace Bridge.Translator
             {
                 translator.AssemblyInfo.ReferencesPath = this.BridgeOptions.ReferencesPath;
             }
-                
+
             translator.OverflowMode = bridgeOptions.ProjectProperties.CheckForOverflowUnderflow.HasValue ?
                 (bridgeOptions.ProjectProperties.CheckForOverflowUnderflow.Value ? OverflowMode.Checked : OverflowMode.Unchecked) : (OverflowMode?)null;
 

--- a/Compiler/Translator/Utils/AssemblyConfigHelper.cs
+++ b/Compiler/Translator/Utils/AssemblyConfigHelper.cs
@@ -93,6 +93,7 @@ namespace Bridge.Translator.Utils
             config.BeforeBuild = helper.ApplyPathTokens(tokens, config.BeforeBuild);
             config.AfterBuild = helper.ApplyPathTokens(tokens, config.AfterBuild);
             config.PluginsPath = helper.ApplyPathTokens(tokens, config.PluginsPath);
+            config.CleanOutputFolderBeforeBuild = helper.ApplyTokens(tokens, config.CleanOutputFolderBeforeBuild);
             config.CleanOutputFolderBeforeBuildPattern = helper.ApplyTokens(tokens, config.CleanOutputFolderBeforeBuildPattern);
             config.Locales = helper.ApplyTokens(tokens, config.Locales);
             config.LocalesOutput = helper.ApplyTokens(tokens, config.LocalesOutput);

--- a/Compiler/Translator/Utils/AssemblyInfo.cs
+++ b/Compiler/Translator/Utils/AssemblyInfo.cs
@@ -189,8 +189,9 @@ namespace Bridge.Translator
         /// <summary>
         /// Deletes files from output directory using pattern "*.js|*.d.ts" before build (before extracting scripts after translation).
         /// It is useful to replace BeforeBuild event if it just contain commands to clean the output folder.
+        /// Default value is null. It can be used either as string or bool value. True means "*.js|*.d.ts"
         /// </summary>
-        public bool CleanOutputFolderBeforeBuild
+        public string CleanOutputFolderBeforeBuild
         {
             get; set;
         }

--- a/Compiler/TranslatorTests/CompilerTests/AssemblyConfigHelperTests.cs
+++ b/Compiler/TranslatorTests/CompilerTests/AssemblyConfigHelperTests.cs
@@ -39,6 +39,7 @@ namespace Bridge.Translator.Tests
                 Assert.AreEqual("true", config.BeforeBuild);
                 Assert.AreEqual("TestConfiguration", config.AfterBuild);
                 Assert.AreEqual("TestDefineConstants", config.PluginsPath);
+                Assert.AreEqual("TestOutputType", config.CleanOutputFolderBeforeBuild);
                 Assert.AreEqual("TestOutDir", config.CleanOutputFolderBeforeBuildPattern);
                 Assert.AreEqual("TestOutputPath", config.Locales);
                 Assert.AreEqual("TestOutputType", config.LocalesOutput);
@@ -107,6 +108,7 @@ namespace Bridge.Translator.Tests
                     BeforeBuild = "$(CheckForOverflowUnderflow)",
                     AfterBuild = "$(Configuration)",
                     PluginsPath = "$(DefineConstants)",
+                    CleanOutputFolderBeforeBuild= "$(OutputType)",
                     CleanOutputFolderBeforeBuildPattern = "$(OutDir)",
                     Locales = "$(OutputPath)",
                     LocalesOutput = "$(OutputType)",

--- a/Compiler/TranslatorTests/CompilerTests/AssemblyInfoJsonConvertersTests.cs
+++ b/Compiler/TranslatorTests/CompilerTests/AssemblyInfoJsonConvertersTests.cs
@@ -218,6 +218,64 @@ namespace Bridge.Translator.Tests
                 "7");
         }
 
+        [Test]
+        public void AssemblyInfoJsonConverters_StringBoolJsonConverterSerialization()
+        {
+            AssertJsonSerialization(
+                new StringBoolInfo(),
+                "{\"Value\":null}",
+                "1");
+
+            AssertJsonSerialization(
+                new StringBoolInfo { Value = "" },
+                "{\"Value\":\"\"}",
+                "2");
+
+            AssertJsonSerialization(
+                new StringBoolInfo { Value = "usemeiftrue" },
+                "{\"Value\":true}",
+                "3");
+
+            AssertJsonSerialization(
+                new StringBoolInfo { Value = "usemeiffalse" },
+                "{\"Value\":false}",
+                "4");
+
+            AssertJsonSerialization(
+                new StringBoolInfo { Value = "some text" },
+                "{\"Value\":\"some text\"}",
+                "5");
+        }
+
+        [Test]
+        public void AssemblyInfoJsonConverters_StringBoolJsonConverterDeserialization()
+        {
+            AssertJsonDeserialization(
+                "{\"Value\":null}",
+                new StringBoolInfo(),
+                "1");
+
+            AssertJsonDeserialization(
+                "{\"Value\":false}",
+                new StringBoolInfo { Value = "usemeiffalse" },
+                "2");
+
+            AssertJsonDeserialization(
+                "{\"Value\":true}",
+                new StringBoolInfo { Value = "usemeiftrue" },
+                "3");
+
+            AssertJsonDeserialization(
+                "{\"Value\":\"Folder1/\"}",
+                new StringBoolInfo { Value = "Folder1/" },
+                "4");
+
+            AssertJsonDeserialization(
+                "{\"Value\":\"\"}",
+                new StringBoolInfo { Value = "" },
+                "5");
+        }
+
         private static void AssertJsonSerialization(object value, string expected, string message = null)
         {
             var actual = JsonConvert.SerializeObject(value, Formatting.None);
@@ -360,6 +418,40 @@ namespace Bridge.Translator.Tests
                 return c1.Enabled == c2.Enabled
                     && c1.Path == c2.Path
                     && c1.FileName == c2.FileName;
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
+            }
+        }
+
+        class StringBoolInfo
+        {
+            [JsonConverter(typeof(StringBoolJsonConverter), "usemeiftrue", "usemeiffalse")]
+            public string Value
+            {
+                get; set;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj == null)
+                {
+                    return false;
+                }
+
+                var ci = obj as StringBoolInfo;
+
+                if (ci == null)
+                {
+                    return false;
+                }
+
+                var c1 = this.Value;
+                var c2 = ci.Value;
+
+                return c1 == c2;
             }
 
             public override int GetHashCode()

--- a/Compiler/TranslatorTests/CompilerTests/AssemblyInfoTests.cs
+++ b/Compiler/TranslatorTests/CompilerTests/AssemblyInfoTests.cs
@@ -40,7 +40,7 @@ namespace Bridge.Translator.Tests
             Assert.False(config.GenerateTypeScript, "GenerateTypeScript");
             Assert.AreEqual(DocumentationMode.Basic, config.GenerateDocumentation, "GenerateDocumentation");
             Assert.Null(config.BuildArguments, "BuildArguments");
-            Assert.False(config.CleanOutputFolderBeforeBuild, "CleanOutputFolderBeforeBuild");
+            Assert.Null(config.CleanOutputFolderBeforeBuild, "CleanOutputFolderBeforeBuild");
             Assert.Null(config.CleanOutputFolderBeforeBuildPattern, "CleanOutputFolderBeforeBuildPattern");
             Assert.Null(config.Configuration, "Configuration");
             Assert.Null(config.Locales, "Locales");

--- a/Compiler/TranslatorTests/IntegrationTests/TranslatorRunner.cs
+++ b/Compiler/TranslatorTests/IntegrationTests/TranslatorRunner.cs
@@ -128,12 +128,7 @@ namespace Bridge.Translator.Tests
 
             var processor = new TranslatorProcessor(bridgeOptions, this.Logger as Bridge.Translator.Logging.Logger);
 
-            var result = processor.PreProcess();
-
-            if (result != null)
-            {
-                Bridge.Translator.TranslatorException.Throw("Unable to preprocess: " + result);
-            }
+            processor.PreProcess();
 
             var translator = processor.Translator;
 


### PR DESCRIPTION
Fixes #3155

New successful rebuild logging has been cleaned up and reduced to the following. 

```
------ Rebuild All started: Project: Demo1, Configuration: Debug Any CPU ------
  Demo1 -> c:\users\user\Demo1\bin\Debug\Demo1.dll
  Bridge started
      To enable further logging use config setting "logging" in bridge.json.
      https://github.com/bridgedotnet/Bridge/wiki/global-configuration#logging
  Bridge done
========== Rebuild All: 1 succeeded, 0 failed, 0 skipped ==========
````