### PR TITLE
[3100] Fixes Bridge.Min.targets *nix compatibility.

### DIFF
--- a/.build/files/Bridge.Min.targets
+++ b/.build/files/Bridge.Min.targets
@@ -44,6 +44,7 @@
       <BridgeUtilWorkDir>$(MSBuildThisFileDirectory)\..\tools\</BridgeUtilWorkDir>
       <BridgePath>$(MSBuildProjectDirectory)\$(OutDir)\Bridge.dll</BridgePath>
       <BridgeUtilCommand>&quot;$(BridgeUtilWorkDir)bridge.exe&quot; -p &quot;$(MSBuildProjectFullPath)&quot; -b &quot;$(BridgePath)&quot; --settings AssemblyName:&quot;$(AssemblyName)&quot;,Configuration:&quot;$(Configuration)&quot;,DefineConstants:&quot;$(DefineConstants)&quot;,OutputPath:&quot;$(OutputPath)&quot;,OutDir:&quot;$(OutDir)&quot;,OutputType:&quot;$(OutputType)&quot;,Platform:&quot;$(Platform)&quot;,RootNamespace:&quot;$(RootNamespace)&quot;</BridgeUtilCommand>
+      <BridgeUtilCommand Condition="$(OnWin) != true">mono $(BridgeUtilCommand)</BridgeUtilCommand>
     </PropertyGroup>
 
     <Message Text="   Working Directory:           $(BridgeUtilWorkDir)" Importance="high" />


### PR DESCRIPTION
Fixes #3100 .

Changes proposed in this pull request:

- Adds 'mono' to the commandline call for bridge in Bridge.Min.Targets if the OS is `Unix`