### PR TITLE
[3293] problems with comparisons with DateTime.MaxValue

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -9784,19 +9784,19 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
             },
 
             gt: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) > System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).gt(System.DateTime.getTicks(b))) : false;
             },
 
             gte: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) >= System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).gte(System.DateTime.getTicks(b))) : false;
             },
 
             lt: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) < System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).lt(System.DateTime.getTicks(b))) : false;
             },
 
             lte: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) <= System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).lte(System.DateTime.getTicks(b))) : false;
             }
         }
     });

--- a/Bridge/Resources/Date.js
+++ b/Bridge/Resources/Date.js
@@ -1161,19 +1161,19 @@
             },
 
             gt: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) > System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).gt(System.DateTime.getTicks(b))) : false;
             },
 
             gte: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) >= System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).gte(System.DateTime.getTicks(b))) : false;
             },
 
             lt: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) < System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).lt(System.DateTime.getTicks(b))) : false;
             },
 
             lte: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) <= System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).lte(System.DateTime.getTicks(b))) : false;
             }
         }
     });

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -673,6 +673,7 @@
     <Compile Include="BridgeIssues\3200\N3264.cs" />
     <Compile Include="BridgeIssues\3200\N3265.cs" />
     <Compile Include="BridgeIssues\3200\N3269.cs" />
+    <Compile Include="BridgeIssues\3200\N3293.cs" />
     <Compile Include="BridgeIssues\3200\N3273.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />

--- a/Tests/Batch3/BridgeIssues/3200/N3293.cs
+++ b/Tests/Batch3/BridgeIssues/3200/N3293.cs
@@ -1,0 +1,42 @@
+using Bridge.Test.NUnit;
+using System;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    /// <summary>
+    /// The test here consists in checking whether System.DateTime tests works
+    /// with current date and max/min values.
+    /// </summary>
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#3293 - {0}")]
+    public class Bridge3293
+    {
+        /// <summary>
+        /// Tests the comparison variations between datetime values.
+        /// </summary>
+        [Test]
+        public static void TestDateTimeComparisons()
+        {
+            var minTim = DateTime.MinValue;
+            var now = DateTime.Now;
+            var maxTim = DateTime.MaxValue;
+
+            Assert.True(now > minTim, "Now is greater than minTime.");
+            Assert.False(now < minTim, "Now is not greater than minimum time.");
+
+            Assert.True(now < maxTim, "Now is smaller than maxTime.");
+            Assert.False(now > maxTim, "Now is not smaller than maxTime.");
+
+            Assert.True(now >= minTim, "Now is greater than or equal minTime.");
+            Assert.False(now <= minTim, "Now is not greater than or equal minimum time.");
+
+            Assert.True(now <= maxTim, "Now is smaller than or equal maxTime.");
+            Assert.False(now >= maxTim, "Now is not smaller than or equal maxTime.");
+
+            Assert.True(now != minTim, "Now is different than minimum time.");
+            Assert.False(now == minTim, "Now is not equal to minimum time.");
+            Assert.True(now != maxTim, "Now is different than maximum time.");
+            Assert.False(now == maxTim, "Now is not equal to maximum time.");
+        }
+    }
+}

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -9784,19 +9784,19 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
             },
 
             gt: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) > System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).gt(System.DateTime.getTicks(b))) : false;
             },
 
             gte: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) >= System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).gte(System.DateTime.getTicks(b))) : false;
             },
 
             lt: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) < System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).lt(System.DateTime.getTicks(b))) : false;
             },
 
             lte: function (a, b) {
-                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a) <= System.DateTime.getTicks(b)) : false;
+                return (System.DateTime.$is(a) && System.DateTime.$is(b)) ? (System.DateTime.getTicks(a).lte(System.DateTime.getTicks(b))) : false;
             }
         }
     });

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -690,6 +690,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3265 - TestGenericAlias", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3265.TestGenericAlias);
             QUnit.test("#3269 - TestTypeParameterInference", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3269.TestTypeParameterInference);
             QUnit.test("#3273 - TestAssemblyGetCustomAttributes", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3273.TestAssemblyGetCustomAttributes);
+            QUnit.test("#3293 - TestDateTimeComparisons", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3293.TestDateTimeComparisons);
             QUnit.test("#381 - TestUseCase", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge381.TestUseCase);
             QUnit.test("#447 - CheckInlineExpression", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge447.CheckInlineExpression);
             QUnit.test("#447 - CheckInlineCalls", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge447.CheckInlineCalls);
@@ -14456,6 +14457,31 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3273", $t.File = "Batch3\\BridgeIssues\\3200\\N3273.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3293", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3293)],
+        statics: {
+            methods: {
+                TestDateTimeComparisons: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3293).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3293, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestDateTimeComparisons()", $t.Line = "17", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3293.TestDateTimeComparisons();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3293", $t.File = "Batch3\\BridgeIssues\\3200\\N3293.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -26968,6 +26968,51 @@ Bridge.$N1391Result =                     r;
         inherits: [System.Attribute]
     });
 
+    /**
+     * The test here consists in checking whether System.DateTime tests works
+     with current date and max/min values.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3293
+     */
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3293", {
+        statics: {
+            methods: {
+                /**
+                 * Tests the comparison variations between datetime values.
+                 *
+                 * @static
+                 * @public
+                 * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3293
+                 * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3293
+                 * @return  {void}
+                 */
+                TestDateTimeComparisons: function () {
+                    var minTim = System.DateTime.getMinValue();
+                    var now = System.DateTime.getNow();
+                    var maxTim = System.DateTime.getMaxValue();
+
+                    Bridge.Test.NUnit.Assert.True(System.DateTime.gt(now, minTim), "Now is greater than minTime.");
+                    Bridge.Test.NUnit.Assert.False(System.DateTime.lt(now, minTim), "Now is not greater than minimum time.");
+
+                    Bridge.Test.NUnit.Assert.True(System.DateTime.lt(now, maxTim), "Now is smaller than maxTime.");
+                    Bridge.Test.NUnit.Assert.False(System.DateTime.gt(now, maxTim), "Now is not smaller than maxTime.");
+
+                    Bridge.Test.NUnit.Assert.True(System.DateTime.gte(now, minTim), "Now is greater than or equal minTime.");
+                    Bridge.Test.NUnit.Assert.False(System.DateTime.lte(now, minTim), "Now is not greater than or equal minimum time.");
+
+                    Bridge.Test.NUnit.Assert.True(System.DateTime.lte(now, maxTim), "Now is smaller than or equal maxTime.");
+                    Bridge.Test.NUnit.Assert.False(System.DateTime.gte(now, maxTim), "Now is not smaller than or equal maxTime.");
+
+                    Bridge.Test.NUnit.Assert.True(!Bridge.equals(now, minTim), "Now is different than minimum time.");
+                    Bridge.Test.NUnit.Assert.False(Bridge.equals(now, minTim), "Now is not equal to minimum time.");
+                    Bridge.Test.NUnit.Assert.True(!Bridge.equals(now, maxTim), "Now is different than maximum time.");
+                    Bridge.Test.NUnit.Assert.False(Bridge.equals(now, maxTim), "Now is not equal to maximum time.");
+                }
+            }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge341A", {
         props: {
             Str: null


### PR DESCRIPTION
Fixes #3293 .

Changes proposed in this pull request:

- System.DateTime comparison to use System.Int64's compare methods.