### PR TITLE
[3259] Avoids resolving already resolved references in Translator.

### DIFF
--- a/Compiler/Translator/Translator/Translator.cs
+++ b/Compiler/Translator/Translator/Translator.cs
@@ -247,29 +247,29 @@ namespace Bridge.Translator
                     continue;
                 }
 
-                // Do not resolve again if the reference has already been resolved previously.
-                AssemblyDefinition assemblyReference = References.FirstOrDefault(r => r.FullName == assemblyReferenceName.FullName);
+                AssemblyDefinition assemblyReference = References.Where(r => r.Name.Name == assemblyReferenceName.Name).FirstOrDefault();
 
                 needed_resolve = assemblyReference == default(AssemblyDefinition);
 
                 if (needed_resolve)
                 {
-                    assemblyReference = asm.MainModule.AssemblyResolver.Resolve(assemblyReferenceName);
+                    throw new InvalidOperationException(assemblyReferenceName.Name + " should be already resolved at this point.");
                 }
 
                 if (assemblyReference.MainModule.Kind != ModuleKind.Dll)
                 {
+                    Log.Trace("GetParentAssemblies(): Assembly '" + assemblyReference.FullName + "' is not a DLL assembly.");
                     continue;
                 }
 
                 if (list.All(r => r.FullName != assemblyReference.FullName))
                 {
                     list.Add(assemblyReference);
-                    Log.Trace("GetParentAssemblies(): Assembly '" + assemblyReference.FullName + "' added " + (needed_resolve ? "(reused resolve)" : "(fresh resolve)") + ".");
+                    Log.Trace("GetParentAssemblies(): Assembly '" + assemblyReference.FullName + "' added.");
                 }
                 else
                 {
-                    Log.Trace("GetParentAssemblies(): Assembly '" + assemblyReference.FullName + "' already present " + (needed_resolve ? "(reused resolve)" : "(fresh resolve)") + ".");
+                    Log.Trace("GetParentAssemblies(): Assembly '" + assemblyReference.FullName + "' already present.");
                 }
 
                 GetParentAssemblies(assemblyReference, list);


### PR DESCRIPTION
This was a suggestion from andersnm in bridgedotnet/Bridge#3259 to address
memory leaks during Bridge builds.

It consists in checking if a reference being loaded is already resolved and,
if so, uses the already resolved instance instead of resolving it again (thus
allocating even more memory)

This mostly affects projects with several references and cross-references
memory allocation by bridge during build time. Anyway, unnecessary
references resolving is replaced by a string search.