### PR TITLE
[3346] Enum.TryParse nulls the out parameter if unable to parse

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -4591,10 +4591,10 @@
         },
 
         tryParse: function (enumType, value, result, ignoreCase) {
-            result.v = 0;
             result.v = Bridge.unbox(enumMethods.parse(enumType, value, ignoreCase, true), true);
 
             if (result.v == null) {
+                result.v = 0;
                 return false;
             }
 

--- a/Bridge/Resources/Enum.js
+++ b/Bridge/Resources/Enum.js
@@ -313,10 +313,10 @@
         },
 
         tryParse: function (enumType, value, result, ignoreCase) {
-            result.v = 0;
             result.v = Bridge.unbox(enumMethods.parse(enumType, value, ignoreCase, true), true);
 
             if (result.v == null) {
+                result.v = 0;
                 return false;
             }
 

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -683,6 +683,7 @@
     <Compile Include="BridgeIssues\3300\N3318.cs" />
     <Compile Include="BridgeIssues\3300\N3323.cs" />
     <Compile Include="BridgeIssues\3300\N3329.cs" />
+    <Compile Include="BridgeIssues\3300\N3346.cs" />
     <Compile Include="BridgeIssues\3300\N3331.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />

--- a/Tests/Batch3/BridgeIssues/3300/N3346.cs
+++ b/Tests/Batch3/BridgeIssues/3300/N3346.cs
@@ -4,6 +4,10 @@ using Bridge.Test.NUnit;
 
 namespace Bridge.ClientTest.Batch3.BridgeIssues
 {
+    /// <summary>
+    /// The test here consists in checking whether Bridge's TryParse
+    /// implementation does not touch the output variable if the parsing fails.
+    /// </summary>
     [Category(Constants.MODULE_ISSUES)]
     [TestFixture(TestNameFormat = "#3346 - {0}")]
     public class Bridge3346
@@ -13,14 +17,30 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             One = 0
         }
 
+        enum TestOtherEnum
+        {
+            Two = 2,
+            One = 1
+        }
+
+        /// <summary>
+        /// Check if whenever parsing fails, the target variable won't be
+        /// changed.
+        /// </summary>
         [Test]
         public static void TestEnumTryParseFail()
         {
             TestEnum i;
             var result = Enum.TryParse("FF", out i);
 
-            Assert.False(result);
-            Assert.AreEqual(TestEnum.One, i);
+            Assert.False(result, "TryParse() 'FF' into an enum returned 'false'.");
+            Assert.AreEqual(TestEnum.One, i, "Failed TryParse() call initialized value with enum's 0 (\"One\").");
+
+            TestOtherEnum j;
+            var result_j = Enum.TryParse("FF", out j);
+
+            Assert.False(result_j, "TryParse() 'FF' into another enum returned 'false'.");
+            Assert.AreEqual(0, j, "Failed TryParse() call initialized value with enum's 0 (no match in enum).");
         }
     }
 }

--- a/Tests/Batch3/BridgeIssues/3300/N3346.cs
+++ b/Tests/Batch3/BridgeIssues/3300/N3346.cs
@@ -1,0 +1,26 @@
+using System;
+using Bridge.Html5;
+using Bridge.Test.NUnit;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [Category(Constants.MODULE_ISSUES)]
+    [TestFixture(TestNameFormat = "#3346 - {0}")]
+    public class Bridge3346
+    {
+        enum TestEnum
+        {
+            One = 0
+        }
+
+        [Test]
+        public static void TestEnumTryParseFail()
+        {
+            TestEnum i;
+            var result = Enum.TryParse("FF", out i);
+
+            Assert.False(result);
+            Assert.AreEqual(TestEnum.One, i);
+        }
+    }
+}

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -4591,10 +4591,10 @@
         },
 
         tryParse: function (enumType, value, result, ignoreCase) {
-            result.v = 0;
             result.v = Bridge.unbox(enumMethods.parse(enumType, value, ignoreCase, true), true);
 
             if (result.v == null) {
+                result.v = 0;
                 return false;
             }
 

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -702,6 +702,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3331 - TestHtmlAttributesIteration", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3331.TestHtmlAttributesIteration);
             QUnit.test("#3331 - TestHtmlAttributesEquality", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3331.TestHtmlAttributesEquality);
             QUnit.test("#3331 - TestHtmlAttributeCollectionsEquality", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3331.TestHtmlAttributeCollectionsEquality);
+            QUnit.test("#3346 - TestEnumTryParseFail", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3346.TestEnumTryParseFail);
             QUnit.test("#381 - TestUseCase", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge381.TestUseCase);
             QUnit.test("#447 - CheckInlineExpression", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge447.CheckInlineExpression);
             QUnit.test("#447 - CheckInlineCalls", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge447.CheckInlineCalls);
@@ -14728,6 +14729,31 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3331", $t.File = "Batch3\\BridgeIssues\\3300\\N3331.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3346", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346)],
+        statics: {
+            methods: {
+                TestEnumTryParseFail: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3346, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestEnumTryParseFail()", $t.Line = "16", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnumTryParseFail();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346", $t.File = "Batch3\\BridgeIssues\\3300\\N3346.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -14767,7 +14767,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             methods: {
                 TestEnumTryParseFail: function (assert) {
                     var $t;
-                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3346, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestEnumTryParseFail()", $t.Line = "16", $t));
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3346, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestEnumTryParseFail()", $t.Line = "30", $t));
                     Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnumTryParseFail();
                 }
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -27637,15 +27637,38 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    /**
+     * The test here consists in checking whether Bridge's TryParse
+     implementation does not touch the output variable if the parsing fails.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346
+     */
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346", {
         statics: {
             methods: {
+                /**
+                 * Check if whenever parsing fails, the target variable won't be
+                 changed.
+                 *
+                 * @static
+                 * @public
+                 * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346
+                 * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346
+                 * @return  {void}
+                 */
                 TestEnumTryParseFail: function () {
                     var i = { v : new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnum() };
                     var result = System.Enum.tryParse(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnum, "FF", i);
 
-                    Bridge.Test.NUnit.Assert.False(result);
-                    Bridge.Test.NUnit.Assert.AreEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnum.One, i.v);
+                    Bridge.Test.NUnit.Assert.False(result, "TryParse() 'FF' into an enum returned 'false'.");
+                    Bridge.Test.NUnit.Assert.AreEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnum.One, i.v, "Failed TryParse() call initialized value with enum's 0 (\"One\").");
+
+                    var j = { v : new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestOtherEnum() };
+                    var result_j = System.Enum.tryParse(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestOtherEnum, "FF", j);
+
+                    Bridge.Test.NUnit.Assert.False(result_j, "TryParse() 'FF' into another enum returned 'false'.");
+                    Bridge.Test.NUnit.Assert.AreEqual(0, j.v, "Failed TryParse() call initialized value with enum's 0 (no match in enum).");
                 }
             }
         }
@@ -27656,6 +27679,16 @@ Bridge.$N1391Result =                     r;
         statics: {
             fields: {
                 One: 0
+            }
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestOtherEnum", {
+        $kind: "enum",
+        statics: {
+            fields: {
+                Two: 2,
+                One: 1
             }
         }
     });

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -27593,6 +27593,29 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346", {
+        statics: {
+            methods: {
+                TestEnumTryParseFail: function () {
+                    var i = { v : new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnum() };
+                    var result = System.Enum.tryParse(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnum, "FF", i);
+
+                    Bridge.Test.NUnit.Assert.False(result);
+                    Bridge.Test.NUnit.Assert.AreEqual(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnum.One, i.v);
+                }
+            }
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3346.TestEnum", {
+        $kind: "enum",
+        statics: {
+            fields: {
+                One: 0
+            }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge341A", {
         props: {
             Str: null


### PR DESCRIPTION
Fixes #3346 