### PR TITLE
Fix XMLHttpRequestEventTarget's events not all being ProgressEvent

### DIFF
--- a/Html5/Ajax/XMLHttpRequestEventTarget.cs
+++ b/Html5/Ajax/XMLHttpRequestEventTarget.cs
@@ -13,25 +13,25 @@ namespace Bridge.Html5
         /// The function to call when a request is aborted.
         /// </summary>
         [Name("onabort")]
-        public Action<Event> OnAbort;
+        public Action<ProgressEvent> OnAbort;
 
         /// <summary>
         /// The function to call when a request encounters an error.
         /// </summary>
         [Name("onerror")]
-        public Action<Event> OnError;
+        public Action<ProgressEvent> OnError;
 
         /// <summary>
         /// The function to call when an HTTP request returns after successfully loading content.
         /// </summary>
         [Name("onload")]
-        public Action<Event> OnLoad;
+        public Action<ProgressEvent> OnLoad;
 
         /// <summary>
         /// A function that gets called when the HTTP request first begins loading data.
         /// </summary>
         [Name("onloadstart")]
-        public Action<Event> OnLoadStart;
+        public Action<ProgressEvent> OnLoadStart;
 
         /// <summary>
         /// A function that is called periodically with information about the progress of the request.
@@ -43,12 +43,12 @@ namespace Bridge.Html5
         /// A function that is called if the event times out; this only happens if a timeout has been previously established by setting the value of the XMLHttpRequest object's timeout attribute.
         /// </summary>
         [Name("ontimeout")]
-        public Action<Event> OnTimeout;
+        public Action<ProgressEvent> OnTimeout;
 
         /// <summary>
         /// A function that is called when the load is completed, even if the request failed.
         /// </summary>
         [Name("onloadend")]
-        public Action<Event> OnLoadEnd;
+        public Action<ProgressEvent> OnLoadEnd;
     }
 }


### PR DESCRIPTION
The events present on `XMLHttpRequestEventTarget` need to be `ProgressEvent` not `Event`, according to the WHATWG spec here: https://xhr.spec.whatwg.org/#events

This change means we don't have to manually cast these event arguments to the correct type.

https://deck.net/ad7792f684b0259078e90aeb4bd2a065

**Expected result:**

```
> {number of bytes downloaded}
```

**Actual result:**

```
<Compilation error\>
```

Changes proposed in this pull request:

- Change the type of `XMLHttpRequestEventTarget`'s `OnAbort`, `OnError`, `OnLoad`, `OnLoadEnd`, `OnLoadStart`, and `OnTimeout` events from `Event` to `ProgressEvent`


I haven't tested tests against this pull request because the Bridge.Test project is not open.