### PR TITLE
[3391] Using Equals() on the same boxed enum returns false

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -72,6 +72,10 @@
                     return this.fn.getHashCode ? this.fn.getHashCode(this.v) : Bridge.getHashCode(this.v);
                 },
                 equals: function (o) {
+                    if (this === o) {
+                        return true;
+                    }
+
                     var eq = this.equals;
                     this.equals = null;
                     var r = Bridge.equals(this.v, o);

--- a/Bridge/Resources/Core.js
+++ b/Bridge/Resources/Core.js
@@ -54,6 +54,10 @@
                     return this.fn.getHashCode ? this.fn.getHashCode(this.v) : Bridge.getHashCode(this.v);
                 },
                 equals: function (o) {
+                    if (this === o) {
+                        return true;
+                    }
+
                     var eq = this.equals;
                     this.equals = null;
                     var r = Bridge.equals(this.v, o);

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -688,6 +688,7 @@
     <Compile Include="BridgeIssues\3300\N3329.cs" />
     <Compile Include="BridgeIssues\3300\N3331.cs" />
     <Compile Include="BridgeIssues\3300\N3346.cs" />
+    <Compile Include="BridgeIssues\3300\N3391.cs" />
     <Compile Include="BridgeIssues\3300\N3386.cs" />
     <Compile Include="BridgeIssues\3300\N3363.cs" />
     <Compile Include="BridgeIssues\3300\N3361.cs" />

--- a/Tests/Batch3/BridgeIssues/3300/N3391.cs
+++ b/Tests/Batch3/BridgeIssues/3300/N3391.cs
@@ -1,0 +1,26 @@
+using Bridge.Html5;
+using Bridge.Test.NUnit;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [TestFixture(TestNameFormat = "#3391 - {0}")]
+    public class Bridge3391
+    {
+        public enum BindingConst
+        {
+            Nulloid = 1
+        }
+
+        [Test]
+        public static void TestBoxedEnumEquals()
+        {
+            object a = BindingConst.Nulloid;
+            object b = a;
+
+            Assert.True(a == b);
+            Assert.True(a.Equals(b));
+        }
+    }
+}

--- a/Tests/Batch3/BridgeIssues/3300/N3391.cs
+++ b/Tests/Batch3/BridgeIssues/3300/N3391.cs
@@ -1,10 +1,11 @@
-using Bridge.Html5;
 using Bridge.Test.NUnit;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Bridge.ClientTest.Batch3.BridgeIssues
 {
+    /// <summary>
+    /// The test here consists in checking whether the equals (==) operator's
+    /// result matches the Equals() method result with boxed enums.
+    /// </summary>
     [TestFixture(TestNameFormat = "#3391 - {0}")]
     public class Bridge3391
     {
@@ -13,14 +14,21 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             Nulloid = 1
         }
 
+        /// <summary>
+        /// Box the enum then check equality.
+        /// </summary>
         [Test]
         public static void TestBoxedEnumEquals()
         {
             object a = BindingConst.Nulloid;
             object b = a;
 
-            Assert.True(a == b);
-            Assert.True(a.Equals(b));
+            Assert.True(a == b, "== operator works.");
+            Assert.True(a.Equals(b), "Equals() method works.");
+            Assert.True((a == b) == a.Equals(b), "Nesting == and Equals() is the same.");
+            Assert.True((a == b) == b.Equals(a), "Nesting == and inverted order of Equals() is the same.");
+            Assert.True((b == a) == a.Equals(b), "Nesting inverted == and Equals() is the same.");
+            Assert.True((a != b) == (!a.Equals(b)), "Nesting != and !Equals() is the same.");
         }
     }
 }

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -72,6 +72,10 @@
                     return this.fn.getHashCode ? this.fn.getHashCode(this.v) : Bridge.getHashCode(this.v);
                 },
                 equals: function (o) {
+                    if (this === o) {
+                        return true;
+                    }
+
                     var eq = this.equals;
                     this.equals = null;
                     var r = Bridge.equals(this.v, o);

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -8,6 +8,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
         main: function Main () {
             Bridge.Test.Runtime.ContextHelper.Init();
             QUnit.test("#3386 - Test64bitKey", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3386.Test64bitKey);
+            QUnit.test("#3391 - TestBoxedEnumEquals", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3391.TestBoxedEnumEquals);
             QUnit.module("Issues3");
             QUnit.test("#69 - ThisKeywordInStructConstructorWorks", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge069.ThisKeywordInStructConstructorWorks);
             QUnit.test("#1000 - TestStaticViaChild", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge1000.TestStaticViaChild);
@@ -14962,6 +14963,31 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3386", $t.File = "Batch3\\BridgeIssues\\3300\\N3386.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3391", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391)],
+        statics: {
+            methods: {
+                TestBoxedEnumEquals: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3391, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestBoxedEnumEquals()", $t.Line = "16", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391.TestBoxedEnumEquals();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391", $t.File = "Batch3\\BridgeIssues\\3300\\N3391.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -14975,7 +14975,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             methods: {
                 TestBoxedEnumEquals: function (assert) {
                     var $t;
-                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3391, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestBoxedEnumEquals()", $t.Line = "16", $t));
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3391, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestBoxedEnumEquals()", $t.Line = "20", $t));
                     Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391.TestBoxedEnumEquals();
                 }
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -27969,6 +27969,29 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391", {
+        statics: {
+            methods: {
+                TestBoxedEnumEquals: function () {
+                    var a = Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391.BindingConst.Nulloid, Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391.BindingConst, System.Enum.toStringFn(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391.BindingConst));
+                    var b = a;
+
+                    Bridge.Test.NUnit.Assert.True(Bridge.referenceEquals(a, b));
+                    Bridge.Test.NUnit.Assert.True(Bridge.equals(a, b));
+                }
+            }
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391.BindingConst", {
+        $kind: "enum",
+        statics: {
+            fields: {
+                Nulloid: 1
+            }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge341A", {
         props: {
             Str: null

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -27969,15 +27969,35 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    /**
+     * The test here consists in checking whether the equals (==) operator's
+     result matches the Equals() method result with boxed enums.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391
+     */
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391", {
         statics: {
             methods: {
+                /**
+                 * Box the enum then check equality.
+                 *
+                 * @static
+                 * @public
+                 * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391
+                 * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391
+                 * @return  {void}
+                 */
                 TestBoxedEnumEquals: function () {
                     var a = Bridge.box(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391.BindingConst.Nulloid, Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391.BindingConst, System.Enum.toStringFn(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391.BindingConst));
                     var b = a;
 
-                    Bridge.Test.NUnit.Assert.True(Bridge.referenceEquals(a, b));
-                    Bridge.Test.NUnit.Assert.True(Bridge.equals(a, b));
+                    Bridge.Test.NUnit.Assert.True(Bridge.referenceEquals(a, b), "== operator works.");
+                    Bridge.Test.NUnit.Assert.True(Bridge.equals(a, b), "Equals() method works.");
+                    Bridge.Test.NUnit.Assert.True((Bridge.referenceEquals(a, b)) === Bridge.equals(a, b), "Nesting == and Equals() is the same.");
+                    Bridge.Test.NUnit.Assert.True((Bridge.referenceEquals(a, b)) === Bridge.equals(b, a), "Nesting == and inverted order of Equals() is the same.");
+                    Bridge.Test.NUnit.Assert.True((Bridge.referenceEquals(b, a)) === Bridge.equals(a, b), "Nesting inverted == and Equals() is the same.");
+                    Bridge.Test.NUnit.Assert.True((!Bridge.referenceEquals(a, b)) === (!Bridge.equals(a, b)), "Nesting != and !Equals() is the same.");
                 }
             }
         }


### PR DESCRIPTION
Fixes #3391 