### PR TITLE
[3394] Passing an instance of a custom implementation of IComparer<T>…

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -11491,7 +11491,7 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 i = lo + ((hi - lo) >> 1);
 
                 try {
-                    c = comparer.compare(array[i], value);
+                    c = System.Collections.Generic.Comparer$1.get(comparer)(array[i], value);
                 } catch (e) {
                     throw new System.InvalidOperationException("Failed to compare two elements in the array.", e);
                 }
@@ -11538,11 +11538,11 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
             }
 
             if (index === 0 && length === array.length) {
-                array.sort(Bridge.fn.bind(comparer, comparer.compare));
+                array.sort(Bridge.fn.bind(comparer, System.Collections.Generic.Comparer$1.get(comparer)));
             } else {
                 var newarray = array.slice(index, index + length);
 
-                newarray.sort(Bridge.fn.bind(comparer, comparer.compare));
+                newarray.sort(Bridge.fn.bind(comparer, System.Collections.Generic.Comparer$1.get(comparer)));
 
                 for (var i = index; i < (index + length) ; i++) {
                     array[i] = newarray[i - index];
@@ -12392,6 +12392,19 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
 
         return Bridge.compare(x, y);
     });
+
+    System.Collections.Generic.Comparer$1.get = function (obj, T) {
+        var m;
+        if (T && (m = obj["System$Collections$Generic$IComparer$1$" + Bridge.getTypeAlias(T) + "$compare"])) {
+            return m;
+        }
+
+        if (m = obj["System$Collections$Generic$IComparer$1$compare"]) {
+            return m;
+        }
+
+        return obj.compare;
+    };
 
     // @source Dictionary.js
 

--- a/Bridge/Resources/Array.js
+++ b/Bridge/Resources/Array.js
@@ -706,7 +706,7 @@
                 i = lo + ((hi - lo) >> 1);
 
                 try {
-                    c = comparer.compare(array[i], value);
+                    c = System.Collections.Generic.Comparer$1.get(comparer)(array[i], value);
                 } catch (e) {
                     throw new System.InvalidOperationException("Failed to compare two elements in the array.", e);
                 }
@@ -753,11 +753,11 @@
             }
 
             if (index === 0 && length === array.length) {
-                array.sort(Bridge.fn.bind(comparer, comparer.compare));
+                array.sort(Bridge.fn.bind(comparer, System.Collections.Generic.Comparer$1.get(comparer)));
             } else {
                 var newarray = array.slice(index, index + length);
 
-                newarray.sort(Bridge.fn.bind(comparer, comparer.compare));
+                newarray.sort(Bridge.fn.bind(comparer, System.Collections.Generic.Comparer$1.get(comparer)));
 
                 for (var i = index; i < (index + length) ; i++) {
                     array[i] = newarray[i - index];

--- a/Bridge/Resources/Collections/Comparer.js
+++ b/Bridge/Resources/Collections/Comparer.js
@@ -21,3 +21,16 @@
 
         return Bridge.compare(x, y);
     });
+
+    System.Collections.Generic.Comparer$1.get = function (obj, T) {
+        var m;
+        if (T && (m = obj["System$Collections$Generic$IComparer$1$" + Bridge.getTypeAlias(T) + "$compare"])) {
+            return m;
+        }
+
+        if (m = obj["System$Collections$Generic$IComparer$1$compare"]) {
+            return m;
+        }
+
+        return obj.compare;
+    };

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -688,6 +688,7 @@
     <Compile Include="BridgeIssues\3300\N3329.cs" />
     <Compile Include="BridgeIssues\3300\N3331.cs" />
     <Compile Include="BridgeIssues\3300\N3346.cs" />
+    <Compile Include="BridgeIssues\3300\N3394.cs" />
     <Compile Include="BridgeIssues\3300\N3391.cs" />
     <Compile Include="BridgeIssues\3300\N3386.cs" />
     <Compile Include="BridgeIssues\3300\N3363.cs" />

--- a/Tests/Batch3/BridgeIssues/3300/N3394.cs
+++ b/Tests/Batch3/BridgeIssues/3300/N3394.cs
@@ -3,9 +3,16 @@ using System.Collections.Generic;
 
 namespace Bridge.ClientTest.Batch3.BridgeIssues
 {
+    /// <summary>
+    /// The test here consists in checking whether a custom comparer can be
+    /// applied to an array of values.
+    /// </summary>
     [TestFixture(TestNameFormat = "#3394 - {0}")]
     public class Bridge3394
     {
+        /// <summary>
+        /// The custom comparer implementation.
+        /// </summary>
         public class CustomComparer : IComparer<int>
         {
             int IComparer<int>.Compare(int a, int b)
@@ -14,6 +21,9 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             }
         }
 
+        /// <summary>
+        /// Create a List of integers and apply the custom comparer.
+        /// </summary>
         [Test]
         public static void TestCustomComparer()
         {
@@ -28,11 +38,11 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
 
             arr.Sort(new CustomComparer());
 
-            Assert.AreEqual(arr[0], 25);
-            Assert.AreEqual(arr[1], 20);
-            Assert.AreEqual(arr[2], 15);
-            Assert.AreEqual(arr[3], 10);
-            Assert.AreEqual(arr[4], 5);
+            Assert.AreEqual(arr[0], 25, "First List entry is 25 (last, before sorting).");
+            Assert.AreEqual(arr[1], 20, "Second List entry is 20 (fourth, before sorting).");
+            Assert.AreEqual(arr[2], 15, "Third List entry is 15 (third, before sorting).");
+            Assert.AreEqual(arr[3], 10, "Fourth List entry is 10 (second, before sorting).");
+            Assert.AreEqual(arr[4], 5, "Last List entry is 20 (first, before sorting).");
         }
     }
 }

--- a/Tests/Batch3/BridgeIssues/3300/N3394.cs
+++ b/Tests/Batch3/BridgeIssues/3300/N3394.cs
@@ -1,0 +1,38 @@
+using Bridge.Test.NUnit;
+using System.Collections.Generic;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [TestFixture(TestNameFormat = "#3394 - {0}")]
+    public class Bridge3394
+    {
+        public class CustomComparer : IComparer<int>
+        {
+            int IComparer<int>.Compare(int a, int b)
+            {
+                return -a.CompareTo(b);
+            }
+        }
+
+        [Test]
+        public static void TestCustomComparer()
+        {
+            List<int> arr = new List<int>()
+            {
+                5,
+                10,
+                15,
+                20,
+                25
+            };
+
+            arr.Sort(new CustomComparer());
+
+            Assert.AreEqual(arr[0], 25);
+            Assert.AreEqual(arr[1], 20);
+            Assert.AreEqual(arr[2], 15);
+            Assert.AreEqual(arr[3], 10);
+            Assert.AreEqual(arr[4], 5);
+        }
+    }
+}

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -11491,7 +11491,7 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 i = lo + ((hi - lo) >> 1);
 
                 try {
-                    c = comparer.compare(array[i], value);
+                    c = System.Collections.Generic.Comparer$1.get(comparer)(array[i], value);
                 } catch (e) {
                     throw new System.InvalidOperationException("Failed to compare two elements in the array.", e);
                 }
@@ -11538,11 +11538,11 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
             }
 
             if (index === 0 && length === array.length) {
-                array.sort(Bridge.fn.bind(comparer, comparer.compare));
+                array.sort(Bridge.fn.bind(comparer, System.Collections.Generic.Comparer$1.get(comparer)));
             } else {
                 var newarray = array.slice(index, index + length);
 
-                newarray.sort(Bridge.fn.bind(comparer, comparer.compare));
+                newarray.sort(Bridge.fn.bind(comparer, System.Collections.Generic.Comparer$1.get(comparer)));
 
                 for (var i = index; i < (index + length) ; i++) {
                     array[i] = newarray[i - index];
@@ -12392,6 +12392,19 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
 
         return Bridge.compare(x, y);
     });
+
+    System.Collections.Generic.Comparer$1.get = function (obj, T) {
+        var m;
+        if (T && (m = obj["System$Collections$Generic$IComparer$1$" + Bridge.getTypeAlias(T) + "$compare"])) {
+            return m;
+        }
+
+        if (m = obj["System$Collections$Generic$IComparer$1$compare"]) {
+            return m;
+        }
+
+        return obj.compare;
+    };
 
     // @source Dictionary.js
 

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -9,6 +9,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             Bridge.Test.Runtime.ContextHelper.Init();
             QUnit.test("#3386 - Test64bitKey", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3386.Test64bitKey);
             QUnit.test("#3391 - TestBoxedEnumEquals", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3391.TestBoxedEnumEquals);
+            QUnit.test("#3394 - TestCustomComparer", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3394.TestCustomComparer);
             QUnit.module("Issues3");
             QUnit.test("#69 - ThisKeywordInStructConstructorWorks", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge069.ThisKeywordInStructConstructorWorks);
             QUnit.test("#1000 - TestStaticViaChild", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge1000.TestStaticViaChild);
@@ -14988,6 +14989,31 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3391", $t.File = "Batch3\\BridgeIssues\\3300\\N3391.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3394", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394)],
+        statics: {
+            methods: {
+                TestCustomComparer: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3394, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestCustomComparer()", $t.Line = "17", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394.TestCustomComparer();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394", $t.File = "Batch3\\BridgeIssues\\3300\\N3394.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -15001,7 +15001,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             methods: {
                 TestCustomComparer: function (assert) {
                     var $t;
-                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3394, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestCustomComparer()", $t.Line = "17", $t));
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3394, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestCustomComparer()", $t.Line = "27", $t));
                     Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394.TestCustomComparer();
                 }
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -28012,6 +28012,47 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394", {
+        statics: {
+            methods: {
+                TestCustomComparer: function () {
+                    var arr = $asm.$.Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394.f1(new (System.Collections.Generic.List$1(System.Int32)).ctor());
+
+                    arr.sort$1(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394.CustomComparer());
+
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(0), 25);
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(1), 20);
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(2), 15);
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(3), 10);
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(4), 5);
+                }
+            }
+        }
+    });
+
+    Bridge.ns("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394", $asm.$);
+
+    Bridge.apply($asm.$.Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394, {
+        f1: function (_o1) {
+            _o1.add(5);
+            _o1.add(10);
+            _o1.add(15);
+            _o1.add(20);
+            _o1.add(25);
+            return _o1;
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394.CustomComparer", {
+        inherits: [System.Collections.Generic.IComparer$1(System.Int32)],
+        alias: ["System$Collections$Generic$IComparer$1$System$Int32$compare", "System$Collections$Generic$IComparer$1$compare"],
+        methods: {
+            System$Collections$Generic$IComparer$1$System$Int32$compare: function (a, b) {
+                return ((-Bridge.compare(a, b)) | 0);
+            }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge341A", {
         props: {
             Str: null

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -28012,19 +28012,35 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    /**
+     * The test here consists in checking whether a custom comparer can be
+     applied to an array of values.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394
+     */
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394", {
         statics: {
             methods: {
+                /**
+                 * Create a List of integers and apply the custom comparer.
+                 *
+                 * @static
+                 * @public
+                 * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394
+                 * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394
+                 * @return  {void}
+                 */
                 TestCustomComparer: function () {
                     var arr = $asm.$.Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394.f1(new (System.Collections.Generic.List$1(System.Int32)).ctor());
 
                     arr.sort$1(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394.CustomComparer());
 
-                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(0), 25);
-                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(1), 20);
-                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(2), 15);
-                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(3), 10);
-                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(4), 5);
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(0), 25, "First List entry is 25 (last, before sorting).");
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(1), 20, "Second List entry is 20 (fourth, before sorting).");
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(2), 15, "Third List entry is 15 (third, before sorting).");
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(3), 10, "Fourth List entry is 10 (second, before sorting).");
+                    Bridge.Test.NUnit.Assert.AreEqual(arr.getItem(4), 5, "Last List entry is 20 (first, before sorting).");
                 }
             }
         }
@@ -28043,6 +28059,13 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    /**
+     * The custom comparer implementation.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394.CustomComparer
+     * @implements  System.Collections.Generic.IComparer$1
+     */
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3394.CustomComparer", {
         inherits: [System.Collections.Generic.IComparer$1(System.Int32)],
         alias: ["System$Collections$Generic$IComparer$1$System$Int32$compare", "System$Collections$Generic$IComparer$1$compare"],


### PR DESCRIPTION
… to List<T>.Sort() does not work

Fixes #3394 