### PR TITLE
[3388] Two excplicit implementations of generic interface are indistinguishable

### DIFF
--- a/Compiler/Contract/BridgeType.cs
+++ b/Compiler/Contract/BridgeType.cs
@@ -306,7 +306,7 @@ namespace Bridge.Contract
             return globalTarget;
         }
 
-        public static string ToJsName(IType type, IEmitter emitter, bool asDefinition = false, bool excludens = false, bool isAlias = false, bool skipMethodTypeParam = false, bool removeScope = true, bool nomodule = false, bool ignoreLiteralName = true, bool ignoreVirtual = false)
+        public static string ToJsName(IType type, IEmitter emitter, bool asDefinition = false, bool excludens = false, bool isAlias = false, bool skipMethodTypeParam = false, bool removeScope = true, bool nomodule = false, bool ignoreLiteralName = true, bool ignoreVirtual = false, bool excludeTypeOnly = false)
         {
             var itypeDef = type.GetDefinition();
             BridgeType bridgeType = emitter.BridgeTypes.Get(type, true);
@@ -337,7 +337,7 @@ namespace Bridge.Contract
 
                 if (arrayType != null && arrayType.ElementType != null)
                 {
-                    var elementAlias = BridgeTypes.ToJsName(arrayType.ElementType, emitter, asDefinition, excludens, isAlias, skipMethodTypeParam);
+                    var elementAlias = BridgeTypes.ToJsName(arrayType.ElementType, emitter, asDefinition, excludens, isAlias, skipMethodTypeParam, excludeTypeOnly: excludeTypeOnly);
 
                     if (isAlias)
                     {
@@ -366,7 +366,7 @@ namespace Bridge.Contract
 
             if (type is ByReferenceType)
             {
-                return BridgeTypes.ToJsName(((ByReferenceType)type).ElementType, emitter, asDefinition, excludens, isAlias, skipMethodTypeParam);
+                return BridgeTypes.ToJsName(((ByReferenceType)type).ElementType, emitter, asDefinition, excludens, isAlias, skipMethodTypeParam, excludeTypeOnly: excludeTypeOnly);
             }
 
             if (ignoreLiteralName)
@@ -396,7 +396,7 @@ namespace Bridge.Contract
             var typeParam = type as ITypeParameter;
             if (typeParam != null)
             {
-                if (skipMethodTypeParam && (typeParam.OwnerType == SymbolKind.Method) || Helpers.IsIgnoreGeneric(typeParam.Owner, emitter))
+                if ((skipMethodTypeParam || excludeTypeOnly) && (typeParam.OwnerType == SymbolKind.Method) || Helpers.IsIgnoreGeneric(typeParam.Owner, emitter))
                 {
                     return JS.Types.System.Object.NAME;
                 }
@@ -461,7 +461,7 @@ namespace Bridge.Contract
                 name = OverloadsCollection.NormalizeInterfaceName(name);
             }
 
-            if (type.TypeArguments.Count > 0 && !Helpers.IsIgnoreGeneric(type, emitter) && !asDefinition)
+            if (type.TypeArguments.Count > 0 && !Helpers.IsIgnoreGeneric(type, emitter) && !asDefinition && !skipMethodTypeParam)
             {
                 if (isAlias)
                 {
@@ -482,7 +482,8 @@ namespace Bridge.Contract
                         }
 
                         needComma = true;
-                        bool needGet = typeArg.Kind == TypeKind.TypeParameter && !asDefinition;
+                        var isTypeParam = typeArg.Kind == TypeKind.TypeParameter;
+                        bool needGet = isTypeParam && !asDefinition && !excludeTypeOnly;
                         if (needGet)
                         {
                             if (!isStr)
@@ -493,7 +494,7 @@ namespace Bridge.Contract
                             sb.Append("\" + " + JS.Types.Bridge.GET_TYPE_ALIAS + "(");
                         }
 
-                        var typeArgName = BridgeTypes.ToJsName(typeArg, emitter, asDefinition, false, true, skipMethodTypeParam, ignoreVirtual:true);
+                        var typeArgName = BridgeTypes.ToJsName(typeArg, emitter, asDefinition, false, true, skipMethodTypeParam, ignoreVirtual:true, excludeTypeOnly: excludeTypeOnly);
 
                         if (!needGet && typeArgName.StartsWith("\""))
                         {
@@ -512,7 +513,7 @@ namespace Bridge.Contract
                                 sb.Insert(0, "\"");
                             }
                         }
-                        else
+                        else if (!isTypeParam || !excludeTypeOnly)
                         {
                             sb.Append(typeArgName);
                         }
@@ -549,7 +550,7 @@ namespace Bridge.Contract
 
                         needComma = true;
 
-                        sb.Append(BridgeTypes.ToJsName(typeArg, emitter, skipMethodTypeParam: skipMethodTypeParam));
+                        sb.Append(BridgeTypes.ToJsName(typeArg, emitter, skipMethodTypeParam: skipMethodTypeParam, excludeTypeOnly: excludeTypeOnly));
                     }
                     sb.Append(")");
                     name = sb.ToString();

--- a/Compiler/Contract/OverloadsCollection.cs
+++ b/Compiler/Contract/OverloadsCollection.cs
@@ -988,7 +988,7 @@ namespace Bridge.Contract
 
         private Dictionary<Tuple<bool, string, bool, bool>, string> overloadName = new Dictionary<Tuple<bool, string, bool, bool>, string>();
 
-        public string GetOverloadName(bool skipInterfaceName = false, string prefix = null, bool withoutTypeParams = false, bool isObjectLiteral = false)
+        public string GetOverloadName(bool skipInterfaceName = false, string prefix = null, bool withoutTypeParams = false, bool isObjectLiteral = false, bool excludeTypeOnly = false)
         {
             if (this.Member == null)
             {
@@ -1007,7 +1007,7 @@ namespace Bridge.Contract
             var contains = this.overloadName.ContainsKey(key);
             if (!contains && this.Member != null)
             {
-                name = this.GetOverloadName(this.Member, skipInterfaceName, prefix, withoutTypeParams, isObjectLiteral);
+                name = this.GetOverloadName(this.Member, skipInterfaceName, prefix, withoutTypeParams, isObjectLiteral, excludeTypeOnly);
                 this.overloadName[key] = name;
             }
             else if(contains)
@@ -1023,10 +1023,10 @@ namespace Bridge.Contract
             return Regex.Replace(interfaceName, @"[\.\(\)\,]", JS.Vars.D.ToString());
         }
 
-        public static string GetInterfaceMemberName(IEmitter emitter, IMember interfaceMember, string name, string prefix, bool withoutTypeParams = false, bool isSetter = false)
+        public static string GetInterfaceMemberName(IEmitter emitter, IMember interfaceMember, string name, string prefix, bool withoutTypeParams = false, bool isSetter = false, bool excludeTypeOnly = false)
         {
             var interfaceMemberName = name ?? OverloadsCollection.Create(emitter, interfaceMember, isSetter).GetOverloadName(true, prefix);
-            var interfaceName = BridgeTypes.ToJsName(interfaceMember.DeclaringType, emitter, withoutTypeParams, false, true);
+            var interfaceName = BridgeTypes.ToJsName(interfaceMember.DeclaringType, emitter, false, false, true, withoutTypeParams, excludeTypeOnly: excludeTypeOnly);
 
             if (interfaceName.StartsWith("\""))
             {
@@ -1098,7 +1098,7 @@ namespace Bridge.Contract
             return true;
         }
 
-        protected virtual string GetOverloadName(IMember definition, bool skipInterfaceName = false, string prefix = null, bool withoutTypeParams = false, bool isObjectLiteral = false)
+        protected virtual string GetOverloadName(IMember definition, bool skipInterfaceName = false, string prefix = null, bool withoutTypeParams = false, bool isObjectLiteral = false, bool excludeTypeOnly = false)
         {
             IMember interfaceMember = null;
             if (definition.IsExplicitInterfaceImplementation)
@@ -1112,7 +1112,7 @@ namespace Bridge.Contract
 
             if (interfaceMember != null && !skipInterfaceName && !this.Emitter.Validator.IsObjectLiteral(interfaceMember.DeclaringTypeDefinition))
             {
-                return OverloadsCollection.GetInterfaceMemberName(this.Emitter, interfaceMember, null, prefix, withoutTypeParams, this.IsSetter);
+                return OverloadsCollection.GetInterfaceMemberName(this.Emitter, interfaceMember, null, prefix, withoutTypeParams, this.IsSetter, excludeTypeOnly);
             }
 
             string name = isObjectLiteral ? this.Emitter.GetLiteralEntityName(definition) : this.Emitter.GetEntityName(definition);

--- a/Compiler/Translator/Emitter/Blocks/FieldBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/FieldBlock.cs
@@ -834,7 +834,7 @@ namespace Bridge.Translator
             {
                 nonEmpty = true;
                 this.EnsureComma();
-                this.WriteScript(OverloadsCollection.Create(Emitter, member).GetOverloadName(false, null, excludeTypeParam));
+                this.WriteScript(OverloadsCollection.Create(Emitter, member).GetOverloadName(false, null, excludeTypeOnly: excludeTypeParam));
                 this.WriteComma();
                 var alias = OverloadsCollection.Create(Emitter, interfaceMember).GetOverloadName(withoutTypeParams: excludeAliasTypeParam);
 

--- a/Compiler/Translator/Emitter/Blocks/VisitorMethodBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/VisitorMethodBlock.cs
@@ -98,7 +98,7 @@ namespace Bridge.Translator
             var isEntryPoint = Helpers.IsEntryPointMethod(this.Emitter, this.MethodDeclaration);
             var member_rr = (MemberResolveResult)this.Emitter.Resolver.ResolveNode(this.MethodDeclaration, this.Emitter);
 
-            string name = overloads.GetOverloadName(false, null, OverloadsCollection.ExcludeTypeParameterForDefinition(member_rr));
+            string name = overloads.GetOverloadName(false, null, excludeTypeOnly: OverloadsCollection.ExcludeTypeParameterForDefinition(member_rr));
 
             if (isEntryPoint)
             {

--- a/Compiler/Translator/Utils/MetadataUtils.cs
+++ b/Compiler/Translator/Utils/MetadataUtils.cs
@@ -964,7 +964,7 @@ namespace Bridge.Translator
                 return JS.Types.System.Object.NAME;
             }
 
-            var name = BridgeTypes.ToJsName(type, emitter, asDefinition, skipMethodTypeParam: true);
+            var name = BridgeTypes.ToJsName(type, emitter, asDefinition, excludeTypeOnly: true);
 
             if (cache && emitter.NamespacesCache != null && name.StartsWith(type.Namespace + "."))
             {

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -688,6 +688,7 @@
     <Compile Include="BridgeIssues\3300\N3329.cs" />
     <Compile Include="BridgeIssues\3300\N3331.cs" />
     <Compile Include="BridgeIssues\3300\N3346.cs" />
+    <Compile Include="BridgeIssues\3300\N3388.cs" />
     <Compile Include="BridgeIssues\3300\N3394.cs" />
     <Compile Include="BridgeIssues\3300\N3391.cs" />
     <Compile Include="BridgeIssues\3300\N3386.cs" />

--- a/Tests/Batch3/BridgeIssues/3300/N3388.cs
+++ b/Tests/Batch3/BridgeIssues/3300/N3388.cs
@@ -1,0 +1,28 @@
+using Bridge.Test.NUnit;
+using System.Collections.Generic;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [TestFixture(TestNameFormat = "#3388 - {0}")]
+    public class Bridge3388
+    {
+        public class MyClass<T> : IFace<T>, IFace<List<T>>
+        {
+            string IFace<T>.Method() => "single";
+            string IFace<List<T>>.Method() => "list";
+        }
+
+        public interface IFace<T>
+        {
+            string Method();
+        }
+
+        [Test]
+        public static void TestTwoInterfaceImplementation()
+        {
+            var c = new MyClass<int>();
+            Assert.AreEqual("single", ((IFace<int>)c).Method());
+            Assert.AreEqual("list", ((IFace<List<int>>)c).Method());
+        }
+    }
+}

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -8,6 +8,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
         main: function Main () {
             Bridge.Test.Runtime.ContextHelper.Init();
             QUnit.test("#3386 - Test64bitKey", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3386.Test64bitKey);
+            QUnit.test("#3388 - TestTwoInterfaceImplementation", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3388.TestTwoInterfaceImplementation);
             QUnit.test("#3391 - TestBoxedEnumEquals", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3391.TestBoxedEnumEquals);
             QUnit.test("#3394 - TestCustomComparer", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3394.TestCustomComparer);
             QUnit.module("Issues3");
@@ -14964,6 +14965,31 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3386", $t.File = "Batch3\\BridgeIssues\\3300\\N3386.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3388", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388)],
+        statics: {
+            methods: {
+                TestTwoInterfaceImplementation: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3388, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestTwoInterfaceImplementation()", $t.Line = "20", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388.TestTwoInterfaceImplementation();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388", $t.File = "Batch3\\BridgeIssues\\3300\\N3388.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -27969,6 +27969,22 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388", {
+        statics: {
+            methods: {
+                TestTwoInterfaceImplementation: function () {
+                    var c = new (Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388.MyClass$1(System.Int32))();
+                    Bridge.Test.NUnit.Assert.AreEqual("single", Bridge.cast(c, Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388.IFace$1(System.Int32)).Bridge$ClientTest$Batch3$BridgeIssues$Bridge3388$IFace$1$System$Int32$Method());
+                    Bridge.Test.NUnit.Assert.AreEqual("list", Bridge.cast(c, Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388.IFace$1(System.Collections.Generic.List$1(System.Int32))).Bridge$ClientTest$Batch3$BridgeIssues$Bridge3388$IFace$1$System$Collections$Generic$List$1$System$Int32$Method());
+                }
+            }
+        }
+    });
+
+    Bridge.definei("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388.IFace$1", function (T) { return {
+        $kind: "interface"
+    }; });
+
     /**
      * The test here consists in checking whether the equals (==) operator's
      result matches the Equals() method result with boxed enums.
@@ -37373,9 +37389,9 @@ Bridge.$N1391Result =                     r;
 
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge2278.Something$1", function (T) { return {
         inherits: [Bridge.ClientTest.Batch3.BridgeIssues.Bridge2278.ISomething$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge2278.Item$1(T))],
-        alias: ["Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$ISomething$1$DoSomething", "Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$ISomething$1$Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$Item$1$" + Bridge.getTypeAlias(T) + "$DoSomething"],
+        alias: ["Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$ISomething$1$Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$Item$1$DoSomething", "Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$ISomething$1$Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$Item$1$" + Bridge.getTypeAlias(T) + "$DoSomething"],
         methods: {
-            Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$ISomething$1$DoSomething: function (t) {
+            Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$ISomething$1$Bridge$ClientTest$Batch3$BridgeIssues$Bridge2278$Item$1$DoSomething: function (t) {
                 return t;
             }
         }
@@ -38324,6 +38340,22 @@ Bridge.$N1391Result =                     r;
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3292.ClassProbe", {
         inherits: [Bridge.ClientTest.Batch3.BridgeIssues.Bridge3292.IInterfaceProbe]
     });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388.MyClass$1", function (T) { return {
+        inherits: [Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388.IFace$1(T),Bridge.ClientTest.Batch3.BridgeIssues.Bridge3388.IFace$1(System.Collections.Generic.List$1(T))],
+        alias: [
+            "Bridge$ClientTest$Batch3$BridgeIssues$Bridge3388$IFace$1$Method", "Bridge$ClientTest$Batch3$BridgeIssues$Bridge3388$IFace$1$" + Bridge.getTypeAlias(T) + "$Method",
+            "Bridge$ClientTest$Batch3$BridgeIssues$Bridge3388$IFace$1$System$Collections$Generic$List$1$Method", "Bridge$ClientTest$Batch3$BridgeIssues$Bridge3388$IFace$1$System$Collections$Generic$List$1$" + Bridge.getTypeAlias(T) + "$Method"
+        ],
+        methods: {
+            Bridge$ClientTest$Batch3$BridgeIssues$Bridge3388$IFace$1$Method: function () {
+                return "single";
+            },
+            Bridge$ClientTest$Batch3$BridgeIssues$Bridge3388$IFace$1$System$Collections$Generic$List$1$Method: function () {
+                return "list";
+            }
+        }
+    }; });
 
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge436Second", {
         inherits: [Bridge.ClientTest.Batch3.BridgeIssues.Bridge436First],


### PR DESCRIPTION
Fixes #3388