### PR TITLE
[3404] Extension method for decimal with additional string parameter produces invalid code.

### DIFF
--- a/Compiler/Translator/Emitter/Blocks/ConversionBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/ConversionBlock.cs
@@ -807,6 +807,12 @@ namespace Bridge.Translator
             {
                 var index = invocationExpression.Arguments.ToList().IndexOf(expression);
                 var methodResolveResult = block.Emitter.Resolver.ResolveNode(invocationExpression, block.Emitter) as MemberResolveResult;
+                var invocationResolveResult = methodResolveResult as CSharpInvocationResolveResult;
+
+                if (invocationResolveResult != null && invocationResolveResult.IsExtensionMethodInvocation)
+                {
+                    index++;
+                }
 
                 if (methodResolveResult != null)
                 {

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -698,6 +698,7 @@
     <Compile Include="BridgeIssues\3300\N3361.cs" />
     <Compile Include="BridgeIssues\3300\N3356.cs" />
     <Compile Include="BridgeIssues\3300\N3352.cs" />
+    <Compile Include="BridgeIssues\3400\N3404.cs" />
     <Compile Include="BridgeIssues\3400\N3401.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />

--- a/Tests/Batch3/BridgeIssues/3400/N3404.cs
+++ b/Tests/Batch3/BridgeIssues/3400/N3404.cs
@@ -1,0 +1,24 @@
+using Bridge.Html5;
+using Bridge.Test.NUnit;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [TestFixture(TestNameFormat = "#3404 - {0}")]
+    public class Bridge3404
+    {
+        [Test]
+        public static void TestExtensionMethodDecimal()
+        {
+            decimal a = 0;
+            Assert.AreEqual("text", a.M("text"));
+        }
+    }
+
+    public static class Bridge3404Ex
+    {
+        public static string M(this decimal a, string b)
+        {
+            return b;
+        }
+    }
+}

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -13,6 +13,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3391 - TestBoxedEnumEquals", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3391.TestBoxedEnumEquals);
             QUnit.test("#3394 - TestCustomComparer", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3394.TestCustomComparer);
             QUnit.test("#3401 - TestCustomComparer", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3401.TestCustomComparer);
+            QUnit.test("#3404 - TestExtensionMethodDecimal", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3404.TestExtensionMethodDecimal);
             QUnit.module("Issues3");
             QUnit.test("#69 - ThisKeywordInStructConstructorWorks", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge069.ThisKeywordInStructConstructorWorks);
             QUnit.test("#1000 - TestStaticViaChild", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge1000.TestStaticViaChild);
@@ -15118,6 +15119,31 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3401", $t.File = "Batch3\\BridgeIssues\\3400\\N3401.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3404", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3404)],
+        statics: {
+            methods: {
+                TestExtensionMethodDecimal: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3404).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3404, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestExtensionMethodDecimal()", $t.Line = "9", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3404.TestExtensionMethodDecimal();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3404", $t.File = "Batch3\\BridgeIssues\\3400\\N3404.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -28215,6 +28215,27 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3404", {
+        statics: {
+            methods: {
+                TestExtensionMethodDecimal: function () {
+                    var a = System.Decimal(0);
+                    Bridge.Test.NUnit.Assert.AreEqual("text", Bridge.ClientTest.Batch3.BridgeIssues.Bridge3404Ex.M(a, "text"));
+                }
+            }
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3404Ex", {
+        statics: {
+            methods: {
+                M: function (a, b) {
+                    return b;
+                }
+            }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge341A", {
         props: {
             Str: null


### PR DESCRIPTION
Fixes #3404 