### PR TITLE
[3360] double.TryParse different behaviour from .Net

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -6960,7 +6960,13 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 var countExp = 0;
 
                 for (var i = 0; i < s.length; i++) {
-                    if (System.Char.isLetter(s[i].charCodeAt(0))) {
+                    if (!System.Char.isNumber(s[i].charCodeAt(0)) &&
+                        s[i] !== '.' &&
+                        s[i] !== ',' &&
+                        s[i] !== nfInfo.positiveSign &&
+                        s[i] !== nfInfo.negativeSign &&
+                        s[i] !== point &&
+                        s[i] !== thousands) {
                         if (s[i].toLowerCase() === "e") {
                             countExp++;
                             if (countExp > 1) {

--- a/Bridge/Resources/Integer.js
+++ b/Bridge/Resources/Integer.js
@@ -647,7 +647,13 @@
                 var countExp = 0;
 
                 for (var i = 0; i < s.length; i++) {
-                    if (System.Char.isLetter(s[i].charCodeAt(0))) {
+                    if (!System.Char.isNumber(s[i].charCodeAt(0)) &&
+                        s[i] !== '.' &&
+                        s[i] !== ',' &&
+                        s[i] !== nfInfo.positiveSign &&
+                        s[i] !== nfInfo.negativeSign &&
+                        s[i] !== point &&
+                        s[i] !== thousands) {
                         if (s[i].toLowerCase() === "e") {
                             countExp++;
                             if (countExp > 1) {

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -701,6 +701,7 @@
     <Compile Include="BridgeIssues\3300\N3390.cs" />
     <Compile Include="BridgeIssues\3300\N3391.cs" />
     <Compile Include="BridgeIssues\3300\N3394.cs" />
+    <Compile Include="BridgeIssues\3300\N3360.cs" />
     <Compile Include="BridgeIssues\3300\N3396.cs" />
     <Compile Include="BridgeIssues\3400\N3401.cs" />
     <Compile Include="BridgeIssues\3400\N3404.cs" />

--- a/Tests/Batch3/BridgeIssues/3300/N3360.cs
+++ b/Tests/Batch3/BridgeIssues/3300/N3360.cs
@@ -1,0 +1,17 @@
+using Bridge.Test.NUnit;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [TestFixture(TestNameFormat = "#3360 - {0}")]
+    public class Bridge3360
+    {
+        [Test]
+        public static void TestDoubleParse()
+        {
+            double test;
+            var result = double.TryParse("2/1", out test);
+
+            Assert.False(result);
+        }
+    }
+}

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -6960,7 +6960,13 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 var countExp = 0;
 
                 for (var i = 0; i < s.length; i++) {
-                    if (System.Char.isLetter(s[i].charCodeAt(0))) {
+                    if (!System.Char.isNumber(s[i].charCodeAt(0)) &&
+                        s[i] !== '.' &&
+                        s[i] !== ',' &&
+                        s[i] !== nfInfo.positiveSign &&
+                        s[i] !== nfInfo.negativeSign &&
+                        s[i] !== point &&
+                        s[i] !== thousands) {
                         if (s[i].toLowerCase() === "e") {
                             countExp++;
                             if (countExp > 1) {

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -8,6 +8,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
         main: function Main () {
             Bridge.Test.Runtime.ContextHelper.Init();
             QUnit.test("#1373 - TypedArraysConstantsInExpressions", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge1373.TypedArraysConstantsInExpressions);
+            QUnit.test("#3360 - TestDoubleParse", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3360.TestDoubleParse);
             QUnit.test("#3382 - TestBaseCtor", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3382.TestBaseCtor);
             QUnit.test("#3385 - TestObjectToChar", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3385.TestObjectToChar);
             QUnit.test("#3386 - Test64bitKey", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3386.Test64bitKey);
@@ -14949,6 +14950,31 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3357", $t.File = "Batch3\\BridgeIssues\\3300\\N3357.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3360", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3360)],
+        statics: {
+            methods: {
+                TestDoubleParse: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3360).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3360, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestDoubleParse()", $t.Line = "8", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3360.TestDoubleParse();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3360", $t.File = "Batch3\\BridgeIssues\\3300\\N3360.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -27901,6 +27901,19 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3360", {
+        statics: {
+            methods: {
+                TestDoubleParse: function () {
+                    var test = { };
+                    var result = System.Double.tryParse("2/1", null, test);
+
+                    Bridge.Test.NUnit.Assert.False(result);
+                }
+            }
+        }
+    });
+
     /**
      * This test consists in ensuring types that can't be represented in
      JavaScript are converted to string when their .ToJson() method is


### PR DESCRIPTION
Fixes #3360 