### PR TITLE
[3415] Convert.ToString returning type when ToString method is available

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -16219,7 +16219,7 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
 
                     // If the object has an override to the toString() method,
                     // then just return its result
-                    if (value.toString !== window.toString) {
+                    if (value.toString !== Object.prototype.toString) {
                         return value.toString();
                     }
 

--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -16217,6 +16217,12 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
                         return "";
                     }
 
+                    // If the object has an override to the toString() method,
+                    // then just return its result
+                    if (value.toString !== window.toString) {
+                        return value.toString();
+                    }
+
                     if (Bridge.isDate(value)) {
                         return System.DateTime.format(value, null, formatProvider || null);
                     }

--- a/Bridge/Resources/Convert.js
+++ b/Bridge/Resources/Convert.js
@@ -273,7 +273,7 @@
 
                     // If the object has an override to the toString() method,
                     // then just return its result
-                    if (value.toString !== window.toString) {
+                    if (value.toString !== Object.prototype.toString) {
                         return value.toString();
                     }
 

--- a/Bridge/Resources/Convert.js
+++ b/Bridge/Resources/Convert.js
@@ -271,6 +271,12 @@
                         return "";
                     }
 
+                    // If the object has an override to the toString() method,
+                    // then just return its result
+                    if (value.toString !== window.toString) {
+                        return value.toString();
+                    }
+
                     if (Bridge.isDate(value)) {
                         return System.DateTime.format(value, null, formatProvider || null);
                     }

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -705,6 +705,7 @@
     <Compile Include="BridgeIssues\3300\N3360.cs" />
     <Compile Include="BridgeIssues\3300\N3396.cs" />
     <Compile Include="BridgeIssues\3400\N3401.cs" />
+    <Compile Include="BridgeIssues\3400\N3415.cs" />
     <Compile Include="BridgeIssues\3400\N3404.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />

--- a/Tests/Batch3/BridgeIssues/3400/N3415.cs
+++ b/Tests/Batch3/BridgeIssues/3400/N3415.cs
@@ -1,0 +1,55 @@
+using System;
+using Bridge.Test.NUnit;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    /// <summary>
+    /// The test here consists in checking whether Convert.ToString(x) acts
+    /// identically to x.ToString(), considering overrridden ToString() method
+    /// when it applies.
+    /// </summary>
+    [TestFixture(TestNameFormat = "#3415 - {0}")]
+    public class Bridge3415
+    {
+        /// <summary>
+        /// A class implementing an override to the .ToString method.
+        /// </summary>
+        public class Overriding
+        {
+            public string Value { get; set; }
+
+            public override string ToString()
+            {
+                return Value + " constant value.";
+            }
+        }
+
+        /// <summary>
+        /// A class that does not implement an override to the .ToString method.
+        /// </summary>
+        public class NotOverriding
+        {
+            public string Value { get; set; }
+        }
+
+        /// <summary>
+        /// Test overridden and not overridden class instances against the expected results.
+        /// </summary>
+        [Test]
+        public static void TestToStringOverriding()
+        {
+            var baseValue = "this is a value";
+
+            var ovr = new Overriding();
+            ovr.Value = baseValue;
+
+            var novr = new NotOverriding();
+            novr.Value = baseValue;
+
+            Assert.AreEqual(Convert.ToString(ovr), baseValue + " constant value.", "Convert.ToString() considers class' override.");
+            Assert.AreEqual(Convert.ToString(ovr), ovr.ToString(), "Convert.ToString(var) produces same result as var.ToString() when ToString() is overridden.");
+            Assert.AreEqual(Convert.ToString(novr), "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415+NotOverriding", "Convert.ToString() considers class' override.");
+            Assert.AreEqual(Convert.ToString(novr), novr.ToString(), "Convert.ToString(var) produces same result as var.ToString() when ToString() is not overridden.");
+        }
+    }
+}

--- a/Tests/Batch3/BridgeIssues/3400/N3415.cs
+++ b/Tests/Batch3/BridgeIssues/3400/N3415.cs
@@ -46,10 +46,29 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             var novr = new NotOverriding();
             novr.Value = baseValue;
 
-            Assert.AreEqual(Convert.ToString(ovr), baseValue + " constant value.", "Convert.ToString() considers class' override.");
-            Assert.AreEqual(Convert.ToString(ovr), ovr.ToString(), "Convert.ToString(var) produces same result as var.ToString() when ToString() is overridden.");
-            Assert.AreEqual(Convert.ToString(novr), "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415+NotOverriding", "Convert.ToString() considers class' override.");
-            Assert.AreEqual(Convert.ToString(novr), novr.ToString(), "Convert.ToString(var) produces same result as var.ToString() when ToString() is not overridden.");
+            Assert.AreEqual(
+                baseValue + " constant value.",
+                Convert.ToString(ovr),
+                "Convert.ToString() considers class' override."
+            );
+
+            Assert.AreEqual(
+                ovr.ToString(),
+                Convert.ToString(ovr),
+                "Convert.ToString(var) produces same result as var.ToString() when ToString() is overridden."
+            );
+
+            Assert.AreEqual(
+                "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415+NotOverriding",
+                Convert.ToString(novr),
+                "Convert.ToString() considers class' override."
+            );
+
+            Assert.AreEqual(
+                novr.ToString(),
+                Convert.ToString(novr),
+                "Convert.ToString(var) produces same result as var.ToString() when ToString() is not overridden."
+            );
         }
     }
 }

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -16219,7 +16219,7 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
 
                     // If the object has an override to the toString() method,
                     // then just return its result
-                    if (value.toString !== window.toString) {
+                    if (value.toString !== Object.prototype.toString) {
                         return value.toString();
                     }
 

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -16217,6 +16217,12 @@ Bridge.Class.addExtend(System.String, [System.IComparable$1(System.String), Syst
                         return "";
                     }
 
+                    // If the object has an override to the toString() method,
+                    // then just return its result
+                    if (value.toString !== window.toString) {
+                        return value.toString();
+                    }
+
                     if (Bridge.isDate(value)) {
                         return System.DateTime.format(value, null, formatProvider || null);
                     }

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -20,6 +20,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3396 - TestMultiDimArrayObjectLiteralDefValue", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3396.TestMultiDimArrayObjectLiteralDefValue);
             QUnit.test("#3401 - TestCustomComparer", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3401.TestCustomComparer);
             QUnit.test("#3404 - TestExtensionMethodDecimal", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3404.TestExtensionMethodDecimal);
+            QUnit.test("#3415 - TestToStringOverriding", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3415.TestToStringOverriding);
             QUnit.module("Issues3");
             QUnit.test("#69 - ThisKeywordInStructConstructorWorks", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge069.ThisKeywordInStructConstructorWorks);
             QUnit.test("#1000 - TestStaticViaChild", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge1000.TestStaticViaChild);
@@ -15842,6 +15843,32 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3404", $t.File = "Batch3\\BridgeIssues\\3400\\N3404.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3415", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415)],
+        $kind: "nested class",
+        statics: {
+            methods: {
+                TestToStringOverriding: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3415, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestToStringOverriding()", $t.Line = "38", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415.TestToStringOverriding();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415", $t.File = "Batch3\\BridgeIssues\\3400\\N3415.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -28965,10 +28965,13 @@ Bridge.$N1391Result =                     r;
                     var novr = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415.NotOverriding();
                     novr.Value = baseValue;
 
-                    Bridge.Test.NUnit.Assert.AreEqual(System.Convert.toString(ovr), (baseValue || "") + " constant value.", "Convert.ToString() considers class' override.");
-                    Bridge.Test.NUnit.Assert.AreEqual(System.Convert.toString(ovr), ovr.toString(), "Convert.ToString(var) produces same result as var.ToString() when ToString() is overridden.");
-                    Bridge.Test.NUnit.Assert.AreEqual(System.Convert.toString(novr), "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415+NotOverriding", "Convert.ToString() considers class' override.");
-                    Bridge.Test.NUnit.Assert.AreEqual(System.Convert.toString(novr), Bridge.toString(novr), "Convert.ToString(var) produces same result as var.ToString() when ToString() is not overridden.");
+                    Bridge.Test.NUnit.Assert.AreEqual((baseValue || "") + " constant value.", System.Convert.toString(ovr), "Convert.ToString() considers class' override.");
+
+                    Bridge.Test.NUnit.Assert.AreEqual(ovr.toString(), System.Convert.toString(ovr), "Convert.ToString(var) produces same result as var.ToString() when ToString() is overridden.");
+
+                    Bridge.Test.NUnit.Assert.AreEqual("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415+NotOverriding", System.Convert.toString(novr), "Convert.ToString() considers class' override.");
+
+                    Bridge.Test.NUnit.Assert.AreEqual(Bridge.toString(novr), System.Convert.toString(novr), "Convert.ToString(var) produces same result as var.ToString() when ToString() is not overridden.");
                 }
             }
         }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -28936,6 +28936,75 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    /**
+     * The test here consists in checking whether Convert.ToString(x) acts
+     identically to x.ToString(), considering overrridden ToString() method
+     when it applies.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415
+     */
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415", {
+        statics: {
+            methods: {
+                /**
+                 * Test overridden and not overridden class instances against the expected results.
+                 *
+                 * @static
+                 * @public
+                 * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415
+                 * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415
+                 * @return  {void}
+                 */
+                TestToStringOverriding: function () {
+                    var baseValue = "this is a value";
+
+                    var ovr = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415.Overriding();
+                    ovr.Value = baseValue;
+
+                    var novr = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415.NotOverriding();
+                    novr.Value = baseValue;
+
+                    Bridge.Test.NUnit.Assert.AreEqual(System.Convert.toString(ovr), (baseValue || "") + " constant value.", "Convert.ToString() considers class' override.");
+                    Bridge.Test.NUnit.Assert.AreEqual(System.Convert.toString(ovr), ovr.toString(), "Convert.ToString(var) produces same result as var.ToString() when ToString() is overridden.");
+                    Bridge.Test.NUnit.Assert.AreEqual(System.Convert.toString(novr), "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415+NotOverriding", "Convert.ToString() considers class' override.");
+                    Bridge.Test.NUnit.Assert.AreEqual(System.Convert.toString(novr), Bridge.toString(novr), "Convert.ToString(var) produces same result as var.ToString() when ToString() is not overridden.");
+                }
+            }
+        }
+    });
+
+    /**
+     * A class that does not implement an override to the .ToString method.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415.NotOverriding
+     */
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415.NotOverriding", {
+        $kind: "nested class",
+        props: {
+            Value: null
+        }
+    });
+
+    /**
+     * A class implementing an override to the .ToString method.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415.Overriding
+     */
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415.Overriding", {
+        $kind: "nested class",
+        props: {
+            Value: null
+        },
+        methods: {
+            toString: function () {
+                return (this.Value || "") + " constant value.";
+            }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge341A", {
         props: {
             Str: null


### PR DESCRIPTION
Fixes #3415 .

Changes proposed in this pull request:

- Changes the behavior of Convert.js' Convert.ToString() when the passed object has a custom implementation of ToString().