### PR TITLE
[3408] Dictionary<T, _>.Values.CopyTo NotImplemented

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -12589,17 +12589,23 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
             },
 
             getValues: function () {
-                if (this.isSimpleKey) {
-                    var values = [];
+                var values = [];
+                var entry;
 
+                if (this.isSimpleKey) {
                     for (var i = 0; i < this.keys.length; i++) {
                         values.push(this.entries[this.keys[i]].value);
                     }
-
-                    return System.Array.init(values, TValue);
+                } else {
+                    for (var i = 0; i < this.keys.length; i++) {
+                        entry = this.entries[this.keys[i]];
+                        for (var j = 0; j < entry.length; j++) {
+                            values.push(entry[j].value);
+                        }
+                    }
                 }
 
-                return new (System.Collections.Generic.DictionaryCollection$1(TValue))(this, false);
+                return System.Array.init(values, TValue);
             },
 
             clear: function () {

--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -12581,11 +12581,30 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
             },
 
             getKeys: function () {
+                var keys = [];
+                var entry;
                 if (this.isSimpleKey) {
-                    return System.Array.init(this.keys, TKey);
+                    keys = this.keys
+                } else {
+                    // FIXME: A single key may hold more than one values. So
+                    // when getting keys, should we return the repeated keys
+                    // when more than one value is bound to them, or return
+                    // just an array of unique keys?
+                    for (var i = 0; i < this.keys.length; i++) {
+                        entry = this.entries[this.keys[i]];
+
+                        // If we don't want to loop thru the entry, we should
+                        // at least throw an exception if there's more than one
+                        // element in a given key.
+                        if (entry.length != 1) {
+                            throw new System.Exception("The single dictionary key has more than one entries at key: " + this.keys[i]);
+                        }
+
+                        keys.push(entry[0].key);
+                    }
                 }
 
-                return new (System.Collections.Generic.DictionaryCollection$1(TKey))(this, true);
+                return System.Array.init(keys, TKey);
             },
 
             getValues: function () {
@@ -12599,9 +12618,12 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 } else {
                     for (var i = 0; i < this.keys.length; i++) {
                         entry = this.entries[this.keys[i]];
-                        for (var j = 0; j < entry.length; j++) {
-                            values.push(entry[j].value);
+
+                        if (entry.length != 1) {
+                            throw new System.Exception("The single dictionary value has more than one entries at key: " + this.keys[i]);
                         }
+
+                        values.push(entry[0].value);
                     }
                 }
 

--- a/Bridge/Resources/Collections/Dictionary.js
+++ b/Bridge/Resources/Collections/Dictionary.js
@@ -126,17 +126,23 @@
             },
 
             getValues: function () {
-                if (this.isSimpleKey) {
-                    var values = [];
+                var values = [];
+                var entry;
 
+                if (this.isSimpleKey) {
                     for (var i = 0; i < this.keys.length; i++) {
                         values.push(this.entries[this.keys[i]].value);
                     }
-
-                    return System.Array.init(values, TValue);
+                } else {
+                    for (var i = 0; i < this.keys.length; i++) {
+                        entry = this.entries[this.keys[i]];
+                        for (var j = 0; j < entry.length; j++) {
+                            values.push(entry[j].value);
+                        }
+                    }
                 }
 
-                return new (System.Collections.Generic.DictionaryCollection$1(TValue))(this, false);
+                return System.Array.init(values, TValue);
             },
 
             clear: function () {

--- a/Bridge/Resources/Collections/Dictionary.js
+++ b/Bridge/Resources/Collections/Dictionary.js
@@ -118,11 +118,30 @@
             },
 
             getKeys: function () {
+                var keys = [];
+                var entry;
                 if (this.isSimpleKey) {
-                    return System.Array.init(this.keys, TKey);
+                    keys = this.keys
+                } else {
+                    // FIXME: A single key may hold more than one values. So
+                    // when getting keys, should we return the repeated keys
+                    // when more than one value is bound to them, or return
+                    // just an array of unique keys?
+                    for (var i = 0; i < this.keys.length; i++) {
+                        entry = this.entries[this.keys[i]];
+
+                        // If we don't want to loop thru the entry, we should
+                        // at least throw an exception if there's more than one
+                        // element in a given key.
+                        if (entry.length != 1) {
+                            throw new System.Exception("The single dictionary key has more than one entries at key: " + this.keys[i]);
+                        }
+
+                        keys.push(entry[0].key);
+                    }
                 }
 
-                return new (System.Collections.Generic.DictionaryCollection$1(TKey))(this, true);
+                return System.Array.init(keys, TKey);
             },
 
             getValues: function () {
@@ -136,9 +155,12 @@
                 } else {
                     for (var i = 0; i < this.keys.length; i++) {
                         entry = this.entries[this.keys[i]];
-                        for (var j = 0; j < entry.length; j++) {
-                            values.push(entry[j].value);
+
+                        if (entry.length != 1) {
+                            throw new System.Exception("The single dictionary value has more than one entries at key: " + this.keys[i]);
                         }
+
+                        values.push(entry[0].value);
                     }
                 }
 

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -706,6 +706,7 @@
     <Compile Include="BridgeIssues\3300\N3360.cs" />
     <Compile Include="BridgeIssues\3300\N3396.cs" />
     <Compile Include="BridgeIssues\3400\N3401.cs" />
+    <Compile Include="BridgeIssues\3400\N3408.cs" />
     <Compile Include="BridgeIssues\3400\N3415.cs" />
     <Compile Include="BridgeIssues\3400\N3404.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />

--- a/Tests/Batch3/BridgeIssues/3400/N3408.cs
+++ b/Tests/Batch3/BridgeIssues/3400/N3408.cs
@@ -1,0 +1,41 @@
+using Bridge.Test.NUnit;
+using System.Collections.Generic;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    /// <summary>
+    /// The test here consists in checking whether copyTo works for dictionary
+    /// when its keys are instances of a class or complex structure.
+    /// </summary>
+    [TestFixture(TestNameFormat = "#3408 - {0}")]
+    public class Bridge3408
+    {
+        /// <summary>
+        /// The tests just creates an instance of a dictionary with an
+        /// empty-bodied class as its keys, adds entries then copies to a
+        /// simple array, then checks whether the value in the array is the
+        /// expected one.
+        /// </summary>
+        [Test]
+        public static void TestCpxDicCopyTo()
+        {
+            var cpx = new Dictionary<C, int>();
+
+            cpx.Add(new C(), 5);
+            cpx.Add(new C(), 7);
+            cpx.Add(new C(), 3);
+
+            var cpa = new int[3];
+            cpx.Values.CopyTo(cpa, 0);
+
+            Assert.AreEqual(5, cpa[0], "First element extracted matches.");
+            Assert.AreEqual(7, cpa[1], "Second element extracted matches.");
+            Assert.AreEqual(3, cpa[2], "Third element extracted matches.");
+        }
+
+        /// <summary>
+        /// A dummy class to serve as a "complex" key for the test dictionary.
+        /// </summary>
+        private class C { }
+    }
+}

--- a/Tests/Batch3/BridgeIssues/3400/N3408.cs
+++ b/Tests/Batch3/BridgeIssues/3400/N3408.cs
@@ -31,6 +31,13 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             Assert.AreEqual(5, cpa[0], "First element extracted matches.");
             Assert.AreEqual(7, cpa[1], "Second element extracted matches.");
             Assert.AreEqual(3, cpa[2], "Third element extracted matches.");
+
+            var cpk = new C[3];
+            cpx.Keys.CopyTo(cpk, 0);
+
+            Assert.True(cpk[0] is C, "First key extracted matches.");
+            Assert.True(cpk[1] is C, "Second key extracted matches.");
+            Assert.True(cpk[2] is C, "Third key extracted matches.");
         }
 
         /// <summary>

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -12589,17 +12589,23 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
             },
 
             getValues: function () {
-                if (this.isSimpleKey) {
-                    var values = [];
+                var values = [];
+                var entry;
 
+                if (this.isSimpleKey) {
                     for (var i = 0; i < this.keys.length; i++) {
                         values.push(this.entries[this.keys[i]].value);
                     }
-
-                    return System.Array.init(values, TValue);
+                } else {
+                    for (var i = 0; i < this.keys.length; i++) {
+                        entry = this.entries[this.keys[i]];
+                        for (var j = 0; j < entry.length; j++) {
+                            values.push(entry[j].value);
+                        }
+                    }
                 }
 
-                return new (System.Collections.Generic.DictionaryCollection$1(TValue))(this, false);
+                return System.Array.init(values, TValue);
             },
 
             clear: function () {

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -12581,11 +12581,30 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
             },
 
             getKeys: function () {
+                var keys = [];
+                var entry;
                 if (this.isSimpleKey) {
-                    return System.Array.init(this.keys, TKey);
+                    keys = this.keys
+                } else {
+                    // FIXME: A single key may hold more than one values. So
+                    // when getting keys, should we return the repeated keys
+                    // when more than one value is bound to them, or return
+                    // just an array of unique keys?
+                    for (var i = 0; i < this.keys.length; i++) {
+                        entry = this.entries[this.keys[i]];
+
+                        // If we don't want to loop thru the entry, we should
+                        // at least throw an exception if there's more than one
+                        // element in a given key.
+                        if (entry.length != 1) {
+                            throw new System.Exception("The single dictionary key has more than one entries at key: " + this.keys[i]);
+                        }
+
+                        keys.push(entry[0].key);
+                    }
                 }
 
-                return new (System.Collections.Generic.DictionaryCollection$1(TKey))(this, true);
+                return System.Array.init(keys, TKey);
             },
 
             getValues: function () {
@@ -12599,9 +12618,12 @@ Bridge.Class.addExtend(System.Boolean, [System.IComparable$1(System.Boolean), Sy
                 } else {
                     for (var i = 0; i < this.keys.length; i++) {
                         entry = this.entries[this.keys[i]];
-                        for (var j = 0; j < entry.length; j++) {
-                            values.push(entry[j].value);
+
+                        if (entry.length != 1) {
+                            throw new System.Exception("The single dictionary value has more than one entries at key: " + this.keys[i]);
                         }
+
+                        values.push(entry[0].value);
                     }
                 }
 

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -21,6 +21,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3396 - TestMultiDimArrayObjectLiteralDefValue", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3396.TestMultiDimArrayObjectLiteralDefValue);
             QUnit.test("#3401 - TestCustomComparer", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3401.TestCustomComparer);
             QUnit.test("#3404 - TestExtensionMethodDecimal", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3404.TestExtensionMethodDecimal);
+            QUnit.test("#3408 - TestCpxDicCopyTo", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3408.TestCpxDicCopyTo);
             QUnit.test("#3415 - TestToStringOverriding", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3415.TestToStringOverriding);
             QUnit.module("Issues3");
             QUnit.test("#69 - ThisKeywordInStructConstructorWorks", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge069.ThisKeywordInStructConstructorWorks);
@@ -15870,6 +15871,32 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3404", $t.File = "Batch3\\BridgeIssues\\3400\\N3404.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3408", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408)],
+        $kind: "nested class",
+        statics: {
+            methods: {
+                TestCpxDicCopyTo: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3408, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestCpxDicCopyTo()", $t.Line = "19", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408.TestCpxDicCopyTo();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408", $t.File = "Batch3\\BridgeIssues\\3400\\N3408.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -29013,6 +29013,13 @@ Bridge.$N1391Result =                     r;
                     Bridge.Test.NUnit.Assert.AreEqual(5, cpa[System.Array.index(0, cpa)], "First element extracted matches.");
                     Bridge.Test.NUnit.Assert.AreEqual(7, cpa[System.Array.index(1, cpa)], "Second element extracted matches.");
                     Bridge.Test.NUnit.Assert.AreEqual(3, cpa[System.Array.index(2, cpa)], "Third element extracted matches.");
+
+                    var cpk = System.Array.init(3, null, Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408.C);
+                    System.Array.copyTo(cpx.getKeys(), cpk, 0, Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408.C);
+
+                    Bridge.Test.NUnit.Assert.True(Bridge.hasValue(cpk[System.Array.index(0, cpk)]), "First key extracted matches.");
+                    Bridge.Test.NUnit.Assert.True(Bridge.hasValue(cpk[System.Array.index(1, cpk)]), "Second key extracted matches.");
+                    Bridge.Test.NUnit.Assert.True(Bridge.hasValue(cpk[System.Array.index(2, cpk)]), "Third key extracted matches.");
                 }
             }
         }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -28979,6 +28979,56 @@ Bridge.$N1391Result =                     r;
     });
 
     /**
+     * The test here consists in checking whether copyTo works for dictionary
+     when its keys are instances of a class or complex structure.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408
+     */
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408", {
+        statics: {
+            methods: {
+                /**
+                 * The tests just creates an instance of a dictionary with an
+                 empty-bodied class as its keys, adds entries then copies to a
+                 simple array, then checks whether the value in the array is the
+                 expected one.
+                 *
+                 * @static
+                 * @public
+                 * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408
+                 * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408
+                 * @return  {void}
+                 */
+                TestCpxDicCopyTo: function () {
+                    var cpx = new (System.Collections.Generic.Dictionary$2(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408.C,System.Int32))();
+
+                    cpx.add(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408.C(), 5);
+                    cpx.add(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408.C(), 7);
+                    cpx.add(new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408.C(), 3);
+
+                    var cpa = System.Array.init(3, 0, System.Int32);
+                    System.Array.copyTo(cpx.getValues(), cpa, 0, System.Int32);
+
+                    Bridge.Test.NUnit.Assert.AreEqual(5, cpa[System.Array.index(0, cpa)], "First element extracted matches.");
+                    Bridge.Test.NUnit.Assert.AreEqual(7, cpa[System.Array.index(1, cpa)], "Second element extracted matches.");
+                    Bridge.Test.NUnit.Assert.AreEqual(3, cpa[System.Array.index(2, cpa)], "Third element extracted matches.");
+                }
+            }
+        }
+    });
+
+    /**
+     * A dummy class to serve as a "complex" key for the test dictionary.
+     *
+     * @private
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408.C
+     */
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3408.C", {
+        $kind: "nested class"
+    });
+
+    /**
      * The test here consists in checking whether Convert.ToString(x) acts
      identically to x.ToString(), considering overrridden ToString() method
      when it applies.


### PR DESCRIPTION
Fixes #3408 .

Changes proposed in this pull request:

- Changes System.Collections.Generic.Dictionary.getValue() client-side implementation to return an array of values when the dictionary keys are complex.
- Adds unit tests