### PR TITLE
[3418] Template attribute does not work on event if the `{this}` placeholder is missing

### DIFF
--- a/Compiler/Translator/Emitter/Blocks/MemberReferenceBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/MemberReferenceBlock.cs
@@ -926,7 +926,9 @@ namespace Bridge.Translator
                     {
                         new InlineArgumentsBlock(this.Emitter, new ArgumentsInfo(this.Emitter, memberReferenceExpression, resolveResult), inline, (IMethod)member.Member, targetrr).EmitFunctionReference();
                     }
-                    else if (resolveResult is InvocationResolveResult || (member.Member.SymbolKind == SymbolKind.Property && this.Emitter.IsAssignment))
+                    else if (resolveResult is InvocationResolveResult ||
+                        (member.Member.SymbolKind == SymbolKind.Property && this.Emitter.IsAssignment) ||
+                        (member.Member != null && member.Member is IEvent))
                     {
                         this.PushWriter(inline);
                     }

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -706,6 +706,7 @@
     <Compile Include="BridgeIssues\3300\N3360.cs" />
     <Compile Include="BridgeIssues\3300\N3396.cs" />
     <Compile Include="BridgeIssues\3400\N3401.cs" />
+    <Compile Include="BridgeIssues\3400\N3418.cs" />
     <Compile Include="BridgeIssues\3400\N3415.cs" />
     <Compile Include="BridgeIssues\3400\N3404.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />

--- a/Tests/Batch3/BridgeIssues/3400/N3418.cs
+++ b/Tests/Batch3/BridgeIssues/3400/N3418.cs
@@ -1,0 +1,51 @@
+using System;
+using Bridge.Test.NUnit;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    /// <summary>
+    /// The test here consists in checking whether templates on events would
+    /// replace the {value} placeholder even if the {this} placeholder is not
+    /// specified.
+    /// </summary>
+    [TestFixture(TestNameFormat = "#3418 - {0}")]
+    public class Bridge3418
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public event Action OnDragEnd
+        {
+            [Template("status = '{value}+';")]
+            add { }
+            [Template("{this}.status = '{value}-';")]
+            remove { }
+        }
+
+        public string status { get; set; }
+
+        static void Handler()
+        {
+        }
+
+        /// <summary>
+        /// Instantiate the class and check whether the template code produces
+        /// the expected side effects in the environment.
+        /// </summary>
+        [Test]
+        public static void TestEventTemplate()
+        {
+            var expected = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418.Handler";
+
+            var program = new Bridge3418();
+            program.status = "none";
+            Assert.AreEqual("none", program.status, "Status variable reads 'none'.");
+
+            program.OnDragEnd += Handler;
+            Assert.AreEqual(expected + "+", program.status, "Template applied correctly for event.add().");
+
+            program.OnDragEnd -= Handler;
+            Assert.AreEqual(expected + "-", program.status, "Template applied correctly for event.remove().");
+        }
+    }
+}

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -22,6 +22,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3401 - TestCustomComparer", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3401.TestCustomComparer);
             QUnit.test("#3404 - TestExtensionMethodDecimal", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3404.TestExtensionMethodDecimal);
             QUnit.test("#3415 - TestToStringOverriding", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3415.TestToStringOverriding);
+            QUnit.test("#3418 - TestEventTemplate", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3418.TestEventTemplate);
             QUnit.module("Issues3");
             QUnit.test("#69 - ThisKeywordInStructConstructorWorks", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge069.ThisKeywordInStructConstructorWorks);
             QUnit.test("#1000 - TestStaticViaChild", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge1000.TestStaticViaChild);
@@ -15896,6 +15897,32 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3415", $t.File = "Batch3\\BridgeIssues\\3400\\N3415.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3418", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418)],
+        $kind: "nested class",
+        statics: {
+            methods: {
+                TestEventTemplate: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3418, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestEventTemplate()", $t.Line = "35", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418.TestEventTemplate();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418", $t.File = "Batch3\\BridgeIssues\\3400\\N3418.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -29050,6 +29050,74 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    /** @namespace System */
+
+    /**
+     * @memberof System
+     * @callback System.Action
+     * @return  {void}
+     */
+
+    /**
+     * The test here consists in checking whether templates on events would
+     replace the {value} placeholder even if the {this} placeholder is not
+     specified.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418
+     */
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418", {
+        statics: {
+            methods: {
+                Handler: function () { },
+                /**
+                 * Instantiate the class and check whether the template code produces
+                 the expected side effects in the environment.
+                 *
+                 * @static
+                 * @public
+                 * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418
+                 * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418
+                 * @return  {void}
+                 */
+                TestEventTemplate: function () {
+                    var expected = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418.Handler";
+
+                    var program = new Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418();
+                    program.status = "none";
+                    Bridge.Test.NUnit.Assert.AreEqual("none", program.status, "Status variable reads 'none'.");
+
+                    program.status = 'Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418.Handler+';;
+                    Bridge.Test.NUnit.Assert.AreEqual((expected || "") + "+", program.status, "Template applied correctly for event.add().");
+
+                    program.status = 'Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418.Handler-';;
+                    Bridge.Test.NUnit.Assert.AreEqual((expected || "") + "-", program.status, "Template applied correctly for event.remove().");
+                }
+            }
+        },
+        props: {
+            status: null
+        },
+        methods: {
+            /**
+             * @instance
+             * @public
+             * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418
+             * @event Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418#OnDragEnd
+             * @return  {System.Action}
+             */
+            addOnDragEnd: function (value) { },
+            /**
+             * @instance
+             * @public
+             * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418
+             * @event Bridge.ClientTest.Batch3.BridgeIssues.Bridge3418#OnDragEnd
+             * @return  {System.Action}
+             */
+            removeOnDragEnd: function (value) { }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge341A", {
         props: {
             Str: null
@@ -39957,8 +40025,6 @@ Bridge.$N1391Result =                     r;
         },
         alias: ["Value", "Bridge$ClientTest$Batch3$BridgeIssues$Bridge3222$IProperty$1$" + Bridge.getTypeAlias(T) + "$Value$1"]
     }; });
-
-    /** @namespace System */
 
     /**
      * @memberof System


### PR DESCRIPTION
Fixes #3418.

Changes proposed in this pull request:

- Fixes events' templates not parsing `{value}` tokens correctly when no `{this}` token is provided.
- Adds unit tests