### PR TITLE
[3203] May object.Keys() method be renamed to something less generic

### DIFF
--- a/Bridge/System/Collections/Generic/Dictionary.cs
+++ b/Bridge/System/Collections/Generic/Dictionary.cs
@@ -37,7 +37,7 @@ namespace System.Collections.Generic
             get;
         }
 
-        new public extern ICollection<TKey> Keys
+        public extern ICollection<TKey> Keys
         {
             [Bridge.Template("getKeys()")]
             get;

--- a/Bridge/System/Object.cs
+++ b/Bridge/System/Object.cs
@@ -65,11 +65,6 @@ namespace System
         public virtual extern int GetHashCode();
 
         [Bridge.Convention(Bridge.Notation.CamelCase)]
-        [Bridge.Template("Object.keys({obj})")]
-        [Bridge.Unbox(true)]
-        public static extern string[] Keys(object obj);
-
-        [Bridge.Convention(Bridge.Notation.CamelCase)]
         [Bridge.Template("Object.getOwnPropertyNames({obj})")]
         [Bridge.Unbox(true)]
         public static extern string[] GetOwnPropertyNames(object obj);

--- a/Tests/Batch1/Collections/Generic/IDictionaryTests.cs
+++ b/Tests/Batch1/Collections/Generic/IDictionaryTests.cs
@@ -45,7 +45,7 @@ namespace Bridge.ClientTest.Collections.Generic
                 }
             }
 
-            public new ICollection<int> Keys
+            public ICollection<int> Keys
             {
                 get
                 {

--- a/Tests/Batch1/Collections/Generic/IReadOnlyDictionaryTests.cs
+++ b/Tests/Batch1/Collections/Generic/IReadOnlyDictionaryTests.cs
@@ -32,7 +32,7 @@ namespace Bridge.ClientTest.Collections.Generic
                 }
             }
 
-            public new IEnumerable<int> Keys
+            public IEnumerable<int> Keys
             {
                 get
                 {

--- a/Tests/Batch3/BridgeIssues/2100/N2141.cs
+++ b/Tests/Batch3/BridgeIssues/2100/N2141.cs
@@ -22,7 +22,6 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
                 Name = "test"
             };
 
-            Assert.AreEqual(1, Object.Keys(config).Length);
             Assert.AreEqual("test", config.Name);
         }
     }

--- a/Tests/Batch3/BridgeIssues/TestBridgeIssues.cs
+++ b/Tests/Batch3/BridgeIssues/TestBridgeIssues.cs
@@ -265,7 +265,7 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             }
         }
 
-        public new ICollection<int> Keys
+        public ICollection<int> Keys
         {
             get
             {

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -14804,7 +14804,6 @@ Bridge.$N1391Result =                     r;
                 TestExternalObjectLiteral: function () {
                     var config = { Name: "test" };
 
-                    Bridge.Test.NUnit.Assert.AreEqual(1, Object.keys(config).length);
                     Bridge.Test.NUnit.Assert.AreEqual("test", config.Name);
                 }
             }


### PR DESCRIPTION
Fixes #3203.

Branch needed to be rebased and this replaces pr #3487.