### PR TITLE
New CSProj format support

### DIFF
--- a/.build/files/Bridge.Min.targets
+++ b/.build/files/Bridge.Min.targets
@@ -6,6 +6,7 @@
     <NoStdLib>True</NoStdLib>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <AdditionalExplicitAssemblyReferences />
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <OnWin>false</OnWin>
     <OnWin Condition="'$(OS)' == 'Windows_NT'">true</OnWin>
   </PropertyGroup>


### PR DESCRIPTION
Implements Bridge.Min package's support for building projects following the new, cleaner format introduced by newer netcore technology.

Basically requires the `DisableImplicitFrameworkReferences`, in congruence with pull request #3341, but without all the changes it introduces.