### PR TITLE
[3558] Unused local function throws NullReferenceException

### DIFF
--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -730,6 +730,7 @@
     <Compile Include="BridgeIssues\3500\N3502.cs" />
     <Compile Include="BridgeIssues\3500\N3513.cs" />
     <Compile Include="BridgeIssues\3500\N3516.cs" />
+    <Compile Include="BridgeIssues\3500\N3558.cs" />
     <Compile Include="BridgeIssues\3500\N3519.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />

--- a/Tests/Batch3/BridgeIssues/3500/N3558.cs
+++ b/Tests/Batch3/BridgeIssues/3500/N3558.cs
@@ -5,9 +5,16 @@ using System.Linq;
 
 namespace Bridge.ClientTest.Batch3.BridgeIssues
 {
+    /// <summary>
+    /// The test here consists in ensuring code built with local function
+    /// definitions that are not actually referenced can be built with Bridge.
+    /// </summary>
     [TestFixture(TestNameFormat = "#3558 - {0}")]
     public class Bridge3558
     {
+        /// <summary>
+        /// 
+        /// </summary>
         [Test]
         public static void TestUnusedLocalFn()
         {
@@ -16,9 +23,7 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
             bool test() => a > 10;
 #pragma warning restore CS8321 // Local function is declared but never used
 
-            {
-                Assert.AreEqual(15, a);
-            }
+            Assert.AreEqual(15, a, "Unused local function does not result in broken Bridge code.");
         }
     }
 }

--- a/Tests/Batch3/BridgeIssues/3500/N3558.cs
+++ b/Tests/Batch3/BridgeIssues/3500/N3558.cs
@@ -1,0 +1,24 @@
+using Bridge.Html5;
+using Bridge.Test.NUnit;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [TestFixture(TestNameFormat = "#3558 - {0}")]
+    public class Bridge3558
+    {
+        [Test]
+        public static void TestUnusedLocalFn()
+        {
+            var a = 15;
+#pragma warning disable CS8321 // Local function is declared but never used
+            bool test() => a > 10;
+#pragma warning restore CS8321 // Local function is declared but never used
+
+            {
+                Assert.AreEqual(15, a);
+            }
+        }
+    }
+}

--- a/Tests/Batch3/BridgeIssues/3500/N3558.cs
+++ b/Tests/Batch3/BridgeIssues/3500/N3558.cs
@@ -13,7 +13,7 @@ namespace Bridge.ClientTest.Batch3.BridgeIssues
     public class Bridge3558
     {
         /// <summary>
-        /// 
+        /// Test by defining a local function and never actually referencing it.
         /// </summary>
         [Test]
         public static void TestUnusedLocalFn()

--- a/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
+++ b/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
@@ -23793,7 +23793,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
                 },
                 ExpressioNBodiedLocalFunctionsTests: function (assert) {
                     var $t;
-                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.CSharp7.TestLocalFunctions).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.TestLocalFunctions, 5, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "ExpressioNBodiedLocalFunctionsTests()", $t.Line = "48", $t));
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.CSharp7.TestLocalFunctions).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestRunner.TestLocalFunctions, 5, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "ExpressioNBodiedLocalFunctionsTests()", $t.Line = "59", $t));
                     Bridge.ClientTest.CSharp7.TestLocalFunctions.ExpressioNBodiedLocalFunctionsTests();
                 }
             }

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -16567,7 +16567,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             methods: {
                 TestUnusedLocalFn: function (assert) {
                     var $t;
-                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3558, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestUnusedLocalFn()", $t.Line = "11", $t));
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3558, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestUnusedLocalFn()", $t.Line = "18", $t));
                     Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558.TestUnusedLocalFn();
                 }
             }

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -32,6 +32,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3516 - TestManagedExternalCastRule", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3516.TestManagedExternalCastRule);
             QUnit.test("#3516 - TestDefaultExternalCastRule", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3516.TestDefaultExternalCastRule);
             QUnit.test("#3519 - TestInjectScript", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3519.TestInjectScript);
+            QUnit.test("#3558 - TestUnusedLocalFn", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3558.TestUnusedLocalFn);
             QUnit.module("Issues3");
             QUnit.test("#69 - ThisKeywordInStructConstructorWorks", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge069.ThisKeywordInStructConstructorWorks);
             QUnit.test("#1000 - TestStaticViaChild", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge1000.TestStaticViaChild);
@@ -16553,6 +16554,32 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3519", $t.File = "Batch3\\BridgeIssues\\3500\\N3519.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3558", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558)],
+        $kind: "nested class",
+        statics: {
+            methods: {
+                TestUnusedLocalFn: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3558, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestUnusedLocalFn()", $t.Line = "11", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558.TestUnusedLocalFn();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558", $t.File = "Batch3\\BridgeIssues\\3500\\N3558.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -31341,6 +31341,8 @@ Bridge.$N1391Result =                     r;
         statics: {
             methods: {
                 /**
+                 * Test by defining a local function and never actually referencing it.
+                 *
                  * @static
                  * @public
                  * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -31330,21 +31330,30 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    /**
+     * The test here consists in ensuring code built with local function
+     definitions that are not actually referenced can be built with Bridge.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558
+     */
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558", {
         statics: {
             methods: {
+                /**
+                 * @static
+                 * @public
+                 * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558
+                 * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558
+                 * @return  {void}
+                 */
                 TestUnusedLocalFn: function () {
                     var a = 15;
                     var test = function () {
                         return a > 10;
-                    }; /// Local function is declared but never used
+                    }; /// Local function is declared but never used /// Local function is declared but never used
 
-
-
-
-                    {
-                        Bridge.Test.NUnit.Assert.AreEqual(15, a);
-                    }
+                    Bridge.Test.NUnit.Assert.AreEqual(15, a, "Unused local function does not result in broken Bridge code.");
                 }
             }
         }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -31330,6 +31330,26 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3558", {
+        statics: {
+            methods: {
+                TestUnusedLocalFn: function () {
+                    var a = 15;
+                    var test = function () {
+                        return a > 10;
+                    }; /// Local function is declared but never used
+
+
+
+
+                    {
+                        Bridge.Test.NUnit.Assert.AreEqual(15, a);
+                    }
+                }
+            }
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge381", {
         statics: {
             methods: {


### PR DESCRIPTION
Also Local fn with directives is replaced incorrectly

Fixes #3558.