### PR TITLE
[3621] DateTime.Date() returns different results if only the seconds field differs in UTC times

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -10313,7 +10313,7 @@
                 if (isUTC === true) {
                     dt.setUTCHours(0);
                     dt.setUTCMinutes(0);
-                    dt.setUTCMinutes(0);
+                    dt.setUTCSeconds(0);
                     dt.setUTCMilliseconds(0);
                 } else {
                     dt.setHours(0);

--- a/Bridge/Resources/Date.js
+++ b/Bridge/Resources/Date.js
@@ -1151,7 +1151,7 @@
                 if (isUTC === true) {
                     dt.setUTCHours(0);
                     dt.setUTCMinutes(0);
-                    dt.setUTCMinutes(0);
+                    dt.setUTCSeconds(0);
                     dt.setUTCMilliseconds(0);
                 } else {
                     dt.setHours(0);

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -755,6 +755,7 @@
     <Compile Include="BridgeIssues\3600\N3609.cs" />
     <Compile Include="BridgeIssues\3600\N3612.cs" />
     <Compile Include="BridgeIssues\3600\N3613.cs" />
+    <Compile Include="BridgeIssues\3600\N3621.cs" />
     <Compile Include="BridgeIssues\3600\N3622.cs" />
     <Compile Include="BridgeIssues\3600\N3625.cs" />
     <Compile Include="BridgeIssues\3600\N3626.cs" />

--- a/Tests/Batch3/BridgeIssues/3600/N3621.cs
+++ b/Tests/Batch3/BridgeIssues/3600/N3621.cs
@@ -1,0 +1,40 @@
+using Bridge.Test.NUnit;
+using System;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    /// <summary>
+    /// Ensures DateTime.AddSeconds() wont change the current day as long as
+    /// the time addition does not switch to a different day.
+    /// </summary>
+    [TestFixture(TestNameFormat = "#3621 - {0}")]
+    public class Bridge3621
+    {
+        /// <summary>
+        /// Creates a DateTime object, then incrementing one of the time units
+        /// to it; By the provided time, it shouldn't switch to the next day
+        /// thus the 'Date' component of the object should be equal across the
+        /// two copies.
+        /// </summary>
+        [Test]
+        public static void TestDateFromDateTime()
+        {
+            DateTime first = new DateTime(2018, 5, 5, 1, 1, 1, 1, DateTimeKind.Utc);
+
+            DateTime second = first.AddSeconds(1);
+            Assert.AreEqual(first.Date, second.Date, "DateTime's 'Date' is not affected by adding seconds, as long as the change do not switch the current day/month/year.");
+
+            second = first.AddMinutes(1);
+            Assert.AreEqual(first.Date, second.Date, "DateTime's 'Date' is not affected by adding minutes.");
+
+            second = first.AddHours(1);
+            Assert.AreEqual(first.Date, second.Date, "DateTime's 'Date' is not affected by adding hours.");
+
+            second = first.AddMilliseconds(100);
+            Assert.AreEqual(first.Date, second.Date, "DateTime's 'Date' is not affected by adding milisseconds.");
+
+            second = first.AddTicks(250);
+            Assert.AreEqual(first.Date, second.Date, "DateTime's 'Date' is not affected by adding to the tick count.");
+        }
+    }
+}

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -10313,7 +10313,7 @@
                 if (isUTC === true) {
                     dt.setUTCHours(0);
                     dt.setUTCMinutes(0);
-                    dt.setUTCMinutes(0);
+                    dt.setUTCSeconds(0);
                     dt.setUTCMilliseconds(0);
                 } else {
                     dt.setHours(0);

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -63,6 +63,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3609 - TestIndexerTemplate", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3609.TestIndexerTemplate);
             QUnit.test("#3612 - TestEnumNullable", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3612.TestEnumNullable);
             QUnit.test("#3613 - TestUnboxCast", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3613.TestUnboxCast);
+            QUnit.test("#3621 - TestDateFromDateTime", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3621.TestDateFromDateTime);
             QUnit.test("#3622 - TestExternalBaseDefaultCtor", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3622.TestExternalBaseDefaultCtor);
             QUnit.test("#3625 - TestLocalFns", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3625.TestLocalFns);
             QUnit.test("#3626 - TestStringFormat", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3626.TestStringFormat);
@@ -17216,6 +17217,32 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3613", $t.File = "Batch3\\BridgeIssues\\3600\\N3613.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3621", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3621)],
+        $kind: "nested class",
+        statics: {
+            methods: {
+                TestDateFromDateTime: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3621).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3621, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestDateFromDateTime()", $t.Line = "19", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3621.TestDateFromDateTime();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3621", $t.File = "Batch3\\BridgeIssues\\3600\\N3621.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -33774,6 +33774,50 @@ Bridge.$N1391Result =                     r;
     });
 
     /**
+     * Ensures DateTime.AddSeconds() wont change the current day as long as
+     the time addition does not switch to a different day.
+     *
+     * @public
+     * @class Bridge.ClientTest.Batch3.BridgeIssues.Bridge3621
+     */
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3621", {
+        statics: {
+            methods: {
+                /**
+                 * Creates a DateTime object, then incrementing one of the time units
+                 to it; By the provided time, it shouldn't switch to the next day
+                 thus the 'Date' component of the object should be equal across the
+                 two copies.
+                 *
+                 * @static
+                 * @public
+                 * @this Bridge.ClientTest.Batch3.BridgeIssues.Bridge3621
+                 * @memberof Bridge.ClientTest.Batch3.BridgeIssues.Bridge3621
+                 * @return  {void}
+                 */
+                TestDateFromDateTime: function () {
+                    var first = System.DateTime.create(2018, 5, 5, 1, 1, 1, 1, 1);
+
+                    var second = System.DateTime.addSeconds(first, 1);
+                    Bridge.Test.NUnit.Assert.AreEqual(System.DateTime.getDate(first), System.DateTime.getDate(second), "DateTime's 'Date' is not affected by adding seconds, as long as the change do not switch the current day/month/year.");
+
+                    second = System.DateTime.addMinutes(first, 1);
+                    Bridge.Test.NUnit.Assert.AreEqual(System.DateTime.getDate(first), System.DateTime.getDate(second), "DateTime's 'Date' is not affected by adding minutes.");
+
+                    second = System.DateTime.addHours(first, 1);
+                    Bridge.Test.NUnit.Assert.AreEqual(System.DateTime.getDate(first), System.DateTime.getDate(second), "DateTime's 'Date' is not affected by adding hours.");
+
+                    second = System.DateTime.addMilliseconds(first, 100);
+                    Bridge.Test.NUnit.Assert.AreEqual(System.DateTime.getDate(first), System.DateTime.getDate(second), "DateTime's 'Date' is not affected by adding milisseconds.");
+
+                    second = System.DateTime.addTicks(first, System.Int64(250));
+                    Bridge.Test.NUnit.Assert.AreEqual(System.DateTime.getDate(first), System.DateTime.getDate(second), "DateTime's 'Date' is not affected by adding to the tick count.");
+                }
+            }
+        }
+    });
+
+    /**
      * Ensuring base class calling works even when inheriting from an
      external class.
      *


### PR DESCRIPTION
Fixes #3621.