### PR TITLE
[3631] Renames Bridge.Builder.v16.dll to v17

### DIFF
--- a/.build/files/Bridge.Min.targets
+++ b/.build/files/Bridge.Min.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="BridgeCompilerTask" AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Bridge.Builder.v16.dll" />
+  <UsingTask TaskName="BridgeCompilerTask" AssemblyFile="$(MSBuildThisFileDirectory)..\tools\Bridge.Builder.v17.dll" />
 
   <PropertyGroup>
     <NoStdLib>True</NoStdLib>

--- a/.build/specs/Bridge.Min.nuspec
+++ b/.build/specs/Bridge.Min.nuspec
@@ -28,7 +28,7 @@
     <file src="../../.build/files/Bridge.Min.targets" target="build/Bridge.Min.targets" />
 
     <!--tools-->
-    <file src="../../Compiler/Build/bin/Release/Bridge.Build.dll" target="tools/Bridge.Builder.v16.dll" />
+    <file src="../../Compiler/Build/bin/Release/Bridge.Build.dll" target="tools/Bridge.Builder.v17.dll" />
     <file src="../../Compiler/Build/bin/Release/Bridge.Contract.dll" target="tools/Bridge.Contract.dll" />
     <file src="../../Compiler/Build/bin/Release/Bridge.Translator.dll" target="tools/Bridge.Translator.dll" />
     <file src="../../Compiler/Builder/bin/Release/bridge.exe" target="tools/bridge.exe" />


### PR DESCRIPTION
The change is applied in the .nuspec file for Bridge.Min and reflects
in the generated (and extracted) NuGet package.
Also the reference for the file within the corresponding .targets file
needed to be updated.