### PR TITLE
[3700] emit | null in generated .d.ts for all C# Reference types

### DIFF
--- a/Bridge/Attributes/OptionalAttribute.cs
+++ b/Bridge/Attributes/OptionalAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Bridge
+{
+    /// <summary>
+    /// Attribute modifies the generated .d.ts to include the TypeScript ? optional modifier.
+    /// </summary>
+    [NonScriptable]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public sealed class OptionalAttribute : Attribute
+    {
+    }
+}

--- a/Bridge/Bridge.csproj
+++ b/Bridge/Bridge.csproj
@@ -54,6 +54,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Attributes\Convention.cs" />
+    <Compile Include="Attributes\OptionalAttribute.cs" />
     <Compile Include="Attributes\PrivateProtectedAttribute.cs" />
     <Compile Include="Attributes\ExternalInterfaceAttribute.cs" />
     <Compile Include="Attributes\CastAttribute.cs" />

--- a/Compiler/Translator/Emitter/TypeScript/ConstructorBlock.cs
+++ b/Compiler/Translator/Emitter/TypeScript/ConstructorBlock.cs
@@ -4,6 +4,7 @@ using ICSharpCode.NRefactory.CSharp;
 using Object.Net.Utilities;
 using System.Collections.Generic;
 using System.Linq;
+using ICSharpCode.NRefactory.TypeSystem;
 
 namespace Bridge.Translator.TypeScript
 {
@@ -128,6 +129,12 @@ namespace Bridge.Translator.TypeScript
                 this.WriteColon();
                 name = BridgeTypes.ToTypeScriptName(p.Type, this.Emitter);
                 this.Write(name);
+
+                var resolveResult = this.Emitter.Resolver.ResolveNode(p.Type, this.Emitter);
+                if (resolveResult != null && (resolveResult.Type.IsReferenceType.HasValue && resolveResult.Type.IsReferenceType.Value || resolveResult.Type.IsKnownType(KnownTypeCode.NullableOfT)))
+                {
+                    this.Write(" | null");
+                }
             }
 
             this.WriteCloseParentheses();

--- a/Compiler/Translator/Emitter/TypeScript/MethodBlock.cs
+++ b/Compiler/Translator/Emitter/TypeScript/MethodBlock.cs
@@ -108,6 +108,12 @@ namespace Bridge.Translator.TypeScript
             var retType = BridgeTypes.ToTypeScriptName(methodDeclaration.ReturnType, this.Emitter);
             this.Write(retType);
 
+            var resolveResult = this.Emitter.Resolver.ResolveNode(methodDeclaration.ReturnType, this.Emitter);
+            if (resolveResult != null && (resolveResult.Type.IsReferenceType.HasValue && resolveResult.Type.IsReferenceType.Value || resolveResult.Type.IsKnownType(KnownTypeCode.NullableOfT)))
+            {
+                this.Write(" | null");
+            }
+
             this.WriteSemiColon();
             this.WriteNewLine();
         }
@@ -136,6 +142,13 @@ namespace Bridge.Translator.TypeScript
 
                 this.WriteColon();
                 name = BridgeTypes.ToTypeScriptName(p.Type, this.Emitter);
+
+                var resolveResult = this.Emitter.Resolver.ResolveNode(p.Type, this.Emitter);
+                if (resolveResult != null && (resolveResult.Type.IsReferenceType.HasValue && resolveResult.Type.IsReferenceType.Value || resolveResult.Type.IsKnownType(KnownTypeCode.NullableOfT)))
+                {
+                    name += " | null";
+                }
+
                 if (p.ParameterModifier == ParameterModifier.Out || p.ParameterModifier == ParameterModifier.Ref)
                 {
                     name = "{v: " + name + "}";

--- a/Compiler/Translator/Emitter/TypeScript/PropertyBlock.cs
+++ b/Compiler/Translator/Emitter/TypeScript/PropertyBlock.cs
@@ -61,9 +61,23 @@ namespace Bridge.Translator.TypeScript
         {
             string name = Helpers.GetPropertyRef(memberResult.Member, this.Emitter, false, false, ignoreInterface);
             this.Write(name);
+
+            var property_rr = this.Emitter.Resolver.ResolveNode(p, this.Emitter);
+            if (property_rr is MemberResolveResult mrr && mrr.Member.Attributes.Any(a => a.AttributeType.FullName == "Bridge.OptionalAttribute"))
+            {
+                this.Write("?");
+            }
+
             this.WriteColon();
             name = BridgeTypes.ToTypeScriptName(p.ReturnType, this.Emitter);
             this.Write(name);
+
+            var resolveResult = this.Emitter.Resolver.ResolveNode(p.ReturnType, this.Emitter);
+            if (resolveResult != null && (resolveResult.Type.IsReferenceType.HasValue && resolveResult.Type.IsReferenceType.Value || resolveResult.Type.IsKnownType(KnownTypeCode.NullableOfT)))
+            {
+                this.Write(" | null");
+            }
+
             this.WriteSemiColon();
             this.WriteNewLine();
         }


### PR DESCRIPTION
[3700] emit | null in generated .d.ts for all C# Reference types
[3701] C# Nullable Types should emit | null in generated .d.ts file
[3702] Proposal: New [Optional] Attribute
Fixes #3700 #3701 #3702 