### PR TITLE
change clearTime in order to fix issue 3757

### DIFF
--- a/Bridge/Resources/Date.js
+++ b/Bridge/Resources/Date.js
@@ -1153,13 +1153,17 @@
                     dt.setUTCMinutes(0);
                     dt.setUTCSeconds(0);
                     dt.setUTCMilliseconds(0);
+                    dt.kind = 1;
                 } else {
                     dt.setHours(0);
                     dt.setMinutes(0);
                     dt.setSeconds(0);
                     dt.setMilliseconds(0);
+                    dt.kind = 2;
                 }
 
+                dt.ticks = this.getTicks(dt);
+                
                 return dt;
             },
 

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -776,6 +776,7 @@
     <Compile Include="BridgeIssues\3700\N3713.cs" />
     <Compile Include="BridgeIssues\3700\N3714.cs" />
     <Compile Include="BridgeIssues\3700\N3728.cs" />
+    <Compile Include="BridgeIssues\3700\N3757.cs" />
     <Compile Include="BridgeIssues\3700\N3733.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />

--- a/Tests/Batch3/BridgeIssues/3700/N3757.cs
+++ b/Tests/Batch3/BridgeIssues/3700/N3757.cs
@@ -1,0 +1,21 @@
+using Bridge.Test.NUnit;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [TestFixture(TestNameFormat = "#3757 - {0}")]
+    public class Bridge3757
+    {
+        [Test]
+        public static void TestDate()
+        {
+            var a = new System.DateTime(2001, 2, 3, 4, 5, 6).Date;
+            var b = new System.DateTime(2001, 2, 3, 4, 5, 7);
+            var c = new System.DateTime(2001, 2, 3, 4, 5, 8).Date;
+            
+            Assert.True(!b.Equals(a)); //gist of issue: throws exception due to wrong DateTime.js $clearTime
+            //next two are safety guards that fix doesn't introduce new bugs
+            Assert.True(!a.Equals(b));
+            Assert.True(a.Equals(c));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3757 

Changes proposed in this pull request:
- datetime misses kind and ticks causing Equals() to fail later