### PR TITLE
[3902] C# strings with unicode escapes can be incorrectly translated …

### DIFF
--- a/Bridge/Resources/.generated/System/Globalization/DateTimeFormatInfoScanner.js
+++ b/Bridge/Resources/.generated/System/Globalization/DateTimeFormatInfoScanner.js
@@ -51,19 +51,19 @@
                 init: function () {
                     this.MonthPostfixChar = 57344;
                     this.IgnorableSymbolChar = 57345;
-                    this.CJKYearSuff = "年";
-                    this.CJKMonthSuff = "月";
-                    this.CJKDaySuff = "日";
-                    this.KoreanYearSuff = "년";
-                    this.KoreanMonthSuff = "월";
-                    this.KoreanDaySuff = "일";
-                    this.KoreanHourSuff = "시";
-                    this.KoreanMinuteSuff = "분";
-                    this.KoreanSecondSuff = "초";
-                    this.CJKHourSuff = "時";
-                    this.ChineseHourSuff = "时";
-                    this.CJKMinuteSuff = "分";
-                    this.CJKSecondSuff = "秒";
+                    this.CJKYearSuff = "\u5e74";
+                    this.CJKMonthSuff = "\u6708";
+                    this.CJKDaySuff = "\u65e5";
+                    this.KoreanYearSuff = "\ub144";
+                    this.KoreanMonthSuff = "\uc6d4";
+                    this.KoreanDaySuff = "\uc77c";
+                    this.KoreanHourSuff = "\uc2dc";
+                    this.KoreanMinuteSuff = "\ubd84";
+                    this.KoreanSecondSuff = "\ucd08";
+                    this.CJKHourSuff = "\u6642";
+                    this.ChineseHourSuff = "\u65f6";
+                    this.CJKMinuteSuff = "\u5206";
+                    this.CJKSecondSuff = "\u79d2";
                 }
             },
             methods: {

--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -42062,19 +42062,19 @@ if (typeof window !== 'undefined' && window.performance && window.performance.no
                 init: function () {
                     this.MonthPostfixChar = 57344;
                     this.IgnorableSymbolChar = 57345;
-                    this.CJKYearSuff = "年";
-                    this.CJKMonthSuff = "月";
-                    this.CJKDaySuff = "日";
-                    this.KoreanYearSuff = "년";
-                    this.KoreanMonthSuff = "월";
-                    this.KoreanDaySuff = "일";
-                    this.KoreanHourSuff = "시";
-                    this.KoreanMinuteSuff = "분";
-                    this.KoreanSecondSuff = "초";
-                    this.CJKHourSuff = "時";
-                    this.ChineseHourSuff = "时";
-                    this.CJKMinuteSuff = "分";
-                    this.CJKSecondSuff = "秒";
+                    this.CJKYearSuff = "\u5e74";
+                    this.CJKMonthSuff = "\u6708";
+                    this.CJKDaySuff = "\u65e5";
+                    this.KoreanYearSuff = "\ub144";
+                    this.KoreanMonthSuff = "\uc6d4";
+                    this.KoreanDaySuff = "\uc77c";
+                    this.KoreanHourSuff = "\uc2dc";
+                    this.KoreanMinuteSuff = "\ubd84";
+                    this.KoreanSecondSuff = "\ucd08";
+                    this.CJKHourSuff = "\u6642";
+                    this.ChineseHourSuff = "\u65f6";
+                    this.CJKMinuteSuff = "\u5206";
+                    this.CJKSecondSuff = "\u79d2";
                 }
             },
             methods: {

--- a/Compiler/Translator/Emitter/Blocks/PrimitiveExpressionBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/PrimitiveExpressionBlock.cs
@@ -1,5 +1,6 @@
 ﻿using Bridge.Contract;
 using ICSharpCode.NRefactory.CSharp;
+using ICSharpCode.NRefactory.Semantics;
 
 namespace Bridge.Translator
 {
@@ -37,7 +38,9 @@ namespace Bridge.Translator
             }
             else
             {
-                this.WriteScript(Bridge.Translator.Emitter.ConvertConstant(this.PrimitiveExpression.Value, this.PrimitiveExpression, this.Emitter));
+                object value = this.PrimitiveExpression.Value;
+
+                this.WriteScript(Bridge.Translator.Emitter.ConvertConstant(value, this.PrimitiveExpression, this.Emitter));
             }
         }
     }

--- a/Compiler/Translator/Emitter/Emitter.Helpers.cs
+++ b/Compiler/Translator/Emitter/Emitter.Helpers.cs
@@ -84,7 +84,7 @@ namespace Bridge.Translator
 
         public virtual string ToJavaScript(object value)
         {
-            return JsonConvert.SerializeObject(value);
+            return JsonConvert.SerializeObject(value, new JsonSerializerSettings { StringEscapeHandling = StringEscapeHandling.EscapeNonAscii });
         }
 
         protected virtual ICSharpCode.NRefactory.CSharp.Attribute GetAttribute(AstNodeCollection<AttributeSection> attributes, string name)

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -813,6 +813,7 @@
     <Compile Include="BridgeIssues\3800\N3855.cs" />
     <Compile Include="BridgeIssues\3800\N3865.cs" />
     <Compile Include="BridgeIssues\3800\N3867.cs" />
+    <Compile Include="BridgeIssues\3900\N3902.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />
     <Compile Include="Utilities\BrowserHelper.cs" />
   </ItemGroup>

--- a/Tests/Batch3/BridgeIssues/3900/N3902.cs
+++ b/Tests/Batch3/BridgeIssues/3900/N3902.cs
@@ -1,0 +1,20 @@
+// this is required in order to reproduce the issue (read below)
+using Bridge.Html5;
+using Bridge.Test.NUnit;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [TestFixture(TestNameFormat = "#3902 - {0}")]
+    public class Bridge3902
+
+    {
+        [Test]
+        public static void TestUnicodeEscapes()
+        {
+            string s = "\ud8a1\ud8a2\ue681";
+            Assert.AreEqual(55457, (int)s[0]);
+            Assert.AreEqual(55458, (int)s[1]);
+            Assert.AreEqual(59009, (int)s[2]);
+        }
+    }
+}

--- a/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
+++ b/Tests/Runner/Batch1/Bridge.Test/bridge.clienttest.runner.js
@@ -3781,7 +3781,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest", function ($asm, globals) {
             QUnit.test("Environment - GetLogicalDrivesEmpty", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.GetLogicalDrivesEmpty);
             QUnit.test("Environment - SetEnvironmentVariableTwoParametersWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.SetEnvironmentVariableTwoParametersWorks);
             QUnit.test("Environment - SetEnvironmentVariableThreeParametersWorks", Bridge.Test.Runtime.BridgeClientTestRunner.EnvironmentTests.SetEnvironmentVariableThreeParametersWorks);
-            QUnit.module("СultureInfo");
+            QUnit.module("\u0421ultureInfo");
             QUnit.test("TypePropertiesAreCorrect", Bridge.Test.Runtime.BridgeClientTestRunner.CultureInfoTests.TypePropertiesAreCorrect);
             QUnit.test("ConstructorWorks_N2583", Bridge.Test.Runtime.BridgeClientTestRunner.CultureInfoTests.ConstructorWorks_N2583);
             QUnit.test("GetCultureInfoWorks_N2583", Bridge.Test.Runtime.BridgeClientTestRunner.CultureInfoTests.GetCultureInfoWorks_N2583);

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -42062,19 +42062,19 @@ if (typeof window !== 'undefined' && window.performance && window.performance.no
                 init: function () {
                     this.MonthPostfixChar = 57344;
                     this.IgnorableSymbolChar = 57345;
-                    this.CJKYearSuff = "年";
-                    this.CJKMonthSuff = "月";
-                    this.CJKDaySuff = "日";
-                    this.KoreanYearSuff = "년";
-                    this.KoreanMonthSuff = "월";
-                    this.KoreanDaySuff = "일";
-                    this.KoreanHourSuff = "시";
-                    this.KoreanMinuteSuff = "분";
-                    this.KoreanSecondSuff = "초";
-                    this.CJKHourSuff = "時";
-                    this.ChineseHourSuff = "时";
-                    this.CJKMinuteSuff = "分";
-                    this.CJKSecondSuff = "秒";
+                    this.CJKYearSuff = "\u5e74";
+                    this.CJKMonthSuff = "\u6708";
+                    this.CJKDaySuff = "\u65e5";
+                    this.KoreanYearSuff = "\ub144";
+                    this.KoreanMonthSuff = "\uc6d4";
+                    this.KoreanDaySuff = "\uc77c";
+                    this.KoreanHourSuff = "\uc2dc";
+                    this.KoreanMinuteSuff = "\ubd84";
+                    this.KoreanSecondSuff = "\ucd08";
+                    this.CJKHourSuff = "\u6642";
+                    this.ChineseHourSuff = "\u65f6";
+                    this.CJKMinuteSuff = "\u5206";
+                    this.CJKSecondSuff = "\u79d2";
                 }
             },
             methods: {

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -122,6 +122,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3855 - TestTypeName", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3855.TestTypeName);
             QUnit.test("#3865 - TestArrayAssembly", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3865.TestArrayAssembly);
             QUnit.test("#3867 - TestBackingField", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3867.TestBackingField);
+            QUnit.test("#3902 - TestUnicodeEscapes", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3902.TestUnicodeEscapes);
             QUnit.module("Issues3");
             QUnit.test("#69 - ThisKeywordInStructConstructorWorks", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge069.ThisKeywordInStructConstructorWorks);
             QUnit.test("#1000 - TestStaticViaChild", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge1000.TestStaticViaChild);
@@ -18812,6 +18813,32 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3867", $t.File = "Batch3\\BridgeIssues\\3800\\N3867.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3902", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3902)],
+        $kind: "nested class",
+        statics: {
+            methods: {
+                TestUnicodeEscapes: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3902).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3902, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestUnicodeEscapes()", $t.Line = "11", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3902.TestUnicodeEscapes();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3902", $t.File = "Batch3\\BridgeIssues\\3900\\N3902.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -12054,7 +12054,7 @@ Bridge.$N1391Result =                     r;
                 Bridge.Test.NUnit.Assert.AreEqual(385941503, v2.v);
 
                 var v3 = { };
-                var b3 = System.UInt32.tryParse("0x1700fffА", v3, radix);
+                var b3 = System.UInt32.tryParse("0x1700fff\u0410", v3, radix);
                 Bridge.Test.NUnit.Assert.False(b3, "b3: " + v3.v);
 
                 var v4 = { };
@@ -36735,6 +36735,19 @@ Bridge.$N1391Result =                     r;
         $kind: "nested class",
         props: {
             Prop: 0
+        }
+    });
+
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3902", {
+        statics: {
+            methods: {
+                TestUnicodeEscapes: function () {
+                    var s = "\ud8a1\ud8a2\ue681";
+                    Bridge.Test.NUnit.Assert.AreEqual(55457, s.charCodeAt(0));
+                    Bridge.Test.NUnit.Assert.AreEqual(55458, s.charCodeAt(1));
+                    Bridge.Test.NUnit.Assert.AreEqual(59009, s.charCodeAt(2));
+                }
+            }
         }
     });
 


### PR DESCRIPTION
Fixes #3902