### PR TITLE
Implement System.Array.LongLength and System.Array.Copy for long indexes

### DIFF
--- a/Bridge/Resources/Array.js
+++ b/Bridge/Resources/Array.js
@@ -1255,6 +1255,9 @@
             }
 
             return arr || result;
+        },
+        getLongLength: function (array) {
+            return System.Int64(array.length);
         }
     };
 

--- a/Bridge/System/Array.cs
+++ b/Bridge/System/Array.cs
@@ -15,6 +15,13 @@ namespace System
             get;
         }
 
+        public long LongLength
+        {
+            [Bridge.Template("System.Array.getLongLength({this})")]
+            get;
+        }
+        
+
         /// <summary>
         /// Gets a value indicating whether the System.Array has a fixed size.
         /// </summary>
@@ -225,6 +232,12 @@ namespace System
 
         [Bridge.Template("System.Array.copy({src}, 0, {dst}, 0, {len})")]
         public static extern void Copy(Array src, Array dst, int len);
+
+        [Bridge.Template("System.Array.copy({src}, {spos}.toNumber(), {dst}, {dpos}.toNumber(), {len}.toNumber())")]
+        public static extern void Copy(Array src, long spos, Array dst, long dpos, long len);
+
+        [Bridge.Template("System.Array.copy({src}, 0, {dst}, 0, {len}.toNumber())")]
+        public static extern void Copy(Array src, Array dst, long len);
 
         [Bridge.Template("System.Array.copy({this}, 0, {array}, {index}, {this}.length)")]
         public extern void CopyTo(Array array, int index);

--- a/Tests/Batch1/ArrayTests.cs
+++ b/Tests/Batch1/ArrayTests.cs
@@ -95,6 +95,14 @@ namespace Bridge.ClientTest
             }
 
             [Test]
+            public void LongLengthWorks()
+            {
+                Assert.AreEqual((long)0, new int[0].LongLength);
+                Assert.AreEqual((long)1, new[] { "x" }.LongLength);
+                Assert.AreEqual((long)2, new[] { "x", "y" }.LongLength);
+            }
+
+            [Test]
             public void RankIsOne()
             {
                 Assert.AreEqual(1, new int[0].Rank);
@@ -667,6 +675,19 @@ namespace Bridge.ClientTest
 
                 var arr3 = new[] { 9, 8, 7, 6 };
                 Array.Copy(arr1, 3, arr3, 2, 1);
+                Assert.AreEqual(new[] { 9, 8, 4, 6 }, arr3);
+            }
+
+            [Test]
+            public void CopyWithDifferentArraysLongWorks()
+            {
+                var arr1 = new[] { 1, 2, 3, 4 };
+                var arr2 = new[] { 9, 8, 7, 6 };
+                Array.Copy(arr1, arr2, (long)2);
+                Assert.AreEqual(new[] { 1, 2, 7, 6 }, arr2);
+
+                var arr3 = new[] { 9, 8, 7, 6 };
+                Array.Copy(arr1, (long)3, arr3, (long)2, (long)1);
                 Assert.AreEqual(new[] { 9, 8, 4, 6 }, arr3);
             }
 


### PR DESCRIPTION
Implements Array.LongLength and System.Array.Copy for use with longs instead of ints.