### PR TITLE
[3979] double.TryParse returns wrong result when input contains + or -

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -7700,17 +7700,19 @@ Bridge.define("System.Type", {
                     return true;
                 }
 
-                var countExp = 0;
+                var countExp = 0,
+                    ePrev = false;
 
                 for (var i = 0; i < s.length; i++) {
                     if (!System.Char.isNumber(s[i].charCodeAt(0)) &&
                         s[i] !== "." &&
                         s[i] !== "," &&
-                        s[i] !== nfInfo.positiveSign &&
-                        s[i] !== nfInfo.negativeSign &&
+                        (s[i] !== nfInfo.positiveSign || i !== 0 && !ePrev) &&
+                        (s[i] !== nfInfo.negativeSign || i !== 0 && !ePrev) &&
                         s[i] !== point &&
                         s[i] !== thousands) {
                         if (s[i].toLowerCase() === "e") {
+                            ePrev = true;
                             countExp++;
 
                             if (countExp > 1) {
@@ -7721,12 +7723,15 @@ Bridge.define("System.Type", {
                                 throw new System.FormatException.$ctor1(errMsg);
                             }
                         } else {
+                            ePrev = false;
                             if (safe) {
                                 return false;
                             }
 
                             throw new System.FormatException.$ctor1(errMsg);
                         }
+                    } else {
+                        ePrev = false;
                     }
                 }
 

--- a/Bridge/Resources/Integer.js
+++ b/Bridge/Resources/Integer.js
@@ -612,17 +612,19 @@
                     return true;
                 }
 
-                var countExp = 0;
+                var countExp = 0,
+                    ePrev = false;
 
                 for (var i = 0; i < s.length; i++) {
                     if (!System.Char.isNumber(s[i].charCodeAt(0)) &&
                         s[i] !== "." &&
                         s[i] !== "," &&
-                        s[i] !== nfInfo.positiveSign &&
-                        s[i] !== nfInfo.negativeSign &&
+                        (s[i] !== nfInfo.positiveSign || i !== 0 && !ePrev) &&
+                        (s[i] !== nfInfo.negativeSign || i !== 0 && !ePrev) &&
                         s[i] !== point &&
                         s[i] !== thousands) {
                         if (s[i].toLowerCase() === "e") {
+                            ePrev = true;
                             countExp++;
 
                             if (countExp > 1) {
@@ -633,12 +635,15 @@
                                 throw new System.FormatException.$ctor1(errMsg);
                             }
                         } else {
+                            ePrev = false;
                             if (safe) {
                                 return false;
                             }
 
                             throw new System.FormatException.$ctor1(errMsg);
                         }
+                    } else {
+                        ePrev = false;
                     }
                 }
 

--- a/Tests/Batch3/Batch3.csproj
+++ b/Tests/Batch3/Batch3.csproj
@@ -842,6 +842,7 @@
     <Compile Include="BridgeIssues\3900\N3951.cs" />
     <Compile Include="BridgeIssues\3900\N3964.cs" />
     <Compile Include="BridgeIssues\3900\N3969.cs" />
+    <Compile Include="BridgeIssues\3900\N3979.cs" />
     <Compile Include="BridgeIssues\3900\N3970.cs" />
     <Compile Include="BridgeIssues\3900\N3958.cs" />
     <Compile Include="BridgeIssues\TestBridgeIssues.cs" />

--- a/Tests/Batch3/BridgeIssues/3900/N3979.cs
+++ b/Tests/Batch3/BridgeIssues/3900/N3979.cs
@@ -1,0 +1,18 @@
+using Bridge.Test.NUnit;
+using System;
+
+namespace Bridge.ClientTest.Batch3.BridgeIssues
+{
+    [TestFixture(TestNameFormat = "#3979 - {0}")]
+    public class Bridge3979
+    {        
+        [Test]
+        public static void TestDoubleParse()
+        {
+            Assert.Throws<FormatException>(() => double.Parse("2+1"));
+            Assert.Throws<FormatException>(() => double.Parse("2ee+1"));
+            Assert.Throws<FormatException>(() => double.Parse("2e++1"));
+            Assert.Throws<FormatException>(() => double.Parse("2e+-1"));
+        }
+    }
+}

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -7700,17 +7700,19 @@ Bridge.define("System.Type", {
                     return true;
                 }
 
-                var countExp = 0;
+                var countExp = 0,
+                    ePrev = false;
 
                 for (var i = 0; i < s.length; i++) {
                     if (!System.Char.isNumber(s[i].charCodeAt(0)) &&
                         s[i] !== "." &&
                         s[i] !== "," &&
-                        s[i] !== nfInfo.positiveSign &&
-                        s[i] !== nfInfo.negativeSign &&
+                        (s[i] !== nfInfo.positiveSign || i !== 0 && !ePrev) &&
+                        (s[i] !== nfInfo.negativeSign || i !== 0 && !ePrev) &&
                         s[i] !== point &&
                         s[i] !== thousands) {
                         if (s[i].toLowerCase() === "e") {
+                            ePrev = true;
                             countExp++;
 
                             if (countExp > 1) {
@@ -7721,12 +7723,15 @@ Bridge.define("System.Type", {
                                 throw new System.FormatException.$ctor1(errMsg);
                             }
                         } else {
+                            ePrev = false;
                             if (safe) {
                                 return false;
                             }
 
                             throw new System.FormatException.$ctor1(errMsg);
                         }
+                    } else {
+                        ePrev = false;
                     }
                 }
 

--- a/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
+++ b/Tests/Runner/Batch3/Bridge.Test/bridge.clienttest.batch3.runner.js
@@ -153,6 +153,7 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
             QUnit.test("#3964 - TestIndexOfAny", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3964.TestIndexOfAny);
             QUnit.test("#3969 - TestCharIndexer", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3969.TestCharIndexer);
             QUnit.test("#3970 - TestNamespaceAndClassSameName", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3970.TestNamespaceAndClassSameName);
+            QUnit.test("#3979 - TestDoubleParse", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3979.TestDoubleParse);
             QUnit.module("Issues3");
             QUnit.test("#69 - ThisKeywordInStructConstructorWorks", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge069.ThisKeywordInStructConstructorWorks);
             QUnit.test("#1000 - TestStaticViaChild", Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge1000.TestStaticViaChild);
@@ -19691,6 +19692,32 @@ Bridge.assembly("Bridge.Test.Bridge.ClientTest.Batch3", function ($asm, globals)
                 var $t;
                 if (this.context == null) {
                     this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3970", $t.File = "Batch3\\BridgeIssues\\3900\\N3970.cs", $t);
+                }
+                return this.context;
+            }
+        }
+    });
+
+    Bridge.define("Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3979", {
+        inherits: [Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979)],
+        $kind: "nested class",
+        statics: {
+            methods: {
+                TestDoubleParse: function (assert) {
+                    var $t;
+                    var t = Bridge.Test.Runtime.TestFixture$1(Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979).BeforeTest(false, assert, Bridge.Test.Runtime.BridgeClientTestBatch3Runner.Bridge3979, void 0, ($t = new Bridge.Test.Runtime.TestContext(), $t.Method = "TestDoubleParse()", $t.Line = "9", $t));
+                    Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979.TestDoubleParse();
+                }
+            }
+        },
+        fields: {
+            context: null
+        },
+        methods: {
+            GetContext: function () {
+                var $t;
+                if (this.context == null) {
+                    this.context = ($t = new Bridge.Test.Runtime.FixtureContext(), $t.Project = "Batch3", $t.ClassName = "Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979", $t.File = "Batch3\\BridgeIssues\\3900\\N3979.cs", $t);
                 }
                 return this.context;
             }

--- a/Tests/Runner/Batch3/code.js
+++ b/Tests/Runner/Batch3/code.js
@@ -39521,6 +39521,36 @@ Bridge.$N1391Result =                     r;
         }
     });
 
+    Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979", {
+        statics: {
+            methods: {
+                TestDoubleParse: function () {
+                    Bridge.Test.NUnit.Assert.Throws$2(System.FormatException, $asm.$.Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979.f1);
+                    Bridge.Test.NUnit.Assert.Throws$2(System.FormatException, $asm.$.Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979.f2);
+                    Bridge.Test.NUnit.Assert.Throws$2(System.FormatException, $asm.$.Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979.f3);
+                    Bridge.Test.NUnit.Assert.Throws$2(System.FormatException, $asm.$.Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979.f4);
+                }
+            }
+        }
+    });
+
+    Bridge.ns("Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979", $asm.$);
+
+    Bridge.apply($asm.$.Bridge.ClientTest.Batch3.BridgeIssues.Bridge3979, {
+        f1: function () {
+            System.Double.parse("2+1");
+        },
+        f2: function () {
+            System.Double.parse("2ee+1");
+        },
+        f3: function () {
+            System.Double.parse("2e++1");
+        },
+        f4: function () {
+            System.Double.parse("2e+-1");
+        }
+    });
+
     Bridge.define("Bridge.ClientTest.Batch3.BridgeIssues.Bridge407", {
         $kind: "struct",
         statics: {


### PR DESCRIPTION
Fixes #3979