### PR TITLE
Fix ReadStream for resources larger than 1MB - fixes issue #3989

### DIFF
--- a/Compiler/Translator/Translator/Translator.Resources.cs
+++ b/Compiler/Translator/Translator/Translator.Resources.cs
@@ -1356,32 +1356,16 @@ namespace Bridge.Translator
 
         protected byte[] ReadStream(Stream stream)
         {
+            if (stream is MemoryStream memoryStream)
+                return memoryStream.ToArray();
+
             if (stream.Position != 0)
-            {
                 stream.Seek(0, SeekOrigin.Begin);
-                stream.Position = 0;
-            }
-
-            byte[] bytes = new byte[stream.Length];
-
-            int numBytesToRead = (int)stream.Length;
-            int numBytesRead = 0;
-
-            var chunkLength = 1 * 1024 * 1024;
-            if (chunkLength > numBytesToRead)
+            using (memoryStream = new MemoryStream())
             {
-                chunkLength = numBytesToRead;
+                stream.CopyTo(memoryStream);
+                return memoryStream.ToArray();
             }
-
-            do
-            {
-                int n = stream.Read(bytes, numBytesRead, chunkLength);
-
-                numBytesRead += n;
-                numBytesToRead -= n;
-            } while (numBytesToRead > 0);
-
-            return bytes;
         }
 
         //private string NormalizePath(string value)


### PR DESCRIPTION
Fixes #3989 

I haven't added any tests for this - I wasn't sure where would be best to put one and whether it would be best to do a full integration test that reads a larger-than-1MB resource from a DLL included in the project or if it should just try to read from a stream that is larger than 1MB. I can add tests if you think that it would be helpful and could offer some guidance.