### PR TITLE
Implements (and uses) the IgnoreDuplicateTypes bridge.js config

### DIFF
--- a/Compiler/Contract/Config/IAssemblyInfo.cs
+++ b/Compiler/Contract/Config/IAssemblyInfo.cs
@@ -227,5 +227,11 @@ namespace Bridge.Contract
             get;
             set;
         }
+
+        bool IgnoreDuplicateTypes
+        {
+            get;
+            set;
+        }
     }
  }

--- a/Compiler/Translator/Utils/AssemblyInfo.cs
+++ b/Compiler/Translator/Utils/AssemblyInfo.cs
@@ -24,6 +24,7 @@ namespace Bridge.Translator
             this.Console = new ConsoleConfig();
             this.Report = new ReportConfig();
             this.Rules = new CompilerRule();
+            this.IgnoreDuplicateTypes = false;
         }
 
         /// <summary>
@@ -336,6 +337,17 @@ namespace Bridge.Translator
         }
 
         public string[] References
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Skips loading types off assemblies when they have already been loaded.
+        /// If false, throws an exception when a same type comes from more than
+        /// one assembly.
+        /// </summary>
+        public bool IgnoreDuplicateTypes
         {
             get;
             set;

--- a/Tests/Batch1/Bridge/bridge.json
+++ b/Tests/Batch1/Bridge/bridge.json
@@ -25,5 +25,6 @@
       "name": "bridge.meta.js",
       "extract": false
     }
-  ]
+  ],
+  "ignoreDuplicateTypes": true
 }

--- a/Tests/Batch3/Bridge/bridge.json
+++ b/Tests/Batch3/Bridge/bridge.json
@@ -21,5 +21,6 @@
   "test": {
     "skipResources": true,
     "skipAuxiliary": true
-  }
+  },
+  "ignoreDuplicateTypes": true
 }

--- a/Tests/Batch4/Bridge/bridge.json
+++ b/Tests/Batch4/Bridge/bridge.json
@@ -23,5 +23,6 @@
   "test": {
     "skipResources": true,
     "skipAuxiliary": true
-  }
+  },
+  "ignoreDuplicateTypes": true
 }


### PR DESCRIPTION
Fixes #3997.

This being accepted will also require a change in Bridge Test project (propagate the setting in Bridge settings created by Bridge.Test.Plugin code), and also in Bridge.Newtonsoft.Json (add the setting so the tests there uses it).

This fix is only relevant for VS2019, which seems to merge references in built assemblies.