### PR TITLE
Issue4030

### DIFF
--- a/Bridge/Resources/.generated/bridge.js
+++ b/Bridge/Resources/.generated/bridge.js
@@ -9058,6 +9058,7 @@ Bridge.define("System.Type", {
 
             // Native .NET accepts the sign in postfixed form. Yet, it is documented otherwise.
             // https://docs.microsoft.com/en-us/dotnet/api/system.decimal.parse
+            // True at least as with: Microsoft (R) Build Engine version 16.1.76+g14b0a930a7 for .NET Framework
             if (!/^\s*[+-]?(\d+|\d+\.|\d*\.\d+)((e|E)[+-]?\d+)?\s*$/.test(v) &&
                 !/^\s*(\d+|\d+\.|\d*\.\d+)((e|E)[+-]?\d+)?[+-]\s*$/.test(v)) {
                 throw new System.FormatException();
@@ -9065,19 +9066,20 @@ Bridge.define("System.Type", {
 
             v = v.replace(/\s/g, "");
 
-            // Move the postfixed - to front, or remove '+' so the underlying
+            // Move the postfixed - to front, or remove "+" so the underlying
             // decimal handler knows what to do with the string.
             if (/[+-]$/.test(v)) {
-                if (v.endsWith('-')) {
+                var vlastpos = v.length - 1;
+                if (v.indexOf("-", vlastpos) === vlastpos) {
                     v = v.replace(/(.*)(-)$/, "$2$1");
                 } else {
-                    v = v.substr(0, v.length - 1);
+                    v = v.substr(0, vlastpos);
                 }
-            } else if (v.startsWith("+")) {
+            } else if (v.lastIndexOf("+", 0) === 0) {
                 v = v.substr(1);
             }
 
-            if (!this.$precision && (dot = v.indexOf('.')) >= 0) {
+            if (!this.$precision && (dot = v.indexOf(".")) >= 0) {
                 this.$precision = v.length - dot - 1;
             }
         }

--- a/Bridge/Resources/Decimal.js
+++ b/Bridge/Resources/Decimal.js
@@ -37,7 +37,7 @@
 
             v = v.replace(/\s/g, "");
 
-            // Move the postfixed - to front, or remove '+' so the underlying
+            // Move the postfixed - to front, or remove "+" so the underlying
             // decimal handler knows what to do with the string.
             if (/[+-]$/.test(v)) {
                 var vlastpos = v.length - 1;
@@ -50,7 +50,7 @@
                 v = v.substr(1);
             }
 
-            if (!this.$precision && (dot = v.indexOf('.')) >= 0) {
+            if (!this.$precision && (dot = v.indexOf(".")) >= 0) {
                 this.$precision = v.length - dot - 1;
             }
         }

--- a/Bridge/Resources/Decimal.js
+++ b/Bridge/Resources/Decimal.js
@@ -29,6 +29,7 @@
 
             // Native .NET accepts the sign in postfixed form. Yet, it is documented otherwise.
             // https://docs.microsoft.com/en-us/dotnet/api/system.decimal.parse
+            // True at least as with: Microsoft (R) Build Engine version 16.1.76+g14b0a930a7 for .NET Framework
             if (!/^\s*[+-]?(\d+|\d+\.|\d*\.\d+)((e|E)[+-]?\d+)?\s*$/.test(v) &&
                 !/^\s*(\d+|\d+\.|\d*\.\d+)((e|E)[+-]?\d+)?[+-]\s*$/.test(v)) {
                 throw new System.FormatException();
@@ -39,12 +40,13 @@
             // Move the postfixed - to front, or remove '+' so the underlying
             // decimal handler knows what to do with the string.
             if (/[+-]$/.test(v)) {
-                if (v.endsWith('-')) {
+                var vlastpos = v.length - 1;
+                if (v.indexOf("-", vlastpos) === vlastpos) {
                     v = v.replace(/(.*)(-)$/, "$2$1");
                 } else {
-                    v = v.substr(0, v.length - 1);
+                    v = v.substr(0, vlastpos);
                 }
-            } else if (v.startsWith("+")) {
+            } else if (v.lastIndexOf("+", 0) === 0) {
                 v = v.substr(1);
             }
 

--- a/Tests/Runner/Batch1/bridge.js
+++ b/Tests/Runner/Batch1/bridge.js
@@ -9058,6 +9058,7 @@ Bridge.define("System.Type", {
 
             // Native .NET accepts the sign in postfixed form. Yet, it is documented otherwise.
             // https://docs.microsoft.com/en-us/dotnet/api/system.decimal.parse
+            // True at least as with: Microsoft (R) Build Engine version 16.1.76+g14b0a930a7 for .NET Framework
             if (!/^\s*[+-]?(\d+|\d+\.|\d*\.\d+)((e|E)[+-]?\d+)?\s*$/.test(v) &&
                 !/^\s*(\d+|\d+\.|\d*\.\d+)((e|E)[+-]?\d+)?[+-]\s*$/.test(v)) {
                 throw new System.FormatException();
@@ -9065,19 +9066,20 @@ Bridge.define("System.Type", {
 
             v = v.replace(/\s/g, "");
 
-            // Move the postfixed - to front, or remove '+' so the underlying
+            // Move the postfixed - to front, or remove "+" so the underlying
             // decimal handler knows what to do with the string.
             if (/[+-]$/.test(v)) {
-                if (v.endsWith('-')) {
+                var vlastpos = v.length - 1;
+                if (v.indexOf("-", vlastpos) === vlastpos) {
                     v = v.replace(/(.*)(-)$/, "$2$1");
                 } else {
-                    v = v.substr(0, v.length - 1);
+                    v = v.substr(0, vlastpos);
                 }
-            } else if (v.startsWith("+")) {
+            } else if (v.lastIndexOf("+", 0) === 0) {
                 v = v.substr(1);
             }
 
-            if (!this.$precision && (dot = v.indexOf('.')) >= 0) {
+            if (!this.$precision && (dot = v.indexOf(".")) >= 0) {
                 this.$precision = v.length - dot - 1;
             }
         }


### PR DESCRIPTION
Fixes #4030.

Notice testing via the unit tests interface for Bridge won't work -- the very shell is not compatible with IE11.

So, `bridge.js` was copied over a 17.9.0 Bridge project with unit tests for 3982, which then worked correctly (yes, the said unit tests triggered the issue in IE11 if they are run just off a standalone project).