### PR TITLE
Remove Array.LastIndexOf and Array.IndexOf instance methods.

### DIFF
--- a/Bridge/System/Array.cs
+++ b/Bridge/System/Array.cs
@@ -126,28 +126,6 @@ namespace System
         public static extern bool TrueForAll<T>(T[] array, Predicate<T> match);
 
         /// <summary>
-        /// The indexOf() method returns the first index at which a given element can be found in the array, or -1 if it is not present.
-        /// </summary>
-        /// <param name="searchElement"></param>
-        /// <returns></returns>
-        public extern int IndexOf(string searchElement);
-
-        /// <summary>
-        /// The indexOf() method returns the first index at which a given element can be found in the array, or -1 if it is not present.
-        /// </summary>
-        /// <param name="searchElement"></param>
-        /// <param name="fromIndex"></param>
-        /// <returns></returns>
-        public extern int IndexOf(string searchElement, int fromIndex);
-
-        /// <summary>
-        /// The lastIndexOf() method returns the last index at which a given element can be found in the array, or -1 if it is not present. The array is searched backwards, starting at fromIndex.
-        /// </summary>
-        /// <param name="searchString"></param>
-        /// <returns></returns>
-        public extern int LastIndexOf(string searchString);
-
-        /// <summary>
         /// The lastIndexOf() method returns the last index at which a given element can be found in the array, or -1 if it is not present. The array is searched backwards, starting at fromIndex.
         /// </summary>
         /// <param name="searchString"></param>

--- a/Tests/Batch1/ArrayTests.cs
+++ b/Tests/Batch1/ArrayTests.cs
@@ -283,7 +283,7 @@ namespace Bridge.ClientTest
             [Test]
             public void IndexOfWithoutStartIndexWorks()
             {
-                Assert.AreEqual(1, new[] { "a", "b", "c", "b" }.IndexOf("b"));
+                Assert.AreEqual(1, Array.IndexOf(new[] { "a", "b", "c", "b" }, "b"));
             }
 
             [Test]
@@ -297,7 +297,7 @@ namespace Bridge.ClientTest
             [Test]
             public void IndexOfWithStartIndexWorks()
             {
-                Assert.AreEqual(3, new[] { "a", "b", "c", "b" }.IndexOf("b", 2));
+                Assert.AreEqual(3, Array.IndexOf(new[] { "a", "b", "c", "b" }, "b", 2));
             }
 
             [Test]

--- a/Tests/Batch1/Collections/Generic/ListTests.cs
+++ b/Tests/Batch1/Collections/Generic/ListTests.cs
@@ -499,7 +499,7 @@ namespace Bridge.ClientTest.Collections.Generic
         [Test]
         public void IndexOfWithoutStartIndexWorks()
         {
-            Assert.AreEqual(1, new[] { "a", "b", "c", "b" }.IndexOf("b"));
+            Assert.AreEqual(1, Array.IndexOf(new[] { "a", "b", "c", "b" },"b"));
         }
 
         [Test]

--- a/Tests/Batch2/BridgeIssues/N772.cs
+++ b/Tests/Batch2/BridgeIssues/N772.cs
@@ -188,7 +188,7 @@ namespace Bridge.ClientTest.Batch2.BridgeIssues
         [Test]
         public void IndexOfWithoutStartIndexWorks()
         {
-            Assert.AreEqual(1, new[] { "a", "b", "c", "b" }.IndexOf("b"));
+            Assert.AreEqual(1, Array.IndexOf(new[] { "a", "b", "c", "b" },"b"));
         }
 
         [Test]
@@ -202,7 +202,7 @@ namespace Bridge.ClientTest.Batch2.BridgeIssues
         [Test]
         public void IndexOfWithStartIndexWorks()
         {
-            Assert.AreEqual(3, new[] { "a", "b", "c", "b" }.IndexOf("b", 2));
+            Assert.AreEqual(3, Array.IndexOf(new[] { "a", "b", "c", "b" }, "b", 2));
         }
 
         [Test]


### PR DESCRIPTION
Fixes #4033 

Changes proposed in this pull request:

- Remove Array.IndexOf and Array.IndexOf instance methods
