### PR TITLE
Fix bug with "hasOwnProperty" dictionary key

### DIFF
--- a/Bridge/System/Object.cs
+++ b/Bridge/System/Object.cs
@@ -24,6 +24,7 @@ namespace System
         public virtual extern object ValueOf();
 
         [Bridge.Convention(Bridge.Notation.CamelCase)]
+        [Bridge.Template("Object.prototype.hasOwnProperty.call({this}, {v})")]
         public virtual extern bool HasOwnProperty(object v);
 
         [Bridge.Convention(Bridge.Notation.CamelCase)]


### PR DESCRIPTION
Using `hasOwnProperty` as a dictionary key causes Bridge.NET to crash:

https://deck.net/ff2b4e49b1057c8ae99c566343b533de

The problem is that it's compiling to `obj.hasOwnProperty(key)`
when it should be compiling to `Object.prototype.hasOwnProperty.call(obj, key)`.

This PR fixes that crash.