### PR TITLE
[4083] Crash when iterator uses goto

### DIFF
--- a/Compiler/Translator/Emitter/Blocks/GeneratorBlock.cs
+++ b/Compiler/Translator/Emitter/Blocks/GeneratorBlock.cs
@@ -283,11 +283,17 @@ namespace Bridge.Translator
             this.Emitter.ReplaceAwaiterByVar = false;
 
             this.DetectReturnType();
+            this.FindAwaitNodes();
 
             this.Steps = new List<IAsyncStep>();
             this.TryInfos = new List<IAsyncTryInfo>();
             this.JumpLabels = new List<IAsyncJumpLabel>();
             this.WrittenAwaitExpressions = new List<AstNode>();
+        }
+
+        protected void FindAwaitNodes()
+        {
+            this.AwaitExpressions = this.GetAwaiters(this.Body);
         }
 
         protected void DetectReturnType()

--- a/Compiler/TranslatorTests/TestProjects/16/Bridge/reference/Test.BridgeIssues.N4083.js
+++ b/Compiler/TranslatorTests/TestProjects/16/Bridge/reference/Test.BridgeIssues.N4083.js
@@ -1,0 +1,136 @@
+Bridge.assembly("TestProject", function ($asm, globals) {
+    "use strict";
+
+    Bridge.define("Test.BridgeIssues.N4083.N4083", {
+        $metadata : function () { return {"nested":[Test.BridgeIssues.N4083.N4083.RedBlackNode$1,Test.BridgeIssues.N4083.N4083.App],"att":1048577,"a":2,"m":[{"a":2,"isSynthetic":true,"n":".ctor","t":1,"sn":"ctor"}]}; }
+    });
+
+    Bridge.define("Test.BridgeIssues.N4083.N4083.App", {
+        $kind: "nested class",
+        $metadata : function () { return {"td":Test.BridgeIssues.N4083.N4083,"att":1048578,"a":2,"m":[{"a":2,"isSynthetic":true,"n":".ctor","t":1,"sn":"ctor"},{"a":2,"n":"Main","is":true,"t":8,"sn":"Main","rt":System.Void}]}; },
+        main: function Main () {
+            var $t, $t1;
+            var c = ($t = new (Test.BridgeIssues.N4083.N4083.RedBlackNode$1(System.Int32))(), $t.Key = "1", $t.Value = 1, $t.Left = ($t1 = new (Test.BridgeIssues.N4083.N4083.RedBlackNode$1(System.Int32))(), $t1.Key = "11", $t1.Value = 11, $t1), $t.Right = ($t1 = new (Test.BridgeIssues.N4083.N4083.RedBlackNode$1(System.Int32))(), $t1.Key = "12", $t1.Value = 12, $t1), $t);
+
+            $t = Bridge.getEnumerator(Test.BridgeIssues.N4083.N4083.RedBlackNode$1(System.Int32).GetPairs(c), System.Collections.Generic.KeyValuePair$2(System.String,System.Int32));
+            try {
+                while ($t.moveNext()) {
+                    var pair = $t.Current;
+                    System.Console.WriteLine((pair.key || "") + " - " + pair.value);
+                }
+            } finally {
+                if (Bridge.is($t, System.IDisposable)) {
+                    $t.System$IDisposable$Dispose();
+                }
+            }
+        }
+    });
+
+    Bridge.define("Test.BridgeIssues.N4083.N4083.RedBlackNode$1", function (V) { return {
+        $kind: "nested class",
+        $metadata : function () { return {"td":Test.BridgeIssues.N4083.N4083,"att":1048578,"a":2,"m":[{"a":2,"isSynthetic":true,"n":".ctor","t":1,"sn":"ctor"},{"a":2,"n":"GetPairs","is":true,"t":8,"pi":[{"n":"root","pt":Test.BridgeIssues.N4083.N4083.RedBlackNode$1(V),"ps":0}],"sn":"GetPairs","rt":System.Collections.Generic.IEnumerable$1(System.Collections.Generic.KeyValuePair$2(System.String,V)),"p":[Test.BridgeIssues.N4083.N4083.RedBlackNode$1(V)]},{"a":2,"n":"Key","t":4,"rt":System.String,"sn":"Key"},{"a":2,"n":"Left","t":4,"rt":Test.BridgeIssues.N4083.N4083.RedBlackNode$1(V),"sn":"Left"},{"a":2,"n":"Right","t":4,"rt":Test.BridgeIssues.N4083.N4083.RedBlackNode$1(V),"sn":"Right"},{"a":2,"n":"Value","t":4,"rt":V,"sn":"Value"}]}; },
+        statics: {
+            methods: {
+                GetPairs: function (root) {
+                    return new (Bridge.GeneratorEnumerable$1(System.Collections.Generic.KeyValuePair$2(System.String,V)))(Bridge.fn.bind(this, function (root) {
+                        var $step = 0,
+                            $jumpFromFinally,
+                            $returnValue,
+                            stack,
+                            node,
+                            $async_e;
+
+                        var $enumerator = new (Bridge.GeneratorEnumerator$1(System.Collections.Generic.KeyValuePair$2(System.String,V)))(Bridge.fn.bind(this, function () {
+                            try {
+                                for (;;) {
+                                    switch ($step) {
+                                        case 0: {
+                                            if (root == null) {
+                                                    $step = 1;
+                                                    continue;
+                                                } 
+                                                $step = 2;
+                                                continue;
+                                        }
+                                        case 1: {
+                                            return false;
+                                        }
+                                        case 2: {
+                                            stack = new (System.Collections.Generic.Stack$1(Test.BridgeIssues.N4083.N4083.RedBlackNode$1(V))).ctor();
+                                                node = root;
+                                        }
+                                        case 3: {
+                                            if (node.Left != null) {
+                                                    $step = 4;
+                                                    continue;
+                                                } 
+                                                $step = 5;
+                                                continue;
+                                        }
+                                        case 4: {
+                                            stack.Push(node);
+                                                node = node.Left;
+                                                $step = 3;
+                                                continue;
+                                        }
+                                        case 5: {
+
+                                        }
+                                        case 6: {
+                                            $enumerator.current = new (System.Collections.Generic.KeyValuePair$2(System.String,V)).$ctor1(node.Key, node.Value);
+                                                $step = 7;
+                                                return true;
+                                        }
+                                        case 7: {
+                                            if (node.Right != null) {
+                                                    $step = 8;
+                                                    continue;
+                                                } 
+                                                $step = 9;
+                                                continue;
+                                        }
+                                        case 8: {
+                                            node = node.Right;
+                                                $step = 3;
+                                                continue;
+                                        }
+                                        case 9: {
+                                            if (stack.Count === 0) {
+                                                    $step = 10;
+                                                    continue;
+                                                } 
+                                                $step = 11;
+                                                continue;
+                                        }
+                                        case 10: {
+                                            return false;
+                                        }
+                                        case 11: {
+                                            node = stack.Pop();
+                                                $step = 6;
+                                                continue;
+
+                                        }
+                                        default: {
+                                            return false;
+                                        }
+                                    }
+                                }
+                            } catch($async_e1) {
+                                $async_e = System.Exception.create($async_e1);
+                                throw $async_e;
+                            }
+                        }));
+                        return $enumerator;
+                    }, arguments));
+                }
+            }
+        },
+        fields: {
+            Key: null,
+            Value: Bridge.getDefaultValue(V),
+            Left: null,
+            Right: null
+        }
+    }; });
+});

--- a/Compiler/TranslatorTests/TestProjects/16/Bridge/reference/bridge.report.log
+++ b/Compiler/TranslatorTests/TestProjects/16/Bridge/reference/bridge.report.log
@@ -37,6 +37,7 @@ Resources:
     Test.BridgeIssues.N384.js    1.099 KB
     Test.BridgeIssues.N3891.js   1.010 KB
     Test.BridgeIssues.N391.js    2.674 KB
+    Test.BridgeIssues.N4083.js   7.651 KB
     Test.BridgeIssues.N411.js    0.646 KB
     Test.BridgeIssues.N447.js    3.164 KB
     Test.BridgeIssues.N475A.js   2.988 KB

--- a/Compiler/TranslatorTests/TestProjects/16/Bridge/reference/index.html
+++ b/Compiler/TranslatorTests/TestProjects/16/Bridge/reference/index.html
@@ -45,6 +45,7 @@
     <script src="Test.BridgeIssues.N384.js"></script>
     <script src="Test.BridgeIssues.N3891.js"></script>
     <script src="Test.BridgeIssues.N391.js"></script>
+    <script src="Test.BridgeIssues.N4083.js"></script>
     <script src="Test.BridgeIssues.N411.js"></script>
     <script src="Test.BridgeIssues.N447.js"></script>
     <script src="Test.BridgeIssues.N475A.js"></script>

--- a/Compiler/TranslatorTests/TestProjects/16/BridgeIssues/4000-4999/N4083.cs
+++ b/Compiler/TranslatorTests/TestProjects/16/BridgeIssues/4000-4999/N4083.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Test.BridgeIssues.N4083
+{
+    public class N4083
+    {
+        public class RedBlackNode<V>
+        {
+            public string Key;
+            public V Value;
+            public RedBlackNode<V> Left;
+            public RedBlackNode<V> Right;
+
+            public static IEnumerable<KeyValuePair<string, V>> GetPairs(RedBlackNode<V> root)
+            {
+                if (root == null)
+                    yield break;
+
+                Stack<RedBlackNode<V>> stack = new Stack<RedBlackNode<V>>();
+                RedBlackNode<V> node = root;
+
+            LStart:
+                if (node.Left != null)
+                {
+                    stack.Push(node);
+                    node = node.Left;
+                    goto LStart;
+                }
+
+            LYieldSelf:
+                yield return new KeyValuePair<string, V>(node.Key, node.Value);
+
+                if (node.Right != null)
+                {
+                    node = node.Right;
+                    goto LStart;
+                }
+
+                if (stack.Count == 0)
+                    yield break;
+
+                node = stack.Pop();
+                goto LYieldSelf;
+            }
+        }
+
+        public class App
+        {
+            public static void Main()
+            {
+                var c = new RedBlackNode<int>
+                {
+                    Key = "1",
+                    Value = 1,
+                    Left = new RedBlackNode<int>
+                    {
+                        Key = "11",
+                        Value = 11
+                    },
+                    Right = new RedBlackNode<int>
+                    {
+                        Key = "12",
+                        Value = 12
+                    }
+                };
+
+                foreach (var pair in RedBlackNode<int>.GetPairs(c))
+                {
+                    System.Console.WriteLine(pair.Key + " - " + pair.Value);
+                }
+            }
+        }
+    }
+}

--- a/Compiler/TranslatorTests/TestProjects/16/test.csproj
+++ b/Compiler/TranslatorTests/TestProjects/16/test.csproj
@@ -96,6 +96,7 @@
     <Compile Include="BridgeIssues\3000-3999\N3745.cs" />
     <Compile Include="BridgeIssues\3000-3999\N3815.cs" />
     <Compile Include="BridgeIssues\3000-3999\N3891.cs" />
+    <Compile Include="BridgeIssues\4000-4999\N4083.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #4083 
@fabriciomurta 
I cannot build latest Bridge.Test (Method not found exception in Bridge translator) therefore I was not able to add unit test. I will investigate lately what is wrong with Bridge.Test

The following code can be used as unit test
```
using System.Collections.Generic;
using System.Diagnostics;

public class RedBlackNode<V>
{
    public string Key;
    public V Value;
    public RedBlackNode<V> Left;
    public RedBlackNode<V> Right;

    public static IEnumerable<KeyValuePair<string, V>> GetPairs(RedBlackNode<V> root)
    {
        if (root == null)
            yield break;

        Stack<RedBlackNode<V>> stack = new Stack<RedBlackNode<V>>();
        RedBlackNode<V> node = root;

        LStart:
        if (node.Left != null)
        {
            stack.Push(node);
            node = node.Left;
            goto LStart;
        }

        LYieldSelf:
        yield return new KeyValuePair<string, V>(node.Key, node.Value);

        if (node.Right != null)
        {
            node = node.Right;
            goto LStart;
        }

        if (stack.Count == 0)
            yield break;

        node = stack.Pop();
        goto LYieldSelf;
    }
}

public class App
{
    public static void Main()
    {
        var c = new RedBlackNode<int> {
            Key = "1",
            Value = 1,
            Left = new RedBlackNode<int> {
                Key = "11",
                Value = 11
            },
            Right = new RedBlackNode<int>
            {
                Key = "12",
                Value = 12
            }
        };

        foreach (var pair in RedBlackNode<int>.GetPairs(c))
        {
            System.Console.WriteLine(pair.Key + " - " + pair.Value);
        }
    }
}
```
