### PR TITLE
Runs BridgeNetCompilerTask only if sources changed

### DIFF
--- a/.build/files/Bridge.Min.targets
+++ b/.build/files/Bridge.Min.targets
@@ -19,7 +19,7 @@
     <PrepareForRunDependsOn>$(PrepareForRunDependsOn);$(BridgeNetCompilerTarget)</PrepareForRunDependsOn>
   </PropertyGroup>
 
-  <Target Name="BridgeNetCompilerTask">
+  <Target Name="BridgeNetCompilerTask" Inputs="$(OutputPath)$(AssemblyName).dll" Outputs="$(OutputPath)bridge\$(AssemblyName).js">
     <Message Text="Bridge started" Importance="high" />
 
     <BridgeCompilerTask


### PR DESCRIPTION
Fixes the issue described in https://forums.bridge.net/forum/community/help/6093-bridge-compiler-running-on-every-project-in-solution-even-if-no-changes.

Changes proposed in this pull request:
- Added inputs and outputs to the Task, so that msbuild will only trigger the task if the source c# files changed.