### PR TITLE
Switches Microsoft.Build NuGet reference to system reference

### DIFF
--- a/Bridge/System/ValueTuple.cs
+++ b/Bridge/System/ValueTuple.cs
@@ -17,7 +17,9 @@ namespace System
     public struct ValueTuple<T1>
         : IEquatable<ValueTuple<T1>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1>>, ITupleInternal
     {
+		#pragma warning disable 0649    // Field is never assigned to, and will always have its default value null
         private static readonly EqualityComparer<T1> s_t1Comparer = EqualityComparer<T1>.Default;
+		#pragma warning restore 0649
 
         /// <summary>
         /// The current <see cref="ValueTuple{T1}"/> instance's first component.
@@ -165,8 +167,10 @@ namespace System
     public struct ValueTuple<T1, T2>
         : IEquatable<ValueTuple<T1, T2>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2>>, ITupleInternal
     {
+		#pragma warning disable 0649    // Field is never assigned to, and will always have its default value null
         private static readonly EqualityComparer<T1> s_t1Comparer = EqualityComparer<T1>.Default;
         private static readonly EqualityComparer<T2> s_t2Comparer = EqualityComparer<T2>.Default;
+		#pragma warning restore 0649
 
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2}"/> instance's first component.
@@ -354,9 +358,11 @@ namespace System
     public struct ValueTuple<T1, T2, T3>
         : IEquatable<ValueTuple<T1, T2, T3>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3>>, ITupleInternal
     {
+		#pragma warning disable 0649    // Field is never assigned to, and will always have its default value null
         private static readonly EqualityComparer<T1> s_t1Comparer = EqualityComparer<T1>.Default;
         private static readonly EqualityComparer<T2> s_t2Comparer = EqualityComparer<T2>.Default;
         private static readonly EqualityComparer<T3> s_t3Comparer = EqualityComparer<T3>.Default;
+		#pragma warning restore 0649
 
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3}"/> instance's first component.
@@ -540,10 +546,12 @@ namespace System
     public struct ValueTuple<T1, T2, T3, T4>
         : IEquatable<ValueTuple<T1, T2, T3, T4>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4>>, ITupleInternal
     {
+		#pragma warning disable 0649    // Field is never assigned to, and will always have its default value null
         private static readonly EqualityComparer<T1> s_t1Comparer = EqualityComparer<T1>.Default;
         private static readonly EqualityComparer<T2> s_t2Comparer = EqualityComparer<T2>.Default;
         private static readonly EqualityComparer<T3> s_t3Comparer = EqualityComparer<T3>.Default;
         private static readonly EqualityComparer<T4> s_t4Comparer = EqualityComparer<T4>.Default;
+		#pragma warning restore 0649
 
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4}"/> instance's first component.
@@ -744,11 +752,13 @@ namespace System
     public struct ValueTuple<T1, T2, T3, T4, T5>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5>>, ITupleInternal
     {
+		#pragma warning disable 0649    // Field is never assigned to, and will always have its default value null
         private static readonly EqualityComparer<T1> s_t1Comparer = EqualityComparer<T1>.Default;
         private static readonly EqualityComparer<T2> s_t2Comparer = EqualityComparer<T2>.Default;
         private static readonly EqualityComparer<T3> s_t3Comparer = EqualityComparer<T3>.Default;
         private static readonly EqualityComparer<T4> s_t4Comparer = EqualityComparer<T4>.Default;
         private static readonly EqualityComparer<T5> s_t5Comparer = EqualityComparer<T5>.Default;
+		#pragma warning restore 0649
 
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5}"/> instance's first component.
@@ -966,12 +976,14 @@ namespace System
     public struct ValueTuple<T1, T2, T3, T4, T5, T6>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6>>, ITupleInternal
     {
+		#pragma warning disable 0649    // Field is never assigned to, and will always have its default value null
         private static readonly EqualityComparer<T1> s_t1Comparer = EqualityComparer<T1>.Default;
         private static readonly EqualityComparer<T2> s_t2Comparer = EqualityComparer<T2>.Default;
         private static readonly EqualityComparer<T3> s_t3Comparer = EqualityComparer<T3>.Default;
         private static readonly EqualityComparer<T4> s_t4Comparer = EqualityComparer<T4>.Default;
         private static readonly EqualityComparer<T5> s_t5Comparer = EqualityComparer<T5>.Default;
         private static readonly EqualityComparer<T6> s_t6Comparer = EqualityComparer<T6>.Default;
+		#pragma warning restore 0649
 
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6}"/> instance's first component.
@@ -1206,6 +1218,7 @@ namespace System
     public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ITupleInternal
     {
+		#pragma warning disable 0649    // Field is never assigned to, and will always have its default value null
         private static readonly EqualityComparer<T1> s_t1Comparer = EqualityComparer<T1>.Default;
         private static readonly EqualityComparer<T2> s_t2Comparer = EqualityComparer<T2>.Default;
         private static readonly EqualityComparer<T3> s_t3Comparer = EqualityComparer<T3>.Default;
@@ -1213,6 +1226,7 @@ namespace System
         private static readonly EqualityComparer<T5> s_t5Comparer = EqualityComparer<T5>.Default;
         private static readonly EqualityComparer<T6> s_t6Comparer = EqualityComparer<T6>.Default;
         private static readonly EqualityComparer<T7> s_t7Comparer = EqualityComparer<T7>.Default;
+		#pragma warning restore 0649
 
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7}"/> instance's first component.
@@ -1465,6 +1479,7 @@ namespace System
         : IEquatable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, IStructuralEquatable, IStructuralComparable, IComparable, IComparable<ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>>, ITupleInternal
         where TRest : struct
     {
+		#pragma warning disable 0649    // Field is never assigned to, and will always have its default value null
         private static readonly EqualityComparer<T1> s_t1Comparer = EqualityComparer<T1>.Default;
         private static readonly EqualityComparer<T2> s_t2Comparer = EqualityComparer<T2>.Default;
         private static readonly EqualityComparer<T3> s_t3Comparer = EqualityComparer<T3>.Default;
@@ -1473,6 +1488,7 @@ namespace System
         private static readonly EqualityComparer<T6> s_t6Comparer = EqualityComparer<T6>.Default;
         private static readonly EqualityComparer<T7> s_t7Comparer = EqualityComparer<T7>.Default;
         private static readonly EqualityComparer<TRest> s_tRestComparer = EqualityComparer<TRest>.Default;
+		#pragma warning restore 0649
 
         /// <summary>
         /// The current <see cref="ValueTuple{T1, T2, T3, T4, T5, T6, T7, TRest}"/> instance's first component.

--- a/Compiler/Translator/Bridge.Translator.csproj
+++ b/Compiler/Translator/Bridge.Translator.csproj
@@ -53,15 +53,9 @@
     <Reference Include="ICSharpCode.NRefactory.CSharp, Version=5.0.0.0, Culture=neutral, PublicKeyToken=d4bfe873e7598c49, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Bridge.NRefactory.5.5.9\lib\net40\ICSharpCode.NRefactory.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.16.0.461\lib\net472\Microsoft.Build.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.Framework.16.0.461\lib\net472\Microsoft.Build.Framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.Utilities.Core.16.0.461\lib\net472\Microsoft.Build.Utilities.Core.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.CodeAnalysis, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.7.0\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>

--- a/Compiler/Translator/packages.config
+++ b/Compiler/Translator/packages.config
@@ -2,9 +2,6 @@
 <packages>
   <package id="AjaxMin" version="5.14.5506.26202" targetFramework="net45" />
   <package id="Bridge.NRefactory" version="5.5.9" targetFramework="net461" />
-  <package id="Microsoft.Build" version="16.0.461" targetFramework="net472" />
-  <package id="Microsoft.Build.Framework" version="16.0.461" targetFramework="net472" />
-  <package id="Microsoft.Build.Utilities.Core" version="16.0.461" targetFramework="net472" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.0" targetFramework="net461" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.7.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.7.0" targetFramework="net461" />

--- a/Compiler/TranslatorTests/Bridge.Translator.Tests.csproj
+++ b/Compiler/TranslatorTests/Bridge.Translator.Tests.csproj
@@ -58,15 +58,7 @@
     <Reference Include="ICSharpCode.NRefactory.CSharp, Version=5.0.0.0, Culture=neutral, PublicKeyToken=d4bfe873e7598c49, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Bridge.NRefactory.5.5.9\lib\net40\ICSharpCode.NRefactory.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.16.0.461\lib\net472\Microsoft.Build.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.Framework.16.0.461\lib\net472\Microsoft.Build.Framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.Utilities.Core.16.0.461\lib\net472\Microsoft.Build.Utilities.Core.dll</HintPath>
-    </Reference>
+    <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.Setup.Configuration.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.VisualStudio.Setup.Configuration.Interop.1.16.30\lib\net35\Microsoft.VisualStudio.Setup.Configuration.Interop.dll</HintPath>

--- a/Compiler/TranslatorTests/packages.config
+++ b/Compiler/TranslatorTests/packages.config
@@ -2,9 +2,6 @@
 <packages>
   <package id="Bridge.NRefactory" version="5.5.9" targetFramework="net461" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net461" />
-  <package id="Microsoft.Build" version="16.0.461" targetFramework="net472" />
-  <package id="Microsoft.Build.Framework" version="16.0.461" targetFramework="net472" />
-  <package id="Microsoft.Build.Utilities.Core" version="16.0.461" targetFramework="net472" />
   <package id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.16.30" targetFramework="net461" developmentDependency="true" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />


### PR DESCRIPTION
When used as Visual Studio's build task, it always uses system references anyway, so this approach would avoid having issues in the future by always using Visual Studio's system libraries.

This would supersede the pull request from ChrML (#4113).